### PR TITLE
lnd: add option for configuring REST port

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -14,6 +14,7 @@ let
     tlskeypath=${secretsDir}/lnd-key
 
     rpclisten=localhost:${toString cfg.rpcPort}
+    restlisten=localhost:${toString cfg.restPort}
 
     bitcoin.active=1
     bitcoin.node=bitcoind
@@ -48,6 +49,11 @@ in {
       type = types.ints.u16;
       default = 10009;
       description = "Port on which to listen for gRPC connections.";
+    };
+    restPort = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "Port on which to listen for REST connections.";
     };
     extraConfig = mkOption {
       type = types.lines;
@@ -104,11 +110,13 @@ in {
         Restart = "on-failure";
         RestartSec = "10s";
         ReadWritePaths = "${cfg.dataDir}";
-        ExecStartPost = [
+        ExecStartPost = let
+          restPort = toString cfg.restPort;
+        in [
           # Run fully privileged for secrets dir write access
           "+${nix-bitcoin-services.script ''
             attempts=50
-            while ! { exec 3>/dev/tcp/127.0.0.1/8080 && exec 3>&-; } &>/dev/null; do
+            while ! { exec 3>/dev/tcp/127.0.0.1/${restPort} && exec 3>&-; } &>/dev/null; do
                   ((attempts-- == 0)) && { echo "lnd REST service unreachable"; exit 1; }
                   sleep 0.1
             done
@@ -119,7 +127,7 @@ in {
 
               ${pkgs.curl}/bin/curl -s \
                 --cacert ${secretsDir}/lnd-cert \
-                -X GET https://127.0.0.1:8080/v1/genseed | ${pkgs.jq}/bin/jq -c '.cipher_seed_mnemonic' > "$mnemonic"
+                -X GET https://127.0.0.1:${restPort}/v1/genseed | ${pkgs.jq}/bin/jq -c '.cipher_seed_mnemonic' > "$mnemonic"
             fi
             chown lnd: "$mnemonic"
             chmod 400 "$mnemonic"
@@ -134,7 +142,7 @@ in {
                 --cacert ${secretsDir}/lnd-cert \
                 -X POST -d "{\"wallet_password\": \"$(cat ${secretsDir}/lnd-wallet-password | tr -d '\n' | base64 -w0)\", \
                 \"cipher_seed_mnemonic\": $(cat ${secretsDir}/lnd-seed-mnemonic | tr -d '\n')}" \
-                https://127.0.0.1:8080/v1/initwallet
+                https://127.0.0.1:${restPort}/v1/initwallet
 
               # Guarantees that RPC calls with cfg.cli succeed after the service is started
               echo Wait until wallet is created
@@ -149,7 +157,7 @@ in {
                 --cacert ${secretsDir}/lnd-cert \
                 -X POST \
                 -d "{\"wallet_password\": \"$(cat ${secretsDir}/lnd-wallet-password | tr -d '\n' | base64 -w0)\"}" \
-                https://127.0.0.1:8080/v1/unlockwallet
+                https://127.0.0.1:${restPort}/v1/unlockwallet
             fi
 
             # Wait until the RPC port is open


### PR DESCRIPTION
I've got a slightly contrived setup where I'm running nix-bitcoin in a container that shares network ports with another container which also uses 8080 and it's harder to change than in lnd ...