### PR TITLE
Enable validatepegin for Liquid

### DIFF
--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -10,6 +10,7 @@ let
     ${optionalString cfg.testnet "testnet=1"}
     ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
     ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
+    ${optionalString (cfg.validatepegin != null) "validatepegin=${if cfg.validatepegin then "1" else "0"}"}
 
     # Connection options
     ${optionalString (cfg.port != null) "port=${toString cfg.port}"}
@@ -164,6 +165,13 @@ in {
           the entire blockchain. ("disable" = disable pruning blocks, "manual"
           = allow manual pruning via RPC, >=550 = automatically prune block files
           to stay under the specified target size in MiB)
+        '';
+      };
+      validatepegin = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = ''
+          Validate pegin claims. All functionaries must run this.
         '';
       };
       enforceTor =  nix-bitcoin-services.enforceTor;

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -143,6 +143,7 @@ in {
       mainchainrpcuser=${config.services.bitcoind.rpcuser}
       mainchainrpcport=8332
     ";
+    services.liquidd.validatepegin = true;
     services.liquidd.listen = true;
     services.liquidd.proxy = config.services.tor.client.socksListenAddress;
     services.liquidd.enforceTor = true;


### PR DESCRIPTION
Closes https://github.com/fort-nix/nix-bitcoin/issues/84

I've made `validatepegin` false-by-default in configuration.nix. Should it be an opt-out? Is setting the option in liquid.conf even necessary? Seems to be enabled by default according to https://github.com/ElementsProject/elements/blob/master/share/examples/liquid.conf "# Validate pegin claims. All functionaries must run this. (default: 1)" @stevenroose