### PR TITLE
Fix package dependencies

### DIFF
--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -73,7 +73,7 @@ in {
 
     systemd.services.clightning = {
       description = "Run clightningd";
-      path  = [ pkgs.bitcoin ];
+      path  = [ pkgs.altcoins.bitcoind ];
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];

--- a/modules/nix-bitcoin-pkgs.nix
+++ b/modules/nix-bitcoin-pkgs.nix
@@ -12,8 +12,8 @@ in {
 
   nixpkgs.config.packageOverrides = pkgs: {
     # Use bitcoin and clightning from unstable
-    bitcoin = nixpkgs-unstable.bitcoin.override { };
-    altcoins.bitcoind = nixpkgs-unstable.altcoins.bitcoind.override { };
+    bitcoin = nixpkgs-unstable.bitcoin.override { miniupnpc = null; };
+    altcoins.bitcoind = nixpkgs-unstable.altcoins.bitcoind.override { miniupnpc = null; };
     clightning = nixpkgs-unstable.clightning.override { };
   };
 }

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -166,7 +166,7 @@ in {
     };
     environment.systemPackages = with pkgs; [
       tor
-      bitcoin
+      altcoins.bitcoind
       nodeinfo
       banlist
       jq


### PR DESCRIPTION
Without this PR nix-bitcoin installs multiple versions of bitcoind and one of them is with GUI. To get rid of GUI bitcoin with this PR, run `nixops deploy`, reboot and run `nix-collect-garbage -d` on your target.