### PR TITLE
Add Electrs .onion to Webindex

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,7 +91,7 @@ Connect to electrs
 
 	On electrum wallet laptop
 	```
-	electrum --oneserver --server=<ELECTRS_ONION>:50002:s
+	electrum --oneserver --server=<ELECTRS_ONION>:s
 	```
 
 	On electrum android phone

--- a/modules/nix-bitcoin-webindex.nix
+++ b/modules/nix-bitcoin-webindex.nix
@@ -21,6 +21,9 @@ let
         <h3>
           lightning node: CLIGHTNING_ID
         </h3>
+        <h3>
+          ${optionalString config.services.electrs.enable "electrum server: ELECTRS_ONION"}
+        </h3>
         </p>
       </body>
     </html>
@@ -33,6 +36,7 @@ let
     nodeinfo
     . <(nodeinfo)
     sed -i "s/CLIGHTNING_ID/$CLIGHTNING_ID/g" /var/www/index.html
+    sed -i "s/ELECTRS_ONION/$ELECTRS_ONION/g" /var/www/index.html
   '';
 in {
   options.services.nix-bitcoin-webindex = {

--- a/pkgs/nodeinfo/nodeinfo.sh
+++ b/pkgs/nodeinfo/nodeinfo.sh
@@ -32,7 +32,7 @@ fi
 ELECTRS_ONION_FILE=/var/lib/onion-chef/operator/electrs
 if [ -e "$ELECTRS_ONION_FILE" ]; then
     ELECTRS_ONION="$(cat $ELECTRS_ONION_FILE)"
-    echo ELECTRS_ONION="$ELECTRS_ONION"
+    echo ELECTRS_ONION="$ELECTRS_ONION:50002"
 fi
 
 SSHD_ONION_FILE=/var/lib/onion-chef/operator/sshd


### PR DESCRIPTION
This PR adds the electrs Tor HS .onion to the webindex for easier connection if `services.electrs.enable` is true. Additionally it adds the port number to `ELECTRS_ONION` in `nodeinfo` and adjusts the documentation accordingly.

Closes #34 