### PR TITLE
Remove electrs tls

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ Connect to electrs
 ### Requirements Android
 * Android phone
 * [Orbot](https://guardianproject.info/apps/orbot/) installed from [F-Droid](https://guardianproject.info/fdroid) (recommended) or [Google Play](https://play.google.com/store/apps/details?id=org.torproject.android&hl=en)
-* [Electrum mobile app](https://electrum.org/#home) installed from [direct download](https://electrum.org/#download) or [Google Play](https://play.google.com/store/apps/details?id=org.electrum.electrum)
+* [Electrum mobile app](https://electrum.org/#home) 4.0.1 and newer installed from [direct download](https://electrum.org/#download) or [Google Play](https://play.google.com/store/apps/details?id=org.electrum.electrum)
 
 ### Requirements Desktop
 * [Tor](https://www.torproject.org/) installed from [source](https://www.torproject.org/docs/tor-doc-unix.html.en) or [repository](https://www.torproject.org/docs/debian.html.en)
@@ -94,22 +94,20 @@ Connect to electrs
 
 4. Connect to electrs
 
-    On electrum wallet laptop
+    Make sure Tor is running on Desktop or as Orbot on Android.
+
+    On Desktop
     ```
-    electrum --oneserver --server=<ELECTRS_ONION>:50002:s --proxy=socks5:localhost:9050
+    electrum --oneserver -1 -s "<ELECTRS_ONION>:50001:t" -p socks5:localhost:9050
     ```
 
-    On electrum android phone
+    On Android
     ```
     Three dots in the upper-right-hand corner
-    Network
-    Proxy mode: socks5, Host: 127.0.0.1, Port: 9050
-    Ok
-    Server
-    Host: <ELECTRS_ONION>, Port: 50002
-    Ok
-    Auto-connect: OFF
-    One-server mode: ON
+    Network > Proxy mode: socks5, Host: 127.0.0.1, Port: 9050
+    Network > Auto-connect: OFF
+    Network > One-server mode: ON
+    Network > Server: <ELECTRS_ONION>:50001:t
     ```
 
 Connect to nix-bitcoin node through ssh Tor Hidden Service

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -102,8 +102,7 @@ in {
         };
         electrs = {
           id = 16;
-          connections = [ "bitcoind" ]
-          ++ ( optionals config.services.electrs.TLSProxy.enable [ "nginx" ]);
+          connections = [ "bitcoind" ];
         };
         spark-wallet = {
           id = 17;
@@ -270,7 +269,6 @@ in {
 
       # electrs: Custom netns configs
       services.electrs = mkIf config.services.electrs.enable {
-        host =  if config.services.electrs.TLSProxy.enable then netns.nginx.address else netns.electrs.address;
         address = netns.electrs.address;
         daemonrpc = "${netns.bitcoind.address}:${toString config.services.bitcoind.rpc.port}";
       };

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -29,11 +29,6 @@ in {
       default = 9735;
       description = "Port on which to listen for tor client connections.";
     };
-    services.electrs.onionport = mkOption {
-      type = types.port;
-      default = 50002;
-      description = "Port on which to listen for tor client connections.";
-    };
     nix-bitcoin.operatorName = mkOption {
       type = types.str;
       default = "operator";
@@ -113,14 +108,8 @@ in {
     services.electrs = {
       port = 50001;
       enforceTor = true;
-      TLSProxy.enable = true;
-      TLSProxy.port = 50003;
     };
-    services.tor.hiddenServices.electrs = mkIf cfg.electrs.enable (mkHiddenService {
-      port = cfg.electrs.onionport;
-      toPort = if cfg.electrs.TLSProxy.enable then cfg.electrs.TLSProxy.port else cfg.electrs.port;
-      toHost = cfg.electrs.host;
-    });
+    services.tor.hiddenServices.electrs = mkHiddenService { port = cfg.electrs.port; toHost = cfg.electrs.address; };
 
     services.spark-wallet = {
       onion-service = true;

--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -16,13 +16,6 @@ makePasswordSecret spark-wallet-password
 [[ -e nanopos-env          ]] || echo "CHARGE_TOKEN=$(cat lightning-charge-token)" > nanopos-env
 [[ -e spark-wallet-login   ]] || echo "login=spark-wallet:$(cat spark-wallet-password)" > spark-wallet-login
 
-if [[ ! -e nginx-key || ! -e nginx-cert ]]; then
-    openssl genrsa -out nginx-key 2048
-    openssl req -new -key nginx-key -out nginx.csr -subj '/CN=localhost/O=electrs'
-    openssl x509 -req -days 1825 -in nginx.csr -signkey nginx-key -out nginx-cert
-    rm nginx.csr
-fi
-
 if [[ ! -e lnd-key || ! -e lnd-cert ]]; then
     openssl ecparam -genkey -name prime256v1 -out lnd-key
     openssl req -config $opensslConf -new -sha256 -key lnd-key -out lnd.csr -subj '/CN=localhost/O=lnd'

--- a/pkgs/generate-secrets/update-secrets.sh
+++ b/pkgs/generate-secrets/update-secrets.sh
@@ -40,8 +40,6 @@ extractPassword liquidrpcpassword liquid-rpcpassword
 extractPassword lightning-charge-api-token lightning-charge-token
 extractPassword spark-wallet-password
 
-rename nginx.key nginx-key
-rename nginx.cert nginx-cert
 rename lnd.key lnd-key
 rename lnd.cert lnd-cert
 

--- a/test/scenarios/default.py
+++ b/test/scenarios/default.py
@@ -13,9 +13,6 @@ machine.wait_for_open_port(4224)  # prometeus metrics provider
 # Check RPC connection to bitcoind
 machine.wait_until_succeeds(log_has_string("electrs", "NetworkInfo"))
 assert_running("nginx")
-# SSL stratum server via nginx. Only check for open port, no content is served here
-# as electrs isn't ready.
-machine.wait_for_open_port(50003)
 # Stop electrs from spamming the test log with 'wait for bitcoind sync' messages
 succeed("systemctl stop electrs")
 

--- a/test/scenarios/withnetns.py
+++ b/test/scenarios/withnetns.py
@@ -27,9 +27,6 @@ machine.wait_until_succeeds(
 # Check RPC connection to bitcoind
 machine.wait_until_succeeds(log_has_string("electrs", "NetworkInfo"))
 assert_running("nginx")
-# SSL stratum server via nginx. Only check for open port, no content is served here
-# as electrs isn't ready.
-machine.wait_until_succeeds("ip netns exec nb-nginx nc -z localhost 50003")
 # Stop electrs from spamming the test log with 'wait for bitcoind sync' messages
 succeed("systemctl stop electrs")
 


### PR DESCRIPTION
This PR removes the electrs tls proxy and its associated complexity. In the future we can allow all kinds of networking with the solution described in https://github.com/fort-nix/nix-bitcoin/issues/193#issuecomment-654174562