### PR TITLE
Always chown bitcoin/liquid data directories

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -207,15 +207,13 @@ in {
       preStart = ''
         if ! test -e ${cfg.dataDir}; then
           mkdir -m 0770 -p '${cfg.dataDir}'
-          chown -R '${cfg.user}:${cfg.group}' '${cfg.dataDir}'
         fi
         if ! test -e ${cfg.dataDir}/blocks; then
           mkdir -m 0770 -p '${cfg.dataDir}/blocks'
-          chown -R '${cfg.user}:${cfg.group}' '${cfg.dataDir}/blocks'
         fi
         cp '${cfg.configFileOption}' '${cfg.dataDir}/bitcoin.conf'
         chmod o-rw  '${cfg.dataDir}/bitcoin.conf'
-        chown '${cfg.user}:${cfg.group}' '${cfg.dataDir}/bitcoin.conf'
+        chown -R '${cfg.user}:${cfg.group}' '${cfg.dataDir}'
         echo "rpcpassword=$(cat /secrets/bitcoin-rpcpassword)" >> '${cfg.dataDir}/bitcoin.conf'
         chmod -R g+rX '${cfg.dataDir}/blocks'
       '';

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -180,11 +180,10 @@ in {
       preStart = ''
         if ! test -e ${cfg.dataDir}; then
           mkdir -m 0770 -p '${cfg.dataDir}'
-          chown '${cfg.user}:${cfg.group}' '${cfg.dataDir}'
         fi
         cp '${configFile}' '${cfg.dataDir}/liquid.conf'
         chmod o-rw  '${cfg.dataDir}/liquid.conf'
-        chown '${cfg.user}:${cfg.group}' '${cfg.dataDir}/liquid.conf'
+        chown '${cfg.user}:${cfg.group}' '${cfg.dataDir}'
         echo "rpcpassword=$(cat /secrets/liquid-rpcpassword)" >> '${cfg.dataDir}/liquid.conf'
         echo "mainchainrpcpassword=$(cat /secrets/bitcoin-rpcpassword)" >> '${cfg.dataDir}/liquid.conf'
       '';


### PR DESCRIPTION
This allows using an existing datadir, for which the user may not have permissions, f.e. an external drive. CC @stevenroose