### PR TITLE
Fix release.nix.patch for our nixops

### DIFF
--- a/pkgs/nixops/release.nix.patch
+++ b/pkgs/nixops/release.nix.patch
@@ -22,7 +22,7 @@
          };
        srcDrv = v: (fetch v) + "/release.nix";
      in self: let
-@@ -83,4 +83,4 @@
+@@ -83,7 +83,7 @@
 # Remove annoying debug message that's shown in nix-shell while evaluating this file
            pysqlite
            typing


### PR DESCRIPTION
Otherwise nix-shell doesn't start up:

```
building '/nix/store/c03b0sb0b822m7n1j0rhg8bfbmqv2vv2-src.drv'...
patching file release.nix
Hunk #3 FAILED at 83.
1 out of 3 hunks FAILED -- saving rejects to file release.nix.rej
builder for '/nix/store/c03b0sb0b822m7n1j0rhg8bfbmqv2vv2-src.drv' failed with exit code 1
error: build of '/nix/store/c03b0sb0b822m7n1j0rhg8bfbmqv2vv2-src.drv' failed
(use '--show-trace' to show detailed location information)
```
CC @erikarvstedt 