### PR TITLE
fix qemu error on travis

### DIFF
--- a/test/make-test.nix
+++ b/test/make-test.nix
@@ -1,14 +1,14 @@
 testArgs:
 
 let
-  pkgs = import <nixpkgs> { config = {}; overlays = []; };
+  stablePkgs = import <nixpkgs> { config = {}; overlays = []; };
   unstable = (import ../pkgs/nixpkgs-pinned.nix).nixpkgs-unstable;
 
   # Stable nixpkgs doesn't yet include the Python testing framework.
   # Use unstable nixpkgs and patch it so that it uses stable nixpkgs for the VM
   # machine configuration.
   testingPkgs =
-    pkgs.runCommand "nixpkgs-testing" {} ''
+    stablePkgs.runCommand "nixpkgs-testing" {} ''
     cp -r ${unstable} $out
     cd $out
     chmod +w -R .
@@ -17,13 +17,13 @@ let
 
   test = (import "${testingPkgs}/nixos/tests/make-test-python.nix") testArgs;
 
-  # Fix the black Python code formatter that's used in the test to allow the test
-  # script to have longer lines. The default width of 88 chars is too restrictive for
-  # our script.
   fixedTest = { system ? builtins.currentSystem, ... }@args:
     let
        pkgs = (import testingPkgs { inherit system; config = {}; overlays = []; } );
        pkgsFixed = pkgs // {
+         # Fix the black Python code formatter that's used in the test to allow the test
+         # script to have longer lines. The default width of 88 chars is too restrictive for
+         # our script.
          python3Packages = pkgs.python3Packages // {
            black = pkgs.writeScriptBin "black" ''
              fileToCheck=''${@:$#}
@@ -31,6 +31,11 @@ let
              exec ${pkgs.python3Packages.black}/bin/black $extraArgs "$@"
            '';
          };
+
+         # QEMU 4.20 from unstable fails on Travis build nodes with message
+         # "error: failed to set MSR 0x48b to 0x159ff00000000"
+         # Use version 4.0.1 instead.
+         inherit (stablePkgs) qemu_test;
        };
     in
       test (args // { pkgs = pkgsFixed; });


### PR DESCRIPTION
this may also be fixed by disabling `vmx` (see [here](https://www.mail-archive.com/qemu-devel@nongnu.org/msg665051.html)),
but it's safer to just return to the old working QEMU version.