### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ It should be a reproducible and extensible platform for applications building on
 Available modules
 ---
 By default the `configuration.nix` provides:
-* bitcoind (pruned) with outbound connections through Tor and inbound connections through a hidden
-      service. By default loaded with banlist of spy nodes.
+* bitcoind with outbound connections through Tor and inbound connections through a hidden service. By default loaded with banlist of spy nodes.
 * [clightning](https://github.com/ElementsProject/lightning) with outbound connections through Tor, not listening
 * includes "nodeinfo" script which prints basic info about the node
 * adds non-root user "operator" which has access to bitcoin-cli and lightning-cli
@@ -40,6 +39,8 @@ In `configuration.nix` the user can enable:
 * [spark-wallet](https://github.com/shesek/spark-wallet)
 * [electrs](https://github.com/romanz/electrs)
 * recurring-donations, a module to repeatedly send lightning payments to recipients specified in the configuration.
+* [bitcoin-core-hwi](https://github.com/bitcoin-core/HWI).
+  * You no longer need extra software to connect your hardware wallet to Bitcoin Core. Use Bitcoin Core's own **H**ardware **W**allet **I**nterface with one `configuration.nix` setting.
 
 The data directories of the services can be found in `/var/lib` on the deployed machines.
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -38,7 +38,7 @@
 
   ### ELECTRS
   # Enable this module to use electrs, an efficient re-implementation of
-  # Electrum Server in Rust. Only enable this if hardware wallets are 
+  # Electrum Server in Rust. Only enable this if hardware wallets are
   # disabled.
   # services.electrs.enable = true;
 
@@ -85,8 +85,8 @@
   # Ledger must be initialized through the official ledger live app and the Bitcoin app must
   # be installed and running on the device.
   # services.hardware-wallets.ledger = true;
-  # Trezor can be initialized with the trezorctl command in nix-bitcoin. More information can 
-  # be found in `docs/usage.md`.
+  # Trezor can be initialized with the trezorctl command in nix-bitcoin. More information in
+  # `docs/usage.md`.
   # services.hardware-wallets.trezor = true;
 
   # FIXME: Define your hostname.

--- a/configuration.nix
+++ b/configuration.nix
@@ -38,7 +38,8 @@
 
   ### ELECTRS
   # Enable this module to use electrs, an efficient re-implementation of
-  # Electrum Server in Rust.
+  # Electrum Server in Rust. Only enable this if hardware wallets are 
+  # disabled.
   # services.electrs.enable = true;
 
   ### LIQUIDD
@@ -80,7 +81,7 @@
 
   ### Hardware wallets
   # Enable this module to allow using hardware wallets. See https://github.com/bitcoin-core/HWI
-  # for more information.
+  # for more information. Only enable this if electrs is disabled.
   # Ledger must be initialized through the official ledger live app and the Bitcoin app must
   # be installed and running on the device.
   # services.hardware-wallets.ledger = true;

--- a/configuration.nix
+++ b/configuration.nix
@@ -84,7 +84,8 @@
   # Ledger must be initialized through the official ledger live app and the Bitcoin app must
   # be installed and running on the device.
   # services.hardware-wallets.ledger = true;
-  # Trezor can be initialized with the trezorctl command in nix-bitcoin.
+  # Trezor can be initialized with the trezorctl command in nix-bitcoin. More information can 
+  # be found in `docs/usage.md`.
   # services.hardware-wallets.trezor = true;
 
   # FIXME: Define your hostname.

--- a/docs/install.md
+++ b/docs/install.md
@@ -341,7 +341,7 @@ You can also build Nix from source by following the instructions at https://nixo
 	```
 	```
 	boot.loader.grub.device = "/dev/sda";
-	``` 
+	```
 
 9. Setup environment
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -132,14 +132,14 @@ This is borrowed from the [NixOS manual](https://nixos.org/nixos/manual/index.ht
 1. Obtain latest NixOS. For example:
 
 	```
-	wget https://releases.nixos.org/nixos/18.09/nixos-18.09.2257.235487585ed/nixos-graphical-18.09.2257.235487585ed-x86_64-linux.iso
+	wget https://releases.nixos.org/nixos/19.03/nixos-19.03.172538.7bb74e65365/nixos-minimal-19.03.172538.7bb74e65365-x86_64-linux.iso
 	```
 	Alternatively you can build NixOS from source by following the instructions at https://nixos.org/nixos/manual/index.html#sec-building-cd.
 
 2. Write NixOS iso to install media (USB/CD). For example:
 
 	```
-	dd if=nixos-graphical-18.09.2257.235487585ed-x86_64-linux.iso of=/dev/sdX
+	dd if=nixos-minimal-19.03.172538.7bb74e65365-x86_64-linux.iso of=/dev/sdX
 	```
 
 	Replace /dev/sdX with the correct device name. You can find this using `sudo fdisk -l`
@@ -309,7 +309,7 @@ You can also build Nix from source by following the instructions at https://nixo
 	{
 	  bitcoin-node =
 	    { config, pkgs, ... }:
-	    { deployment.targetHost = 1.2.3.4;
+	    { deployment.targetHost = "1.2.3.4";
 	    };
 	}
 	```
@@ -329,7 +329,7 @@ You can also build Nix from source by following the instructions at https://nixo
 	```
 	nano hardware-configuration.nix
 	```
-	Copy contents of NixOS machine's `hardware-configuration.nix` to file.
+	Copy contents of NixOS machine's `/etc/nixos/hardware-configuration.nix` to file.
 
 8. Add boot option to `hardware-configuration.nix`
 
@@ -339,8 +339,9 @@ You can also build Nix from source by following the instructions at https://nixo
 	```
 	Option 2: Set grub device for Legacy Boot (MBR)
 	```
-	boot.loader.grub.device = "/dev/sda":
 	```
+	boot.loader.grub.device = "/dev/sda";
+	``` 
 
 9. Setup environment
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,7 +149,7 @@ Connect to nix-bitcoin node through ssh Tor Hidden Service
 
 6. Now you can run `nixops deploy -d bitcoin-node` and it will connect through the ssh tunnel you established in step iv. This also allows you to do more complex ssh setups that `nixops ssh` doesn't support. An example would be authenticating with [Trezor's ssh agent](https://github.com/romanz/trezor-agent), which provides extra security.
 
-Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
+Initialize a Trezor for Bitcoin Core's Hardware Wallet Interface
 ---
 
 1. Enable Trezor in `configuration.nix`
@@ -169,7 +169,7 @@ Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
 	nixops deploy -d bitcoin-node
 	```
 
-3. Check that your nix-bitcoin node recognizes the Trezor
+3. Check that your nix-bitcoin node recognizes your Trezor
 
 	```
 	nixops ssh operator@bitcoin-node
@@ -177,35 +177,35 @@ Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
 	```
 	Should show something relating to your Trezor
 
-3. Start the Trezor in bootloader mode
+4. If your Trezor has outdated firmware or is not yet initialized: Start your Trezor in bootloader mode
 
 	Trezor v1
 	```
-	Plug in the Trezor with both buttons depressed
+	Plug in your Trezor with both buttons depressed
 	```
 
 	Trezor v2
 	```
-	Start swiping your finger across the Trezor's touchscreen and plug in the USB cable when your finger is halfway through
+	Start swiping your finger across your Trezor's touchscreen and plug in the USB cable when your finger is halfway through
 	```
 
-4. Update your Trezor's firmware
+5. If your Trezor's firmware is outdated: Update your Trezor's firmware
 
 	```
 	trezorctl firmware-update
 	```
 	Follow the on-screen instructions
 
-	**Caution: This command _will_ wipe your device. If you already store Bitcoin on it, only do this with the recovery seed nearby.**
+	**Caution: This command _will_ wipe your Trezor. If you already store Bitcoin on it, only do this with the recovery seed nearby.**
 
-5. Set up your Trezor, if this is a fresh device
+6. If your Trezor is not yet initialized: Set up your Trezor
 
 	```
 	trezorctl reset-device -p
 	```
 	Follow the on-screen instructions
 
-6. Find your Trezor
+7. Find your Trezor
 
 	```
 	hwi enumerate
@@ -214,4 +214,4 @@ Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
 	hwi enumerate
 	```
 
-7. Follow Bitcoin Core's instructions on [Using Bitcoin Core with Hardware Wallets](https://github.com/bitcoin-core/HWI/blob/master/docs/bitcoin-core-usage.md) to use your Trezor with `bitcoin-cli` on your nix-bitcoin node
+8. Follow Bitcoin Core's instructions on [Using Bitcoin Core with Hardware Wallets](https://github.com/bitcoin-core/HWI/blob/master/docs/bitcoin-core-usage.md) to use your Trezor with `bitcoin-cli` on your nix-bitcoin node

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -197,7 +197,7 @@ Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
 	Follow the on-screen instructions
 
 	**Caution: This command _will_ wipe your device. If you already store Bitcoin on it, only do this with the recovery seed nearby.**
-	
+
 5. Set up your Trezor, if this is a fresh device
 
 	```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,3 +148,70 @@ Connect to nix-bitcoin node through ssh Tor Hidden Service
 	```
 
 6. Now you can run `nixops deploy -d bitcoin-node` and it will connect through the ssh tunnel you established in step iv. This also allows you to do more complex ssh setups that `nixops ssh` doesn't support. An example would be authenticating with [Trezor's ssh agent](https://github.com/romanz/trezor-agent), which provides extra security.
+
+Initialize a Trezor for Bitcoin Core's Hardware Wallet Integration
+---
+
+1. Enable Trezor in `configuration.nix`
+
+	Change
+	```
+	# services.hardware-wallets.trezor = true;
+	```
+	to
+	```
+	services.hardware-wallets.trezor = true;
+	```
+
+2. Deploy new `configuration.nix`
+
+	```
+	nixops deploy -d bitcoin-node
+	```
+
+3. Check that your nix-bitcoin node recognizes the Trezor
+
+	```
+	nixops ssh operator@bitcoin-node
+	lsusb
+	```
+	Should show something relating to your Trezor
+
+3. Start the Trezor in bootloader mode
+
+	Trezor v1
+	```
+	Plug in the Trezor with both buttons depressed
+	```
+
+	Trezor v2
+	```
+	Start swiping your finger across the Trezor's touchscreen and plug in the USB cable when your finger is halfway through
+	```
+
+4. Update your Trezor's firmware
+
+	```
+	trezorctl firmware-update
+	```
+	Follow the on-screen instructions
+
+	**Caution: This command _will_ wipe your device. If you already store Bitcoin on it, only do this with the recovery seed nearby.**
+	
+5. Set up your Trezor, if this is a fresh device
+
+	```
+	trezorctl reset-device -p
+	```
+	Follow the on-screen instructions
+
+6. Find your Trezor
+
+	```
+	hwi enumerate
+	hwi -t trezor -d <path from previous command> promptpin
+	hwi -t trezor -d <path> sendpin <number positions for the PIN as displayed on your device's screen>
+	hwi enumerate
+	```
+
+7. Follow Bitcoin Core's instructions on [Using Bitcoin Core with Hardware Wallets](https://github.com/bitcoin-core/HWI/blob/master/docs/bitcoin-core-usage.md) to use your Trezor with `bitcoin-cli` on your nix-bitcoin node


### PR DESCRIPTION
Update install.md instructions, add instructions for initializing trezor in usage.md, add reference to docs/usage.md in configuration.nix hw section, add documentation on exclusivity of electrs and hwi (can't use one if the other is enabled because electrs needs `disablewallet` in `bitcoin.conf`).

Usage instructions for ledger should follow. @0xB10C 

Closes https://github.com/fort-nix/nix-bitcoin/issues/65