### PR TITLE
bump vbox default disk size to 350gb

### DIFF
--- a/contrib/vbox-resize-disk1.sh
+++ b/contrib/vbox-resize-disk1.sh
@@ -24,7 +24,7 @@ while getopts ":d:m:s:f:yh" opt; do
       echo "Options:"
       echo "  -d <deployment>  NixOps deployment name. Default: bitcoin-node."
       echo "  -m <machine>     NixOps machine name. Default: bitcoin-node."
-      echo "  -s <size>        New disk size in megabytes. Default: 307200 (300gb)."
+      echo "  -s <size>        New disk size in megabytes. Default: 358400 (350gb)."
       echo "  -f <file>        Path to vbox disk file/VDI. Default: read from nixops export."
       echo "  -y               Don't ask for confirmation."
       exit 0
@@ -42,7 +42,7 @@ done
 
 DEPLOYMENT=${DEPLOYMENT:-"bitcoin-node"}
 MACHINE=${MACHINE:-"bitcoin-node"}
-NEW_SIZE=${NEW_SIZE:-307200}
+NEW_SIZE=${NEW_SIZE:-358400}
 DISK_FILE=${DISK_FILE:-$(nixops export -d $DEPLOYMENT | jq -r '..|."virtualbox.disks"?|select(.!=null)' | jq -r .disk1.path)}
 
 echo "Resizing virtualbox disk for use with nixops and nix-bitcoin."
@@ -67,7 +67,7 @@ nixops start -d $DEPLOYMENT
 
 # (
 # echo d # [d]elete 50gb partition
-# echo n # [n]ew partitoin
+# echo n # [n]ew partition
 # echo p # [p]rimary partition
 # echo   # partition number (Accept default: 1)
 # echo   # first sector (Accept default: 1)

--- a/docs/install.md
+++ b/docs/install.md
@@ -124,7 +124,7 @@ You can also build Nix from source by following the instructions at https://nixo
 	./contrib/vbox-resize-disk1.sh
 	```
 
-	NixOps provides a virtualbox disk thats 50gb in size, but we need more than that to house the Bitcoin blockchain. By default, this script will resize the disk to 300gb. Run it with `-h` to see options. Make sure to run this from within your nix-shell.
+	NixOps provides a virtualbox disk thats 50gb in size, but we need more than that to house the Bitcoin blockchain. By default, this script will resize the disk to 350gb. Run it with `-h` to see options. Make sure to run this from within your nix-shell.
 
 7. Nixops automatically creates an ssh key for use with `nixops ssh`. Access `bitcoin-node` through ssh in nix-shell with
 
@@ -171,7 +171,7 @@ In order to build binaries for your linux (NixOS) virtual machine on a macOS hos
 2. Confirm that nix-linuxkit works
 
     ```
-	nix-build /Users/lev/.cache/nix-linuxkit-builder/example.nix
+	nix-build ~/.cache/nix-linuxkit-builder/example.nix
 	```
 
 	As the installer says, run a `nix-build` to make sure that you are able to build linux binaries. The `example.nix` is specifically configured to force a x86_64-linux build. Remove the generated `result` folder afterwards.
@@ -191,7 +191,7 @@ Tutorial: install and configure NixOS for nix-bitcoin on your own hardware
 
 2. Optional: Disable Simultaneous Multi-Threading (SMT) in the BIOS
 
-    Researchers recommend disabling (SMT), also known as Hyper-Threading Technology in the Intel® world to significantly reduce the impact of speculative exacution-based attacks (https://mdsattacks.com/).
+    Researchers recommend disabling (SMT), also known as Hyper-Threading Technology in the Intel® world to significantly reduce the impact of speculative execution-based attacks (https://mdsattacks.com/).
 
 ## 1. NixOS installation
 


### PR DESCRIPTION
It turns out that 300gb is not enough as electrs consumes ~50gb as well. 

```
$ du -sh /var/lib/*
248G	/var/lib/bitcoind
60M	/var/lib/clightning
48G	/var/lib/electrs
20K	/var/lib/nixos
44K	/var/lib/onion-chef
12K	/var/lib/private
156K	/var/lib/systemd
6.7M	/var/lib/tor
4.0K	/var/lib/udisks2
```

PR also contains some typo fixes.