### PR TITLE
Fix systemd leak

### DIFF
--- a/modules/dbus.nix
+++ b/modules/dbus.nix
@@ -1,0 +1,55 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  inherit (config) nix-bitcoin-services;
+  dataDir = "/var/lib/dbus-hardening";
+  # Mitigates a security issue that allows unprivileged users to read
+  # other unprivileged user's processes' credentials from CGroup using
+  # `systemctl status`.
+  dbus-hardening = pkgs.writeText "dbus.conf" ''
+    <?xml version="1.0" encoding="UTF-8"?> <!-- -*- XML -*- -->
+
+    <!DOCTYPE busconfig PUBLIC
+     "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+     "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+    <busconfig>
+      <policy user="root">
+        <allow send_destination="org.freedesktop.systemd1"
+          send_interface="org.freedesktop.systemd1.Manager"
+          send_member="GetUnitProcesses"/>
+      </policy>
+
+      <policy context="mandatory">
+        <deny send_destination="org.freedesktop.systemd1"
+          send_interface="org.freedesktop.systemd1.Manager"
+          send_member="GetUnitProcesses"/>
+      </policy>
+    </busconfig>
+  '';
+in {
+  config = {
+    systemd.tmpfiles.rules = [
+      "d '${dataDir}/etc/dbus-1/system.d' 0770 messagebus messagebus - -"
+    ];
+
+    services.dbus.packages = [ "${dataDir}" ];
+
+    systemd.services.hardeneddbus = {
+      description = "Install hardeneddbus";
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        cp ${dbus-hardening} ${dataDir}/etc/dbus-1/system.d/dbus.conf
+        chmod 640 ${dataDir}/etc/dbus-1/system.d/dbus.conf
+      '';
+      serviceConfig = nix-bitcoin-services.defaultHardening // {
+        PrivateNetwork = "true";
+        Type = "oneshot";
+        User = "messagebus";
+        ReadWritePaths = "${dataDir}";
+      };
+    };
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -15,6 +15,7 @@
     ./lnd.nix
     ./secrets/secrets.nix
     ./netns-isolation.nix
+    ./dbus.nix
   ];
 
   disabledModules = [ "services/networking/bitcoind.nix" ];

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -42,6 +42,9 @@ in {
 
     networking.firewall.enable = true;
 
+    # hideProcessInformation even if hardened kernel profile is disabled
+    security.hideProcessInformation = true;
+
     # Tor
     services.tor = {
       enable = true;

--- a/test/scenarios/default.py
+++ b/test/scenarios/default.py
@@ -51,6 +51,13 @@ assert_matches("curl -L localhost/store", "tshirt")
 machine.wait_until_succeeds(log_has_string("bitcoind-import-banlist", "Importing node banlist"))
 assert_no_failure("bitcoind-import-banlist")
 
+# test that `systemctl status` can't leak credentials
+assert_matches(
+    "sudo -u electrs systemctl status clightning 2>&1 >/dev/null",
+    "Failed to dump process list for 'clightning.service', ignoring: Access denied",
+)
+machine.succeed("grep -Fq hidepid=2 /proc/mounts")
+
 ### Additional tests
 
 # Current time in µs

--- a/test/scenarios/withnetns.py
+++ b/test/scenarios/withnetns.py
@@ -113,6 +113,13 @@ assert_matches_exactly(
 # test that netns-exec can not be executed by users that are not operator
 machine.fail("sudo -u clightning netns-exec nb-bitcoind ip a")
 
+# test that `systemctl status` can't leak credentials
+assert_matches(
+    "sudo -u electrs systemctl status clightning 2>&1 >/dev/null",
+    "Failed to dump process list for 'clightning.service', ignoring: Access denied",
+)
+machine.succeed("grep -Fq hidepid=2 /proc/mounts")
+
 ### Additional tests
 
 # Current time in µs


### PR DESCRIPTION
Mitigates a security issue that allows unprivileged users to read other unprivileged user's processes' credentials from CGroup using `systemctl status`. Also adds tests to make sure this issue doesn't reoccur.