### PR TITLE
Fix secrets setup

### DIFF
--- a/modules/secrets/generate-secrets.nix
+++ b/modules/secrets/generate-secrets.nix
@@ -12,8 +12,8 @@ with lib;
     requiredBy = [ "setup-secrets.service" ];
     before = [ "setup-secrets.service" ];
     serviceConfig = {
-       Type = "oneshot";
-       RemainAfterExit = true;
+      Type = "oneshot";
+      RemainAfterExit = true;
     } // config.nix-bitcoin-services.defaultHardening;
     script = ''
       mkdir -p "${config.nix-bitcoin.secretsDir}"

--- a/modules/secrets/generate-secrets.nix
+++ b/modules/secrets/generate-secrets.nix
@@ -14,7 +14,7 @@ with lib;
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-    } // config.nix-bitcoin-services.defaultHardening;
+    };
     script = ''
       mkdir -p "${config.nix-bitcoin.secretsDir}"
       cd "${config.nix-bitcoin.secretsDir}"

--- a/modules/secrets/secrets.nix
+++ b/modules/secrets/secrets.nix
@@ -56,7 +56,7 @@ in
       serviceConfig = {
          Type = "oneshot";
          RemainAfterExit = true;
-      } // config.nix-bitcoin-services.defaultHardening;
+      };
       script = ''
         setupSecret() {
             file="$1"


### PR DESCRIPTION
See commit msgs.
We didn't catch this error because `nix-bitcoin.nix` sets the secrets dir to `/secrets` (default is `/etc/nix-bitcoin-secrets`).