### PR TITLE
electrs ssl

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,9 +89,19 @@ Connect to electrs
 
 4. Connect to electrs
 
-	On electrum wallet machine
+	On electrum wallet laptop
 	```
-	electrum --oneserver --server=<ELECTRS_ONION>:50001:t
+	electrum --oneserver --server=<ELECTRS_ONION>:50002:s
+	```
+
+	On electrum android phone
+	```
+	Three dots in the upper-right-hand corner
+	Network
+	Server > Enter <ELECTRS_ONION>
+	Back
+	Auto-connect: OFF
+	One-server mode: ON
 	```
 
 Connect to nix-bitcoin node through ssh Tor Hidden Service

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -146,10 +146,12 @@ in {
      
     services.spark-wallet.onion-service = true;
     services.electrs.port = 50001;
+    services.electrs.onionport = 50002;
+    services.electrs.nginxport = 50003;
     services.electrs.high-memory = false;
     services.tor.hiddenServices.electrs = {
       map = [{
-        port = config.services.electrs.port; toPort = config.services.electrs.port;
+        port = config.services.electrs.onionport; toPort = config.services.electrs.nginxport;
       }];
       version = 3;
     };

--- a/network/network.nix
+++ b/network/network.nix
@@ -36,6 +36,20 @@ let
     group = "clightning";
     permissions = "0440";
   };
+  ssl_certificate_key = {
+    keyFile = ../secrets/ssl_certificate_key.key;
+    destDir = "/secrets/";
+    user = "nginx";
+    group = "root";
+    permissions = "0440";
+  };
+  ssl_certificate = {
+    keyFile = ../secrets/ssl_certificate.crt;
+    destDir = "/secrets/";
+    user = "nginx";
+    group = "root";
+    permissions = "0440";
+  };
 in {
   network.description = "Bitcoin Core node";
 
@@ -50,6 +64,7 @@ in {
       // (if (config.services.lightning-charge.enable) then { inherit lightning-charge-api-token; } else { })
       // (if (config.services.nanopos.enable) then { inherit lightning-charge-api-token-for-nanopos; } else { })
       // (if (config.services.liquidd.enable) then { inherit liquid-rpcpassword; } else { })
-      // (if (config.services.spark-wallet.enable) then { inherit spark-wallet-login; } else { });
+      // (if (config.services.spark-wallet.enable) then { inherit spark-wallet-login; } else { })
+      // (if (config.services.electrs.enable) then { inherit ssl_certificate_key ssl_certificate; } else { });
     } // (bitcoin-node { inherit config pkgs; });
 }

--- a/secrets/generate_secrets.sh
+++ b/secrets/generate_secrets.sh
@@ -17,3 +17,9 @@ echo Write secrets to $SECRETSFILE
     echo \}
 } >> $SECRETSFILE
 echo Done
+
+echo Generate Self-Signed Cert
+openssl genrsa -out secrets/ssl_certificate_key.key 2048
+openssl req -new -key secrets/ssl_certificate_key.key -out secrets/ssl_certificate.csr -subj "/C=KN"
+openssl x509 -req -days 1825 -in secrets/ssl_certificate.csr -signkey secrets/ssl_certificate_key.key -out secrets/ssl_certificate.crt
+echo Done

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,7 @@ with import nixpkgs { };
 stdenv.mkDerivation rec {
   name = "nix-bitcoin-environment";
 
-  buildInputs = [ pkgs.nixops pkgs.figlet pkgs.apg ];
+  buildInputs = [ pkgs.nixops pkgs.figlet pkgs.apg pkgs.openssl ];
 
   shellHook = ''
     export NIX_PATH="nixpkgs=${nixpkgs}:."


### PR DESCRIPTION
This PR modifies electrs to use a self-signed ssl certificate to provide additional connection security. This is vital for the Electrum Android App and should align connecting to electrs with standard Electrum usage.

Relevant Issue: https://github.com/jonasnick/nix-bitcoin/issues/33