### PR TITLE
Update: nixpkgs and elementsd

### DIFF
--- a/pkgs/elementsd/default.nix
+++ b/pkgs/elementsd/default.nix
@@ -5,13 +5,13 @@
 with stdenv.lib;
 stdenv.mkDerivation rec{
   name = "elements" + (toString (optional (!withGui) "d")) + "-" + version;
-  version = "0.18.1.3";
+  version = "0.18.1.8";
 
   src = fetchurl {
     urls = [
             "https://github.com/ElementsProject/elements/archive/elements-${version}.tar.gz"
            ];
-    sha256 = "b51d6ee89cf97ae3b19263dc23c576fd690386b1b2850360d595e24159fc0452";
+    sha256 = "8e1a69e959617c0d200150dff9b0302b5c295ec96f1c94c39c3e8af4d99295de";
    };
 
   nativeBuildInputs =

--- a/pkgs/elementsd/get-sha256.sh
+++ b/pkgs/elementsd/get-sha256.sh
@@ -1,0 +1,24 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p git gnupg
+set -euo pipefail
+
+TMPDIR="$(mktemp -d -p /tmp)"
+trap "rm -rf $TMPDIR" EXIT
+cd $TMPDIR
+
+echo "Fetching latest release"
+git clone https://github.com/elementsproject/elements 2> /dev/null
+cd elements
+latest=$(git describe --tags `git rev-list --tags --max-count=1`)
+echo "Latest release is ${latest}"
+
+# GPG verification
+export GNUPGHOME=$TMPDIR
+echo "Fetching Steven Roose's Key"
+gpg --keyserver hkps://hkps.pool.sks-keyservers.net --recv-keys DE10E82629A8CAD55B700B972F2A88D7F8D68E87 2> /dev/null
+echo "Verifying latest release"
+git verify-tag ${latest}
+
+echo "tag: ${latest}"
+# The prefix option is necessary because GitHub prefixes the archive contents in this format
+echo "sha256: $(git archive --format tar.gz --prefix=elements-${latest}/ ${latest} | sha256sum | cut -d\  -f1)"

--- a/pkgs/hwi/default.nix
+++ b/pkgs/hwi/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, fetchurl, fetchFromGitHub, python3 }:
+{ pkgs, stdenv, fetchurl, fetchFromGitHub, python3 }:
 
 with stdenv.lib;
 
@@ -9,18 +9,22 @@ let
       mnemonic = self.callPackage ./mnemonic {};
       # HWI requires ecdsa <0.14 but nixpkgs has a newer version
       ecdsa = self.callPackage ./ecdsa {};
+      # HWI requires hidapi 0.7.99 but nixpkgs has a newer version
+      hidapi = self.callPackage ./hidapi {
+        inherit (pkgs) udev libusb1;
+      };
     };
   };
 in
 python.pkgs.buildPythonPackage rec {
   pname = "hwi";
-  version = "1.0.3";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "HWI";
     rev = version;
-    sha256 = "1xb8w6w6j6vv2ik2bb25y2w6m0gikmh5446jar0frfp6r6das5nn";
+    sha256 = "01xjkv74ksj8m0l6frk03wq82ilzp5gkz4rf7lhi1h6qkb9kb1x0";
   };
 
   # TODO: enable tests

--- a/pkgs/hwi/hidapi/default.nix
+++ b/pkgs/hwi/hidapi/default.nix
@@ -1,0 +1,32 @@
+{ stdenv, libusb1, udev, darwin, fetchPypi, buildPythonPackage, cython }:
+
+buildPythonPackage rec {
+  pname = "hidapi";
+  version = "0.7.99.post21";
+
+  src = fetchPypi {
+    inherit pname version;
+    sha256 = "e0be1aa6566979266a8fc845ab0e18613f4918cf2c977fe67050f5dc7e2a9a97";
+  };
+
+  propagatedBuildInputs =
+    stdenv.lib.optionals stdenv.isLinux [ libusb1 udev ] ++
+    stdenv.lib.optionals stdenv.isDarwin [ darwin.IOKit darwin.apple_sdk.frameworks.CoreFoundation ] ++
+    [ cython ];
+
+  # Fix the USB backend library lookup
+  postPatch = stdenv.lib.optionalString stdenv.isLinux ''
+    libusb=${libusb1.dev}/include/libusb-1.0
+    test -d $libusb || { echo "ERROR: $libusb doesn't exist, please update/fix this build expression."; exit 1; }
+    sed -i -e "s|/usr/include/libusb-1.0|$libusb|" setup.py
+  '';
+
+  meta = with stdenv.lib; {
+    description = "A Cython interface to the hidapi from https://github.com/signal11/hidapi";
+    homepage = "https://github.com/trezor/cython-hidapi";
+    # license can actually be either bsd3 or gpl3
+    # see https://github.com/trezor/cython-hidapi/blob/master/LICENSE-orig.txt
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ np ];
+  };
+}

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,11 +8,11 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "7829e5791ba1f6e6dbddbb9b43dda72024dd2bd1";
-    sha256 = "0hs9swpz0kibjc8l3nx4m10kig1fcjiyy35qy2zgzm0a33pj114w";
+    rev = "b103b4bc62085f475d81e61dca85fe03e7eff935";
+    sha256 = "1fjb5c80g1vsz9xvii5l6aiga392pbw6dvjky8wmx8xrc5f5g7ja";
   };
   nixpkgs-unstable = fetch {
-    rev = "8ba41a1e14961fe43523f29b8b39acb569b70e72";
-    sha256 = "0c2wn7si8vcx0yqwm92dpry8zqjglj9dfrvmww6ha6ihnjl6mfhh";
+    rev = "a5cc7d3197705f933d88e97c0c61849219ce76c1";
+    sha256 = "0b7y2nv5nj776zh9jwir8fq1qrgcqpaap05qxlxp9qfngw12k6ji";
   };
 }


### PR DESCRIPTION
This PR updates nixpkgs (unstable rev includes bitcoind 0.20.0) and elementsd. It also adds an elementsd `get-sha256.sh` to easily determine verified sha256 sums for updates.