### PR TITLE
Rename nix-bitcoin.nix to presets/secure-node.nix

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -18,10 +18,7 @@
     #./hardware-configuration.nix
   ];
   # FIXME: Enable modules by uncommenting their respective line. Disable
-  # modules by commenting out their respective line.  Enable this module to
-  # use the nix-bitcoin node configuration. Only disable this if you know what
-  # you are doing.
-  services.nix-bitcoin.enable = true;
+  # modules by commenting out their respective line.
 
   ### BITCOIND
   # Bitcoind is enabled by default if nix-bitcoin is enabled

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -4,7 +4,7 @@
 
 { config, pkgs, lib, ... }: {
   imports = [
-    <nix-bitcoin/modules/nix-bitcoin.nix>
+    <nix-bitcoin/modules/presets/secure-node.nix>
 
     # FIXME: The hardened kernel profile improves security but
     # decreases performance by ~50%.
@@ -26,7 +26,7 @@
   ### BITCOIND
   # Bitcoind is enabled by default if nix-bitcoin is enabled
   #
-  # You can override default settings from nix-bitcoin.nix as follows
+  # You can override default settings from secure-node.nix as follows
   # services.bitcoind.prune = lib.mkForce 100000;
   #
   # You can add options that are not defined in modules/bitcoind.nix as follows

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -256,7 +256,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
     systemd.services.bitcoind = {
       description = "Bitcoin daemon";
       requires = [ "nix-bitcoin-secrets.target" ];

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -71,6 +71,7 @@ in {
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.nix-bitcoin.clightning (hiPrio cfg.cli) ];
     users.users.clightning = {
         description = "clightning User";
         group = "clightning";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,7 +7,7 @@
   lightning-charge = ./lightning-charge.nix;
   liquid = ./liquid.nix;
   nanopos = ./nanopos.nix;
-  nix-bitcoin = ./nix-bitcoin.nix;
+  presets.secure-node = ./presets/secure-node.nix;
   nix-bitcoin-webindex = ./nix-bitcoin-webindex.nix;
   spark-wallet = ./spark-wallet.nix;
   recurring-donations = ./recurring-donations.nix;

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -44,11 +44,6 @@ in {
       default = 50001;
       description = "RPC port.";
     };
-    onionport = mkOption {
-      type = types.ints.u16;
-      default = 50002;
-      description = "Port on which to listen for tor client connections.";
-    };
     extraArgs = mkOption {
       type = types.separatedString " ";
       default = "";

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -61,6 +61,8 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [{
+    environment.systemPackages = [ pkgs.nix-bitcoin.electrs ];
+
     systemd.services.electrs = {
       description = "Electrs Electrum Server";
       wantedBy = [ "multi-user.target" ];

--- a/modules/hardware-wallets.nix
+++ b/modules/hardware-wallets.nix
@@ -32,11 +32,16 @@ in {
   };
 
   config = mkMerge [
-    {
-      # Create group
+    (mkIf (cfg.ledger || cfg.trezor) {
+      environment.systemPackages = with pkgs; [
+        nix-bitcoin.hwi
+        # Provides lsusb for debugging
+        usbutils
+      ];
       users.groups."${cfg.group}" = {};
-    }
+    })
     (mkIf cfg.ledger {
+
       # Ledger Nano S according to https://github.com/LedgerHQ/udev-rules/blob/master/add_udev_rules.sh
       # Don't use rules from nixpkgs because we want to use our own group.
       services.udev.packages = lib.singleton (pkgs.writeTextFile {
@@ -48,6 +53,7 @@ in {
       });
     })
     (mkIf cfg.trezor {
+      environment.systemPackages = [ pkgs.python3.pkgs.trezor ];
       # Don't use rules from nixpkgs because we want to use our own group.
       services.udev.packages = lib.singleton (pkgs.writeTextFile {
         name = "trezord-udev-rules";

--- a/modules/lightning-charge.nix
+++ b/modules/lightning-charge.nix
@@ -24,6 +24,7 @@ in {
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.nix-bitcoin.lightning-charge ];
     systemd.services.lightning-charge = {
       description = "Run lightning-charge";
       wantedBy = [ "multi-user.target" ];

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -195,7 +195,11 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.nix-bitcoin.elementsd ];
+    environment.systemPackages = [
+      pkgs.nix-bitcoin.elementsd
+      (hiPrio cfg.cli)
+      (hiPrio cfg.swap-cli)
+    ];
     systemd.services.liquidd = {
       description = "Elements daemon providing access to the Liquid sidechain";
       requires = [ "bitcoind.service" ];

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -77,7 +77,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
+    environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
     systemd.services.lnd = {
       description = "Run LND";
       path  = [ pkgs.nix-bitcoin.bitcoind ];

--- a/modules/nanopos.nix
+++ b/modules/nanopos.nix
@@ -52,6 +52,7 @@ in {
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.nix-bitcoin.nanopos ];
     systemd.services.nanopos = {
       description = "Run nanopos";
       wantedBy = [ "multi-user.target" ];
@@ -60,7 +61,6 @@ in {
       serviceConfig = {
         EnvironmentFile = "${config.nix-bitcoin.secretsDir}/nanopos-env";
         ExecStart = "${pkgs.nix-bitcoin.nanopos}/bin/nanopos -y ${cfg.itemsFile} -p ${toString cfg.port} --show-bolt11";
-
         User = "nanopos";
         Restart = "on-failure";
         RestartSec = "10s";

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -1,3 +1,9 @@
 # This file exists only for backwards compatibility
 
-import ./presets/secure-node.nix
+{ lib, ... }:
+{
+   imports = [
+     ./presets/secure-node.nix
+     (lib.mkRemovedOptionModule [ "services" "nix-bitcoin" "enable" ] "Please directly import ./presets/secure-node.nix")
+   ]
+}

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -1,0 +1,3 @@
+# This file exists only for backwards compatibility
+
+import ./presets/secure-node.nix

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -17,17 +17,8 @@ let
 in {
   imports = [ ../modules.nix ];
 
-  options.services.nix-bitcoin = {
-    enable = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
-        If enabled, the nix-bitcoin service will be installed.
-      '';
-    };
-  };
-
-  config = mkIf cfg.enable {
+  config =  {
+    # For backwards compatibility only
     nix-bitcoin.secretsDir = mkDefault "/secrets";
 
     networking.firewall.enable = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -21,6 +21,14 @@ let
 in {
   imports = [ ../modules.nix ];
 
+  options = {
+    services.electrs.onionport = mkOption {
+      type = types.ints.u16;
+      default = 50002;
+      description = "Port on which to listen for tor client connections.";
+    };
+  };
+
   config =  {
     # For backwards compatibility only
     nix-bitcoin.secretsDir = mkDefault "/secrets";
@@ -90,7 +98,6 @@ in {
     services.electrs = {
       port = 50001;
       enforceTor = true;
-      onionport = 50002;
       TLSProxy.enable = true;
       TLSProxy.port = 50003;
     };

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -22,6 +22,12 @@ in {
   imports = [ ../modules.nix ];
 
   options = {
+    services.clightning.onionport = mkOption {
+      type = types.ints.u16;
+      default = 9735;
+      description = "Port on which to listen for tor client connections.";
+    };
+
     services.electrs.onionport = mkOption {
       type = types.ints.u16;
       default = 50002;
@@ -71,9 +77,9 @@ in {
       proxy = config.services.tor.client.socksListenAddress;
       enforceTor = true;
       always-use-proxy = true;
-      bind-addr = "127.0.0.1:9735";
+      bind-addr = "127.0.0.1:${toString config.services.clightning.onionport}";
     };
-    services.tor.hiddenServices.clightning = mkHiddenService { port = 9735; };
+    services.tor.hiddenServices.clightning = mkHiddenService { port = config.services.clightning.onionport; };
 
     # lnd
     services.lnd.enforceTor = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -136,11 +136,11 @@ in {
     users.users.operator = {
       isNormalUser = true;
       extraGroups = [ config.services.bitcoind.group ]
-        ++ (if config.services.clightning.enable then [ "clightning" ] else [ ])
-        ++ (if config.services.lnd.enable then [ "lnd" ] else [ ])
-        ++ (if config.services.liquidd.enable then [ config.services.liquidd.group ] else [ ])
-        ++ (if (config.services.hardware-wallets.ledger || config.services.hardware-wallets.trezor)
-          then [ config.services.hardware-wallets.group ] else [ ]);
+        ++ (optionals config.services.clightning.enable [ "clightning" ])
+        ++ (optionals config.services.lnd.enable [ "lnd" ])
+        ++ (optionals config.services.liquidd.enable [ config.services.liquidd.group ])
+        ++ (optionals (config.services.hardware-wallets.ledger || config.services.hardware-wallets.trezor)
+            [ config.services.hardware-wallets.group ]);
     };
     # Give operator access to onion hostnames
     services.onion-chef.enable = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -3,7 +3,6 @@
 with lib;
 
 let
-  cfg = config.services.nix-bitcoin;
   operatorCopySSH = pkgs.writeText "operator-copy-ssh.sh" ''
     mkdir -p ${config.users.users.operator.home}/.ssh
     if [ -e "${config.users.users.root.home}/.vbox-nixops-client-key" ]; then

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -90,10 +90,10 @@ in {
     services.liquidd = {
       rpcuser = "liquidrpc";
       prune = 1000;
-      extraConfig = "
-      mainchainrpcuser=${cfg.bitcoind.rpcuser}
-      mainchainrpcport=8332
-    ";
+      extraConfig = ''
+        mainchainrpcuser=${cfg.bitcoind.rpcuser}
+        mainchainrpcport=8332
+      '';
       validatepegin = true;
       listen = true;
       proxy = cfg.tor.client.socksListenAddress;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -118,7 +118,10 @@ in {
     # Create user 'operator' which can access the node's services
     users.users.operator = {
       isNormalUser = true;
-      extraGroups = [ cfg.bitcoind.group ]
+      extraGroups = [
+          "systemd-journal"
+          cfg.bitcoind.group
+        ]
         ++ (optionals cfg.clightning.enable [ "clightning" ])
         ++ (optionals cfg.lnd.enable [ "lnd" ])
         ++ (optionals cfg.liquidd.enable [ cfg.liquidd.group ])

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -108,30 +108,11 @@ in {
     services.nix-bitcoin-webindex.enforceTor = true;
 
 
-    environment.systemPackages = with pkgs; with nix-bitcoin;
-    [
+    environment.systemPackages = with pkgs; [
       tor
-      bitcoind
-      (hiPrio cfg.bitcoind.cli)
-      nodeinfo
       jq
       qrencode
-    ]
-    ++ optionals cfg.clightning.enable [clightning (hiPrio cfg.clightning.cli)]
-    ++ optionals cfg.lnd.enable [lnd (hiPrio cfg.lnd.cli)]
-    ++ optionals cfg.lightning-charge.enable [lightning-charge]
-    ++ optionals cfg.nanopos.enable [nanopos]
-    ++ optionals cfg.nix-bitcoin-webindex.enable [nginx]
-    ++ optionals cfg.liquidd.enable [elementsd (hiPrio cfg.liquidd.cli) (hiPrio cfg.liquidd.swap-cli)]
-    ++ optionals cfg.spark-wallet.enable [spark-wallet]
-    ++ optionals cfg.electrs.enable [electrs]
-    ++ optionals (cfg.hardware-wallets.ledger || cfg.hardware-wallets.trezor) [
-        hwi
-        # To allow debugging issues with lsusb
-        usbutils
-    ]
-    ++ optionals cfg.hardware-wallets.trezor [
-        python3.pkgs.trezor
+      nix-bitcoin.nodeinfo
     ];
 
     # Create user operator which can use bitcoin-cli and lightning-cli

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -4,7 +4,7 @@ with lib;
 
 let
   cfg = config.services.nix-bitcoin;
-  operatorCopySSH = pkgs.writeText "operator-copy-ssh.sh" '' 
+  operatorCopySSH = pkgs.writeText "operator-copy-ssh.sh" ''
     mkdir -p ${config.users.users.operator.home}/.ssh
     if [ -e "${config.users.users.root.home}/.vbox-nixops-client-key" ]; then
       cp ${config.users.users.root.home}/.vbox-nixops-client-key ${config.users.users.operator.home}/.ssh/authorized_keys
@@ -15,7 +15,7 @@ let
     chown -R operator ${config.users.users.operator.home}/.ssh
   '';
 in {
-  imports = [ ./modules.nix ];
+  imports = [ ../modules.nix ];
 
   options.services.nix-bitcoin = {
     enable = mkOption {

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -23,35 +23,36 @@ in {
     networking.firewall.enable = true;
 
     # Tor
-    services.tor.enable = true;
-    services.tor.client.enable = true;
-    # LND uses ControlPort to create onion services
-    services.tor.controlPort = if config.services.lnd.enable then 9051 else null;
+    services.tor = {
+      enable = true;
+      client.enable = true;
+      # LND uses ControlPort to create onion services
+      controlPort = if config.services.lnd.enable then 9051 else null;
 
-    # Tor SSH service
-    services.tor.hiddenServices.sshd = {
-      map = [{
-        port = 22;
-      }];
-      version = 3;
+      hiddenServices.sshd = {
+        map = [ { port = 22; } ];
+        version = 3;
+      };
     };
 
     # bitcoind
-    services.bitcoind.enable = true;
-    services.bitcoind.listen = true;
-    services.bitcoind.sysperms = if config.services.electrs.enable then true else null;
-    services.bitcoind.disablewallet = if config.services.electrs.enable then true else null;
-    services.bitcoind.proxy = config.services.tor.client.socksListenAddress;
-    services.bitcoind.enforceTor = true;
-    services.bitcoind.port = 8333;
-    services.bitcoind.zmqpubrawblock = "tcp://127.0.0.1:28332";
-    services.bitcoind.zmqpubrawtx = "tcp://127.0.0.1:28333";
-    services.bitcoind.assumevalid = "00000000000000000000e5abc3a74fe27dc0ead9c70ea1deb456f11c15fd7bc6";
-    services.bitcoind.addnodes = [ "ecoc5q34tmbq54wl.onion" ];
-    services.bitcoind.discover = false;
-    services.bitcoind.addresstype = "bech32";
-    services.bitcoind.prune = 0;
-    services.bitcoind.dbCache = 1000;
+    services.bitcoind = {
+      enable = true;
+      listen = true;
+      sysperms = if config.services.electrs.enable then true else null;
+      disablewallet = if config.services.electrs.enable then true else null;
+      proxy = config.services.tor.client.socksListenAddress;
+      enforceTor = true;
+      port = 8333;
+      zmqpubrawblock = "tcp://127.0.0.1:28332";
+      zmqpubrawtx = "tcp://127.0.0.1:28333";
+      assumevalid = "00000000000000000000e5abc3a74fe27dc0ead9c70ea1deb456f11c15fd7bc6";
+      addnodes = [ "ecoc5q34tmbq54wl.onion" ];
+      discover = false;
+      addresstype = "bech32";
+      prune = 0;
+      dbCache = 1000;
+    };
     services.tor.hiddenServices.bitcoind = {
       map = [{
         port = config.services.bitcoind.port;
@@ -60,11 +61,13 @@ in {
     };
 
     # clightning
-    services.clightning.bitcoin-rpcuser = config.services.bitcoind.rpcuser;
-    services.clightning.proxy = config.services.tor.client.socksListenAddress;
-    services.clightning.enforceTor = true;
-    services.clightning.always-use-proxy = true;
-    services.clightning.bind-addr = "127.0.0.1:9735";
+    services.clightning = {
+      bitcoin-rpcuser = config.services.bitcoind.rpcuser;
+      proxy = config.services.tor.client.socksListenAddress;
+      enforceTor = true;
+      always-use-proxy = true;
+      bind-addr = "127.0.0.1:9735";
+    };
     services.tor.hiddenServices.clightning = {
       map = [{
         port = 9735; toPort = 9735;
@@ -112,17 +115,19 @@ in {
 
     services.nix-bitcoin-webindex.enforceTor = true;
 
-    services.liquidd.rpcuser = "liquidrpc";
-    services.liquidd.prune = 1000;
-    services.liquidd.extraConfig = "
+    services.liquidd = {
+      rpcuser = "liquidrpc";
+      prune = 1000;
+      extraConfig = "
       mainchainrpcuser=${config.services.bitcoind.rpcuser}
       mainchainrpcport=8332
     ";
-    services.liquidd.validatepegin = true;
-    services.liquidd.listen = true;
-    services.liquidd.proxy = config.services.tor.client.socksListenAddress;
-    services.liquidd.enforceTor = true;
-    services.liquidd.port = 7042;
+      validatepegin = true;
+      listen = true;
+      proxy = config.services.tor.client.socksListenAddress;
+      enforceTor = true;
+      port = 7042;
+    };
     services.tor.hiddenServices.liquidd = {
       map = [{
         port = config.services.liquidd.port; toPort = config.services.liquidd.port;
@@ -131,17 +136,21 @@ in {
     };
 
     services.spark-wallet.onion-service = true;
-    services.electrs.port = 50001;
-    services.electrs.enforceTor = true;
-    services.electrs.onionport = 50002;
-    services.electrs.TLSProxy.enable = true;
-    services.electrs.TLSProxy.port = 50003;
+
+    services.electrs = {
+      port = 50001;
+      enforceTor = true;
+      onionport = 50002;
+      TLSProxy.enable = true;
+      TLSProxy.port = 50003;
+    };
     services.tor.hiddenServices.electrs = {
       map = [{
         port = config.services.electrs.onionport; toPort = config.services.electrs.TLSProxy.port;
       }];
       version = 3;
     };
+
     environment.systemPackages = with pkgs; with nix-bitcoin; let
       s = config.services;
     in

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -27,7 +27,7 @@ in {
       enable = true;
       client.enable = true;
       # LND uses ControlPort to create onion services
-      controlPort = if config.services.lnd.enable then 9051 else null;
+      controlPort = mkIf config.services.lnd.enable 9051;
 
       hiddenServices.sshd = {
         map = [ { port = 22; } ];

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -47,6 +47,7 @@ in {
   };
 
   config = mkIf cfg.enable {
+    environment.systemPackages = [ pkgs.nix-bitcoin.spark-wallet ];
     services.tor.enable = cfg.onion-service;
     # requires client functionality for Bitcoin rate lookup
     services.tor.client.enable = true;

--- a/test/test.nix
+++ b/test/test.nix
@@ -10,7 +10,7 @@ import ./make-test.nix rec {
 
   machine = { pkgs, lib, ... }: with lib; {
     imports = [
-      ../modules/nix-bitcoin.nix
+      ../modules/presets/secure-node.nix
       ../modules/secrets/generate-secrets.nix
       # using the hardened profile increases total test duration by ~50%, so disable it for now
       # hardened

--- a/test/test.nix
+++ b/test/test.nix
@@ -16,7 +16,6 @@ import ./make-test.nix rec {
       # hardened
     ];
 
-    services.nix-bitcoin.enable = true;
     services.bitcoind.extraConfig = mkForce "connect=0";
 
     services.clightning.enable = true;


### PR DESCRIPTION
Note that all commits up to and including `extract variable 'cfg'` are pure refactorings without any effects on evaluation results.
You can verify this with [this helper script](https://gist.github.com/5b0b1a7787ebc1342fcc3f237da5afa7), which compares the VM test derivation of the current worktree to the one in master.
Copy it to the repo root and use it like this:
```
git checkout ab61794 # commit 'extract variable 'cfg'
./diff-vm-drv.sh
# => No changes
git checkout 6c22e13 # commit 'copy-root-authorized-keys: use inline script definition'
./diff-vm-drv.sh
# => diff of changes
```