### PR TITLE
RPC Whitelist

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -13,7 +13,7 @@ let
 
     ${optionalString cfg.testnet "testnet=1"}
     ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
-    "prune=${toString cfg.prune}
+    prune=${toString cfg.prune}
     ${optionalString (cfg.sysperms != null) "sysperms=${if cfg.sysperms then "1" else "0"}"}
     ${optionalString (cfg.disablewallet != null) "disablewallet=${if cfg.disablewallet then "1" else "0"}"}
     ${optionalString (cfg.assumevalid != null) "assumevalid=${cfg.assumevalid}"}

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -28,8 +28,12 @@ let
 
     # RPC server options
     rpcport=${toString cfg.rpc.port}
+    rpcwhitelistdefault=0
     ${concatMapStringsSep  "\n"
-      (rpcUser: "rpcauth=${rpcUser.name}:${rpcUser.passwordHMAC}")
+      (rpcUser: ''
+        rpcauth=${rpcUser.name}:${rpcUser.passwordHMAC}
+        ${optionalString (rpcUser.rpcwhitelist != []) "rpcwhitelist=${rpcUser.name}:${lib.strings.concatStringsSep "," rpcUser.rpcwhitelist}"}
+      '')
       (attrValues cfg.rpc.users)
     }
     ${lib.concatMapStrings (rpcbind: "rpcbind=${rpcbind}\n") cfg.rpcbind}
@@ -116,6 +120,14 @@ in {
                 description = ''
                   Password HMAC-SHA-256 for JSON-RPC connections. Must be a string of the
                   format <SALT-HEX>$<HMAC-HEX>.
+                '';
+              };
+              rpcwhitelist = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = ''
+                  List of allowed rpc calls for each user.
+                  If empty list, rpcwhitelist is disabled for that user.
                 '';
               };
             };

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -13,7 +13,7 @@ let
     always-use-proxy=${if cfg.always-use-proxy then "true" else "false"}
     ${optionalString (cfg.bind-addr != null) "bind-addr=${cfg.bind-addr}"}
     ${optionalString (cfg.bitcoin-rpcconnect != null) "bitcoin-rpcconnect=${cfg.bitcoin-rpcconnect}"}
-    bitcoin-rpcuser=${config.services.bitcoind.rpcuser}
+    bitcoin-rpcuser=${config.services.bitcoind.rpc.users.public.name}
     rpc-file-mode=0660
   '';
 in {
@@ -112,7 +112,7 @@ in {
         # The RPC socket has to be removed otherwise we might have stale sockets
         rm -f ${cfg.dataDir}/bitcoin/lightning-rpc
         chmod 600 ${cfg.dataDir}/config
-        echo "bitcoin-rpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword)" >> '${cfg.dataDir}/config'
+        echo "bitcoin-rpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-public)" >> '${cfg.dataDir}/config'
         ${optionalString cfg.announce-tor "echo announce-addr=$(cat /var/lib/onion-chef/clightning/clightning) >> '${cfg.dataDir}/config'"}
         '';
       serviceConfig = nix-bitcoin-services.defaultHardening // {

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -74,7 +74,7 @@ in {
       requires = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];
       preStart = ''
-        echo "cookie = \"${config.services.bitcoind.rpcuser}:$(cat ${secretsDir}/bitcoin-rpcpassword)\"" \
+        echo "cookie = \"${config.services.bitcoind.rpc.users.public.name}:$(cat ${secretsDir}/bitcoin-rpcpassword-public)\"" \
           > electrs.toml
         '';
       serviceConfig = nix-bitcoin-services.defaultHardening // {

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -246,7 +246,7 @@ in {
         chmod 640  '${cfg.dataDir}/elements.conf'
         chown -R '${cfg.user}:${cfg.group}' '${cfg.dataDir}'
         echo "rpcpassword=$(cat ${secretsDir}/liquid-rpcpassword)" >> '${cfg.dataDir}/elements.conf'
-        echo "mainchainrpcpassword=$(cat ${secretsDir}/bitcoin-rpcpassword)" >> '${cfg.dataDir}/elements.conf'
+        echo "mainchainrpcpassword=$(cat ${secretsDir}/bitcoin-rpcpassword-public)" >> '${cfg.dataDir}/elements.conf'
       '';
       serviceConfig = nix-bitcoin-services.defaultHardening // {
         Type = "simple";

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -25,7 +25,7 @@ let
     ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
 
     bitcoind.rpchost=${cfg.bitcoind-host}
-    bitcoind.rpcuser=${config.services.bitcoind.rpcuser}
+    bitcoind.rpcuser=${config.services.bitcoind.rpc.users.public.name}
     bitcoind.zmqpubrawblock=${config.services.bitcoind.zmqpubrawblock}
     bitcoind.zmqpubrawtx=${config.services.bitcoind.zmqpubrawtx}
 
@@ -145,7 +145,7 @@ in {
       after = [ "bitcoind.service" ] ++ onion-chef-service;
       preStart = ''
         install -m600 ${configFile} '${cfg.dataDir}/lnd.conf'
-        echo "bitcoind.rpcpass=$(cat ${secretsDir}/bitcoin-rpcpassword)" >> '${cfg.dataDir}/lnd.conf'
+        echo "bitcoind.rpcpass=$(cat ${secretsDir}/bitcoin-rpcpassword-public)" >> '${cfg.dataDir}/lnd.conf'
         ${optionalString cfg.announce-tor "echo externalip=$(cat /var/lib/onion-chef/lnd/lnd) >> '${cfg.dataDir}/lnd.conf'"}
       '';
       serviceConfig = nix-bitcoin-services.defaultHardening // {

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -73,6 +73,16 @@ in {
       discover = false;
       addresstype = "bech32";
       dbCache = 1000;
+      rpc.users.privileged = {
+        name = "bitcoinrpc";
+        # Placeholder to be sed'd out by bitcoind preStart
+        passwordHMAC = "bitcoin-HMAC-privileged";
+      };
+      rpc.users.public = {
+        name = "publicrpc";
+        # Placeholder to be sed'd out by bitcoind preStart
+        passwordHMAC = "bitcoin-HMAC-public";
+      };
     };
     services.tor.hiddenServices.bitcoind = mkHiddenService { port = cfg.bitcoind.port; toHost = cfg.bitcoind.bind; };
 
@@ -96,7 +106,7 @@ in {
       rpcuser = "liquidrpc";
       prune = 1000;
       extraConfig = ''
-        mainchainrpcuser=${cfg.bitcoind.rpcuser}
+        mainchainrpcuser=${config.services.bitcoind.rpc.users.public.name}
         mainchainrpcport=8332
       '';
       validatepegin = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -82,6 +82,66 @@ in {
         name = "publicrpc";
         # Placeholder to be sed'd out by bitcoind preStart
         passwordHMAC = "bitcoin-HMAC-public";
+        rpcwhitelist = [
+          "echo"
+          "getinfo"
+          # Blockchain
+          "getbestblockhash"
+          "getblock"
+          "getblockchaininfo"
+          "getblockcount"
+          "getblockfilter"
+          "getblockhash"
+          "getblockheader"
+          "getblockstats"
+          "getchaintips"
+          "getchaintxstats"
+          "getdifficulty"
+          "getmempoolancestors"
+          "getmempooldescendants"
+          "getmempoolentry"
+          "getmempoolinfo"
+          "getrawmempool"
+          "gettxout"
+          "gettxoutproof"
+          "gettxoutsetinfo"
+          "scantxoutset"
+          "verifytxoutproof"
+          # Mining
+          "getblocktemplate"
+          "getmininginfo"
+          "getnetworkhashps"
+          # Network
+          "getnetworkinfo"
+          # Rawtransactions
+          "analyzepsbt"
+          "combinepsbt"
+          "combinerawtransaction"
+          "converttopsbt"
+          "createpsbt"
+          "createrawtransaction"
+          "decodepsbt"
+          "decoderawtransaction"
+          "decodescript"
+          "finalizepsbt"
+          "fundrawtransaction"
+          "getrawtransaction"
+          "joinpsbts"
+          "sendrawtransaction"
+          "signrawtransactionwithkey"
+          "testmempoolaccept"
+          "utxoupdatepsbt"
+          # Util
+          "createmultisig"
+          "deriveaddresses"
+          "estimatesmartfee"
+          "getdescriptorinfo"
+          "signmessagewithprivkey"
+          "validateaddress"
+          "verifymessage"
+          # Zmq
+          "getzmqnotifications"
+        ];
       };
     };
     services.tor.hiddenServices.bitcoind = mkHiddenService { port = cfg.bitcoind.port; toHost = cfg.bitcoind.bind; };

--- a/pkgs/generate-secrets/default.nix
+++ b/pkgs/generate-secrets/default.nix
@@ -1,6 +1,9 @@
 { pkgs }: with pkgs;
 
+let
+  rpcauth = pkgs.writeScriptBin "rpcauth" (builtins.readFile ./rpcauth/rpcauth.py);
+in
 writeScript "generate-secrets" ''
-  export PATH=${lib.makeBinPath [ coreutils apg openssl ]}
+  export PATH=${lib.makeBinPath [ coreutils apg openssl gnugrep rpcauth python35 ]}
   . ${./generate-secrets.sh} ${./openssl.cnf}
 ''

--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -6,12 +6,15 @@ makePasswordSecret() {
     [[ -e $1 ]] || apg -m 20 -x 20 -M Ncl -n 1 > "$1"
 }
 
-makePasswordSecret bitcoin-rpcpassword
+makePasswordSecret bitcoin-rpcpassword-privileged
+makePasswordSecret bitcoin-rpcpassword-public
 makePasswordSecret lnd-wallet-password
 makePasswordSecret liquid-rpcpassword
 makePasswordSecret lightning-charge-token
 makePasswordSecret spark-wallet-password
 
+[[ -e bitcoin-HMAC-privileged ]] || rpcauth privileged $(cat bitcoin-rpcpassword-privileged) | grep rpcauth | cut -d ':' -f 2 > bitcoin-HMAC-privileged
+[[ -e bitcoin-HMAC-public ]] || rpcauth public $(cat bitcoin-rpcpassword-public) | grep rpcauth | cut -d ':' -f 2 > bitcoin-HMAC-public
 [[ -e lightning-charge-env ]] || echo "API_TOKEN=$(cat lightning-charge-token)" > lightning-charge-env
 [[ -e nanopos-env          ]] || echo "CHARGE_TOKEN=$(cat lightning-charge-token)" > nanopos-env
 [[ -e spark-wallet-login   ]] || echo "login=spark-wallet:$(cat spark-wallet-password)" > spark-wallet-login

--- a/pkgs/generate-secrets/rpcauth/rpcauth.py
+++ b/pkgs/generate-secrets/rpcauth/rpcauth.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from argparse import ArgumentParser
+from base64 import urlsafe_b64encode
+from binascii import hexlify
+from getpass import getpass
+from os import urandom
+
+import hmac
+
+def generate_salt(size):
+    """Create size byte hex salt"""
+    return hexlify(urandom(size)).decode()
+
+def generate_password():
+    """Create 32 byte b64 password"""
+    return urlsafe_b64encode(urandom(32)).decode('utf-8')
+
+def password_to_hmac(salt, password):
+    m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), 'SHA256')
+    return m.hexdigest()
+
+def main():
+    parser = ArgumentParser(description='Create login credentials for a JSON-RPC user')
+    parser.add_argument('username', help='the username for authentication')
+    parser.add_argument('password', help='leave empty to generate a random password or specify "-" to prompt for password', nargs='?')
+    args = parser.parse_args()
+
+    if not args.password:
+        args.password = generate_password()
+    elif args.password == '-':
+        args.password = getpass()
+
+    # Create 16 byte hex salt
+    salt = generate_salt(16)
+    password_hmac = password_to_hmac(salt, args.password)
+
+    print('String to be appended to bitcoin.conf:')
+    print('rpcauth={0}:{1}${2}'.format(args.username, salt, password_hmac))
+    print('Your password:\n{0}'.format(args.password))
+
+if __name__ == '__main__':
+    main()

--- a/test/scenarios/default.py
+++ b/test/scenarios/default.py
@@ -7,6 +7,15 @@ succeed('[[ $(stat -c "%U:%G %a" /secrets/dummy) = "root:root 440" ]]')
 assert_running("bitcoind")
 machine.wait_until_succeeds("bitcoin-cli getnetworkinfo")
 assert_matches("su operator -c 'bitcoin-cli getnetworkinfo' | jq", '"version"')
+# Test RPC Whitelist
+machine.wait_until_succeeds("su operator -c 'bitcoin-cli help'")
+# Restating rpcuser & rpcpassword overrides privileged credentials
+machine.fail(
+    "bitcoin-cli -rpcuser=publicrpc -rpcpassword=$(cat /secrets/bitcoin-rpcpassword-public) help"
+)
+machine.wait_until_succeeds(
+    log_has_string("bitcoind", "RPC User publicrpc not allowed to call method help")
+)
 
 assert_running("electrs")
 machine.wait_for_open_port(4224)  # prometeus metrics provider

--- a/test/scenarios/withnetns.py
+++ b/test/scenarios/withnetns.py
@@ -19,6 +19,15 @@ succeed('[[ $(stat -c "%U:%G %a" /secrets/dummy) = "root:root 440" ]]')
 assert_running("bitcoind")
 machine.wait_until_succeeds("bitcoin-cli getnetworkinfo")
 assert_matches("su operator -c 'bitcoin-cli getnetworkinfo' | jq", '"version"')
+# Test RPC Whitelist
+machine.wait_until_succeeds("su operator -c 'bitcoin-cli help'")
+# Restating rpcuser & rpcpassword overrides privileged credentials
+machine.fail(
+    "bitcoin-cli -rpcuser=publicrpc -rpcpassword=$(cat /secrets/bitcoin-rpcpassword-public) help"
+)
+machine.wait_until_succeeds(
+    log_has_string("bitcoind", "RPC User publicrpc not allowed to call method help")
+)
 
 assert_running("electrs")
 machine.wait_until_succeeds(


### PR DESCRIPTION
This PR changes bitcoind rpc authentication to the `rpcauth` feature with HMAC-SHA-256 hashed passwords. It implements an `rpcwhitelist` of harmless rpc calls for services with rpc access (`clightning`, `lnd`, `liquidd`, and `electrs`).

Right now, I transfer the HMAC's from the `/secrets` directory by replacing a placeholder inside `bitcoin.conf` via `sed` in the `systemd.services.bitcoind.preStart`. I'm not sure if this is the optimal solution.

Closes https://github.com/fort-nix/nix-bitcoin/issues/191
Closes https://github.com/fort-nix/nix-bitcoin/issues/183