### PR TITLE
Update nixpkgs and switch from nixpkgs-unstable to nixos-unstable. 

### DIFF
--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -2,12 +2,12 @@
   nixpkgs = builtins.fetchGit {
     url = "https://github.com/nixos/nixpkgs-channels";
     ref = "nixos-19.03";
-    rev = "7936400662bc9379beb69855b0e0b7c0110e5f3c";
+    rev = "6ec0970062c62935da71e6dbd3576bbbdcbfa10c";
   };
   nixpkgs-unstable = builtins.fetchGit {
     url = "https://github.com/nixos/nixpkgs-channels";
-    ref = "nixpkgs-unstable";
-    rev = "02bb5e35eae8a9e124411270a6790a08f68e905b";
+    ref = "nixos-unstable";
+    rev = "24debf74ef5c6e7799a5bc7edc4b2d6eae8e3c07";
   };
 }
 


### PR DESCRIPTION
Notable change: includes bitcoind version bump to 0.18

fixes #60 