### PR TITLE
nixops: fix format exception from upstream nixops

### DIFF
--- a/pkgs/nixops/release.nix.patch
+++ b/pkgs/nixops/release.nix.patch
@@ -43,3 +43,15 @@
                                     ('destDir',     'string'),
                                     ('user',        'string'),
                                     ('group',       'string'),
+
+--- a/nixops/deployment.py
++++ b/nixops/deployment.py
+@@ -748,7 +748,7 @@
+                 if res == 100 or force_reboot or m.state == m.RESCUE:
+                     if not allow_reboot and not force_reboot:
+                         raise Exception("the new configuration requires a "
+-                                        "reboot to take effect (hint: use "
++                                        "reboot of '{}' to take effect (hint: use "
+                                         "‘--allow-reboot’)".format(m.name))
+                     m.reboot_sync()
+                     res = 0


### PR DESCRIPTION
Without this our nixops doesn't build with unstable nixpkgs.

I still don't understand why the nixpkgs are not properly pinned. Our `nixops` should be built with nothing but `(import ./pkgs/nixpkgs-pinned.nix).nixpkgs;` but apparently that's not the case.