### PR TITLE
Get electrs source tarball with gpg verified sha256 and corresponding helper script

### DIFF
--- a/pkgs/electrs/default.nix
+++ b/pkgs/electrs/default.nix
@@ -1,17 +1,16 @@
-{ lib, rustPlatform, clang, llvmPackages, fetchFromGitHub, pkgs }:
+{ lib, rustPlatform, llvmPackages, fetchurl, pkgs }:
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
   version = "0.8.3";
 
-  src = fetchFromGitHub {
-    owner = "romanz";
-    repo = "electrs";
-    rev = "v${version}";
-    sha256 = "01993iv3kkf56s5x33gvk433zjwvqlfxa5vqrjl4ghr4i303ysc2";
+  src = fetchurl {
+    url = "https://github.com/romanz/electrs/archive/v${version}.tar.gz";
+    # Use ./get-sha256.sh to fetch latest (verified) sha256
+    sha256 = "6a00226907a0c36b10884e7dd9f87eb58123f089977a752b917d166af072ea3d";
   };
 
   # Needed for librocksdb-sys
-  buildInputs = [ clang ];
+  nativeBuildInputs = [ llvmPackages.clang ];
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
   cargoSha256 = if pkgs ? cargo-vendor then

--- a/pkgs/electrs/get-sha256.sh
+++ b/pkgs/electrs/get-sha256.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p git gnupg
+set -euo pipefail
+
+TMPDIR="$(mktemp -d -p /tmp)"
+trap "rm -rf $TMPDIR" EXIT
+cd $TMPDIR
+
+echo "Fetching latest release"
+git clone https://github.com/romanz/electrs 2> /dev/null
+cd electrs
+latest=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo "Latest release is ${latest}"
+
+# GPG verification
+export GNUPGHOME=$TMPDIR
+echo "Fetching Roman Zeyde's Key"
+gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys 15c8c3574ae4f1e25f3f35c587cae5fa46917cbb 2> /dev/null
+echo "Verifying latest release"
+git verify-tag ${latest}
+
+echo "tag: ${latest}"
+# The prefix option is necessary because GitHub prefixes the archive contents in this format
+echo "sha256: $(git archive --format tar.gz --prefix=electrs-"${latest//v}"/ ${latest} | sha256sum | cut -d\  -f1)"

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,11 +8,11 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "c2c5dcc00b05f0f6007d7a997dc9d90aefb49f28";
-    sha256 = "1sjy9b1jh7k4bhww42zyjjim4c1nn8r4fdbqmyqy4hjyfrh9z6jc";
+    rev = "839cd8d03aa55f067e23a64097fc5b7d7e02f468";
+    sha256 = "1w0xklkk9lbwvrx02gng71pyf476h223098692pji5wg5l0sgm02";
   };
   nixpkgs-unstable = fetch {
-    rev = "ea79a830dcf9c0059656da7f52835d2663d5c436";
-    sha256 = "0vqnfh99358v9ym5z9i3dsfy0l4xxgh9hr278pi1y11gdl092014";
+    rev = "7c2fc1ce23a805f3220d867f528ceb9bd848d2e1";
+    sha256 = "1g562hlp5ha11a41daav9bnq86n4nmbm3xzhpzmma8c4jn4k2p8y";
   };
 }


### PR DESCRIPTION
This PR changes the electrs expression to fetch sources from the releases archive with `fetchurl` instead of `fetchFromGitHub`. This allows us to calculate the sha256 ahead of time and compare it with Roman Zeyde's gpg-signed git tags. I have provided a helper script to automate the process.

Overall this should improve expression integrity, and I plan to implement this for all our packages where gpg verification is possible.