### PR TITLE
Electrs fixes

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -63,7 +63,8 @@
   # Electrum Server in Rust. Only enable this if hardware wallets are
   # disabled.
   # services.electrs.enable = true;
-  # If you have ≥8GB memory, enable this option so electrs will sync faster.
+  # If you have more than 8GB memory, enable this option so electrs will
+  # sync faster.
   # services.electrs.high-memory = true;
 
   ### LIQUIDD

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -46,7 +46,7 @@ in {
     services.bitcoind = {
       enable = true;
       listen = true;
-      dataDirReadableByGroup = mkIf cfg.electrs.enable true;
+      dataDirReadableByGroup = mkIf cfg.electrs.high-memory true;
       proxy = cfg.tor.client.socksListenAddress;
       enforceTor = true;
       port = 8333;

--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -18,7 +18,7 @@ makePasswordSecret spark-wallet-password
 
 if [[ ! -e nginx-key || ! -e nginx-cert ]]; then
     openssl genrsa -out nginx-key 2048
-    openssl req -new -key nginx-key -out nginx.csr -subj "/C=KN"
+    openssl req -new -key nginx-key -out nginx.csr -subj '/CN=localhost/O=electrs'
     openssl x509 -req -days 1825 -in nginx.csr -signkey nginx-key -out nginx-cert
     rm nginx.csr
 fi


### PR DESCRIPTION
AFAIK electrs only needs sysperms when it is not getting blocks over jsonrpc, i.e. cfg.high-memory.

I also removed the St. Kitts and Nevis country-code. It was initially a joke, but I think it's unnecessary and could be used to fingerprint nix-bitcoin users. More feedback on the fingerprinting of TLS certs welcome.