### PR TITLE
Remove bitcoin, clightning, electrs, liquid user home directory

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -330,7 +330,6 @@ in {
     users.users.${cfg.user} = {
       group = cfg.group;
       description = "Bitcoin daemon user";
-      home = cfg.dataDir;
     };
     users.groups.${cfg.group} = {};
     users.groups.bitcoinrpc = {};

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -8,6 +8,7 @@ let
   configFile = pkgs.writeText "config" ''
     autolisten=${if cfg.autolisten then "true" else "false"}
     network=bitcoin
+    bitcoin-datadir=${config.services.bitcoind.dataDir}
     ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
     always-use-proxy=${if cfg.always-use-proxy then "true" else "false"}
     ${optionalString (cfg.bind-addr != null) "bind-addr=${cfg.bind-addr}"}
@@ -76,7 +77,6 @@ in {
         description = "clightning User";
         group = "clightning";
         extraGroups = [ "bitcoinrpc" ];
-        home = cfg.dataDir;
     };
     users.groups.clightning = {};
 

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -107,7 +107,6 @@ in {
       description = "electrs User";
       group = cfg.group;
       extraGroups = [ "bitcoinrpc" "bitcoin"];
-      home = cfg.dataDir;
     };
     users.groups.${cfg.group} = {};
   }

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -235,7 +235,6 @@ in {
     users.users.${cfg.user} = {
       group = cfg.group;
       description = "Liquid sidechain user";
-      home = cfg.dataDir;
     };
     users.groups.${cfg.group} = {};
     nix-bitcoin.secrets.liquid-rpcpassword.user = "liquid";

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -156,7 +156,7 @@ in {
       description = "LND User";
       group = "lnd";
       extraGroups = [ "bitcoinrpc" ];
-      home = cfg.dataDir;
+      home = cfg.dataDir; # lnd creates .lnd dir in HOME
     };
     users.groups.lnd = {};
     nix-bitcoin.secrets = {


### PR DESCRIPTION
Closes https://github.com/fort-nix/nix-bitcoin/issues/53

Combined with the fact that AFAICT you can't login with `bitcoin`, `clightning`, `electrs`, `liquid` users, this should completely eliminate the possibility of an attacker placing something similar to a `.bashrc` file into the users home which is then executed every time the user logs in.

For example:
```console
[root@nix-bitcoin:/var/lib]# sudo -u bitcoin printenv
LANG=en_US.UTF-8
TERMINFO_DIRS=/root/.nix-profile/share/terminfo:/etc/profiles/per-user/root/share/terminfo:/nix/var/nix/profiles/default/share/terminfo:/run/current-system/sw/share/terminfo
TERM=xterm-256color
PATH=/root/bin:/run/wrappers/bin:/root/.nix-profile/bin:/etc/profiles/per-user/root/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin
MAIL=/var/mail/bitcoin
LOGNAME=bitcoin
USER=bitcoin
HOME=/var/empty
SHELL=/run/current-system/sw/bin/nologin
SUDO_COMMAND=/run/current-system/sw/bin/printenv
SUDO_USER=root
SUDO_UID=0
SUDO_GID=0
LOCALE_ARCHIVE=/run/current-system/sw/lib/locale/locale-archive
NIX_PATH=nixpkgs=/nix/var/nix/profiles/per-user/root/channels/nixos:nixos-config=/etc/nixos/configuration.nix:/nix/var/nix/profiles/per-user/root/channels
TZDIR=/etc/zoneinfo
```
The rest of the system should be protected with `ProtectHome=true` and `ProtectSystem=full`

Tested with `nixops deploy` on NixOS nix-bitcoin node