### PR TITLE
Fix virtualbox deployment for 19.09

### DIFF
--- a/pkgs/nixops/default.nix
+++ b/pkgs/nixops/default.nix
@@ -1,0 +1,53 @@
+# An updated version of nixops that's compatible with machines running NixOS 19.09.
+# 19.09 demands a suitable base image (defined in nixops-vbox/nix/virtualbox.nix) to
+# start the virtualbox guest service during system activation.
+
+{ stdenv, nixops, runCommand, fetchFromGitHub }:
+
+let
+  pluginData = {
+    aws = {
+      owner = "nixos";
+      repo = "nixops-aws";
+      rev= "v1.0.0";
+      sha256 = "1if6spscsgd6ckivgvbqza5fvvn5hbafi1n8q0fw98s3xpz2hjfm";
+    };
+    hetzner = {
+      owner = "nixos";
+      repo = "nixops-hetzner";
+      rev = "v1.0.0";
+      sha256 = "0cxfjpk2daczv3m7q5bsgfvd30qgmm1y7dnvz6nd7s7l7l0gsvas";
+    };
+    vbox = {
+      owner = "nix-community";
+      repo = "nixops-vbox";
+      rev = "bff6054ce9e7f5f9aa830617577f1a511a461063";
+      sha256 = "0j0lbi8rqmw17ji367zh94lvlb062iiyavl4l7m851v40wqr8a5i";
+    };
+    libvirtd = {
+      owner = "nix-community";
+      repo = "nixops-libvirtd";
+      rev = "v1.0.0";
+      sha256 = "0g2ag4mhgrxws3h4q8cvfh4ks1chgpjm018ayqd48lagyvi32l8m";
+    };
+  };
+
+  origSrc = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixops";
+    rev = "2434bf26e0bba49441041ffce36dc324f049bc00";
+    sha256 = "0ag05pjwwqdw8in49hr8m8bdg31xsgqs1cawcqyh6a5lsys7f6zg";
+  };
+
+  src = runCommand "src" {} ''
+    cp --no-preserve=mode -r ${origSrc} $out
+    cd $out
+    patch -p1 < ${./release.nix.patch}
+  '';
+
+  nixopsRelease = import "${src}/release.nix" {
+    inherit pluginData;
+    p = (p: with p; [ aws hetzner vbox libvirtd ]);
+  };
+in
+nixopsRelease.build.${builtins.currentSystem}

--- a/pkgs/nixops/release.nix.patch
+++ b/pkgs/nixops/release.nix.patch
@@ -1,0 +1,34 @@
+--- a/release.nix
++++ b/release.nix
+@@ -1,6 +1,7 @@
+ { nixopsSrc ? { outPath = ./.; revCount = 0; shortRev = "abcdef"; rev = "HEAD"; }
+ , officialRelease ? false
+ , nixpkgs ? <nixpkgs>
++, pluginData
+ , p ? (p: [ ])
+ }:
+
+@@ -10,11 +11,10 @@ let
+
+   allPlugins = let
+     plugins = let
+-      allPluginVers = import ./data.nix;
++      allPluginVers = pluginData;
+       fetch = v:
+         pkgs.fetchFromGitHub {
+-          inherit (v) owner repo sha256;
+-          rev = "v${v.version}";
++          inherit (v) owner repo sha256 rev;
+         };
+       srcDrv = v: (fetch v) + "/release.nix";
+     in self: let
+@@ -83,4 +83,4 @@
+# Remove annoying debug message that's shown in nix-shell while evaluating this file
+           pysqlite
+           typing
+           pluggy
+-        ] ++ pkgs.lib.traceValFn (x: "Using plugins: " + builtins.toJSON x) (map (d: d.build.${system}) (p allPlugins));
++        ] ++ (map (d: d.build.${system}) (p allPlugins));
+
+
+       # For "nix-build --run-env".

--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,9 @@ with import nixpkgs { };
 stdenv.mkDerivation rec {
   name = "nix-bitcoin-environment";
 
-  buildInputs = [ pkgs.nixops pkgs.figlet pkgs.apg pkgs.openssl ];
+  nixops19_09 = callPackage ./pkgs/nixops {};
+
+  buildInputs = with pkgs; [ nixops19_09 figlet apg openssl ];
 
   shellHook = ''
     export NIX_PATH="nixpkgs=${nixpkgs}:."


### PR DESCRIPTION
Without this, starting the virtualbox guest service fails during machine activation.
This is due to an incompatible NixOS machine base image.
Fix this by using an updated version of nixops.

I've already reported [this issue](https://github.com/NixOS/nixops/issues/1207) upstream.

@jonasnick, could you check if this new nixops version works
correctly for your non-virtualbox deployments?

