### PR TITLE
nbxplorer/btcpayserver: add module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ env:
   - PKG=elementsd STABLE=0
   - PKG=electrs STABLE=1
   - PKG=electrs STABLE=0
+  - PKG=nbxplorer STABLE=1
+  - PKG=nbxplorer STABLE=0
+  - PKG=btcpayserver STABLE=1
+  - PKG=btcpayserver STABLE=0
   - PKG=liquid-swap STABLE=1
   - PKG=lightning-loop STABLE=0
   - PKG=nixops19_09 STABLE=1

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -76,6 +76,20 @@
   # sync faster. Only available if hardware wallets are disabled.
   # services.electrs.high-memory = true;
 
+  ### BTCPayServer
+  # Enable this module to use BTCPayServer, a self-hosted, open-source
+  # cryptocurrency payment processor.
+  # Privacy Warning: BTCPayServer currently looks up price rates without
+  # proxying them through Tor. This means an outside observer can correlate
+  # your BTCPayServer usage, like invoice creation times, with your IP address.
+  # services.btcpayserver.enable = true;
+  # Enable this option to connect BTCPayServer to clightning.
+  # services.btcpayserver.lightningBackend = "clightning";
+  # Enable this option to connect BTCPayServert to lnd.
+  # services.btcpayserver.lightningBackend = "lnd";
+  # Afterwards you need to go into Store > General Settings > Lightning Nodes
+  # and click to use "the internal lightning node of this BTCPay Server".
+
   ### LIQUIDD
   # Enable this module to use Liquid, a sidechain for an inter-exchange
   # settlement network linking together cryptocurrency exchanges and

--- a/modules/backups.nix
+++ b/modules/backups.nix
@@ -16,6 +16,8 @@ let
     ${config.services.liquidd.dataDir}
     ${optionalString cfg.with-bulk-data "${config.services.electrs.dataDir}"}
     ${config.services.lightning-charge.dataDir}
+    ${config.services.nbxplorer.dataDir}
+    ${config.services.btcpayserver.dataDir}
     /var/lib/tor
     # Extra files
     ${cfg.extraFiles}

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -1,0 +1,211 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services;
+  inherit (config) nix-bitcoin-services;
+in {
+  options.services = {
+    nbxplorer = {
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nix-bitcoin.nbxplorer;
+        defaultText = "pkgs.nix-bitcoin.nbxplorer";
+        description = "The package providing nbxplorer binaries.";
+      };
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/nbxplorer";
+        description = "The data directory for nbxplorer.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "nbxplorer";
+        description = "The user as which to run nbxplorer.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.nbxplorer.user;
+        description = "The group as which to run nbxplorer.";
+      };
+      bind = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "The address on which to bind.";
+      };
+      enable = mkOption {
+        # This option is only used by netns-isolation
+        internal = true;
+        default = cfg.btcpayserver.enable;
+      };
+      enforceTor = nix-bitcoin-services.enforceTor;
+    };
+
+    btcpayserver = {
+      enable = mkEnableOption "btcpayserver";
+      package = mkOption {
+        type = types.package;
+        default = pkgs.nix-bitcoin.btcpayserver;
+        defaultText = "pkgs.nix-bitcoin.btcpayserver";
+        description = "The package providing btcpayserver binaries.";
+      };
+      dataDir = mkOption {
+        type = types.path;
+        default = "/var/lib/btcpayserver";
+        description = "The data directory for btcpayserver.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "btcpayserver";
+        description = "The user as which to run btcpayserver.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.btcpayserver.user;
+        description = "The group as which to run btcpayserver.";
+      };
+      bind = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "The address on which to bind.";
+      };
+      lightningBackend = mkOption {
+        type = types.nullOr (types.enum [ "clightning" "lnd" ]);
+        default = null;
+        description = "The lightning node implementation to use.";
+      };
+      enforceTor = nix-bitcoin-services.enforceTor;
+    };
+  };
+
+  config = mkIf cfg.btcpayserver.enable {
+    assertions = let
+      backend = cfg.btcpayserver.lightningBackend;
+    in [
+      { assertion = (backend != null) -> cfg.${backend}.enable;
+        message = "btcpayserver requires ${backend}.";
+      }
+    ];
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.nbxplorer.dataDir}' 0770 ${cfg.nbxplorer.user} ${cfg.nbxplorer.group} - -"
+      "d '${cfg.btcpayserver.dataDir}' 0770 ${cfg.btcpayserver.user} ${cfg.btcpayserver.group} - -"
+    ];
+
+    systemd.services.nbxplorer = let
+      configFile = builtins.toFile "config" ''
+        network=mainnet
+        btcrpcuser=${cfg.bitcoind.rpc.users.btcpayserver.name}
+        btcrpcurl=http://${builtins.elemAt config.services.bitcoind.rpcbind 0}:8332
+        btcnodeendpoint=${config.services.bitcoind.bind}:8333
+        bind=${cfg.nbxplorer.bind}
+      '';
+    in {
+      description = "Run nbxplorer";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" ];
+      preStart = ''
+        install -m 600 ${configFile} ${cfg.nbxplorer.dataDir}/settings.config
+        echo "btcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-btcpayserver)" \
+          >> '${cfg.nbxplorer.dataDir}/settings.config'
+      '';
+      serviceConfig = nix-bitcoin-services.defaultHardening // {
+        ExecStart = ''
+          ${cfg.nbxplorer.package}/bin/nbxplorer --conf=${cfg.nbxplorer.dataDir}/settings.config \
+            --datadir=${cfg.nbxplorer.dataDir}
+        '';
+        User = cfg.nbxplorer.user;
+        Restart = "on-failure";
+        RestartSec = "10s";
+        ReadWritePaths = cfg.nbxplorer.dataDir;
+        MemoryDenyWriteExecute = "false";
+      } // (if cfg.nbxplorer.enforceTor
+        then nix-bitcoin-services.allowTor
+        else nix-bitcoin-services.allowAnyIP
+      );
+    };
+
+    systemd.services.btcpayserver = let
+      configFile = builtins.toFile "config" (''
+        network=mainnet
+        socksendpoint=${cfg.tor.client.socksListenAddress}
+        btcexplorerurl=http://${cfg.nbxplorer.bind}:24444/
+        btcexplorercookiefile=${cfg.nbxplorer.dataDir}/Main/.cookie
+        bind=${cfg.btcpayserver.bind}
+      '' + optionalString (cfg.btcpayserver.lightningBackend == "clightning") ''
+        btclightning=type=clightning;server=unix:///${cfg.clightning.dataDir}/bitcoin/lightning-rpc
+      '');
+      lndConfig =
+        "btclightning=type=lnd-rest;" +
+        "server=https://${toString cfg.lnd.listen}:${toString cfg.lnd.restPort}/;" +
+        "macaroonfilepath=/run/lnd/btcpayserver.macaroon;" +
+        "certthumbprint=";
+    in let self = {
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "nbxplorer.service" ]
+                 ++ optional (cfg.btcpayserver.lightningBackend != null) "${cfg.btcpayserver.lightningBackend}.service";
+      after = self.requires;
+      preStart = ''
+        install -m 600 ${configFile} ${cfg.btcpayserver.dataDir}/settings.config
+        ${optionalString (cfg.btcpayserver.lightningBackend == "lnd") ''
+          {
+            echo -n "${lndConfig}";
+            ${pkgs.openssl}/bin/openssl x509 -noout -fingerprint -sha256 -in ${config.nix-bitcoin.secretsDir}/lnd-cert \
+              | sed -e 's/.*=//;s/://g';
+          } >> ${cfg.btcpayserver.dataDir}/settings.config
+        ''}
+      '';
+      serviceConfig = nix-bitcoin-services.defaultHardening // {
+        ExecStart = ''
+          ${cfg.btcpayserver.package}/bin/btcpayserver --conf=${cfg.btcpayserver.dataDir}/settings.config \
+            --datadir=${cfg.btcpayserver.dataDir}
+        '';
+        User = cfg.btcpayserver.user;
+        Restart = "on-failure";
+        RestartSec = "10s";
+        ReadWritePaths = cfg.btcpayserver.dataDir;
+        MemoryDenyWriteExecute = "false";
+      } // (if cfg.btcpayserver.enforceTor
+        then nix-bitcoin-services.allowTor
+        else nix-bitcoin-services.allowAnyIP
+      );
+    }; in self;
+
+    services.lnd.macaroons.btcpayserver = mkIf (cfg.btcpayserver.lightningBackend == "lnd") {
+      inherit (cfg.btcpayserver) user;
+      permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"address","action":"read"},{"entity":"message","action":"read"},{"entity":"peers","action":"read"},{"entity":"signer","action":"read"},{"entity":"invoices","action":"read"},{"entity":"invoices","action":"write"},{"entity":"address","action":"write"}'';
+    };
+
+    users.users.${cfg.nbxplorer.user} = {
+      description = "nbxplorer user";
+      group = cfg.nbxplorer.group;
+      extraGroups = [ "bitcoinrpc" ];
+      home = cfg.nbxplorer.dataDir;
+    };
+    users.groups.${cfg.nbxplorer.group} = {};
+    users.users.${cfg.btcpayserver.user} = {
+      description = "btcpayserver user";
+      group = cfg.btcpayserver.group;
+      extraGroups = [ "nbxplorer" ]
+                    ++ optional (cfg.btcpayserver.lightningBackend == "clightning") cfg.clightning.user;
+      home = cfg.btcpayserver.dataDir;
+    };
+    users.groups.${cfg.btcpayserver.group} = {};
+
+    services.bitcoind.rpc.users.btcpayserver = {
+      passwordHMACFromFile = true;
+      rpcwhitelist = cfg.bitcoind.rpc.users.public.rpcwhitelist ++ [
+        "setban"
+        "generatetoaddress"
+        "getpeerinfo"
+      ];
+    };
+    nix-bitcoin.secrets.bitcoin-rpcpassword-btcpayserver = {
+      user = "bitcoin";
+      group = "nbxplorer";
+    };
+    nix-bitcoin.secrets.bitcoin-HMAC-btcpayserver.user = "bitcoin";
+  };
+}

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -174,13 +174,12 @@ in {
             mnemonic=${secretsDir}/lnd-seed-mnemonic
             if [[ ! -f $mnemonic ]]; then
               echo Create lnd seed
-
+              umask u=r,go=
               ${pkgs.curl}/bin/curl -s \
                 --cacert ${secretsDir}/lnd-cert \
                 -X GET https://127.0.0.1:${restPort}/v1/genseed | ${pkgs.jq}/bin/jq -c '.cipher_seed_mnemonic' > "$mnemonic"
             fi
             chown lnd: "$mnemonic"
-            chmod 400 "$mnemonic"
           ''}"
           "${let
             mainnetDir = "${cfg.dataDir}/chain/bitcoin/mainnet";

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -18,6 +18,7 @@
     ./netns-isolation.nix
     ./security.nix
     ./backups.nix
+    ./btcpayserver.nix
   ];
 
   disabledModules = [ "services/networking/bitcoind.nix" ];

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -160,6 +160,8 @@ in {
             ${ipNetns} route add default via ${bridgeIp}
             ${netnsIptables} -w -P INPUT DROP
             ${netnsIptables} -w -A INPUT -s 127.0.0.1,${bridgeIp},${v.address} -j ACCEPT
+            # allow return traffic to outgoing connections initiated by the service itself
+            ${netnsIptables} -w -A INPUT -m conntrack --ctstate ESTABLISHED -j ACCEPT
           '' + (optionalString (config.services.${n}.enforceTor or false)) ''
             ${netnsIptables} -w -P OUTPUT DROP
             ${netnsIptables} -w -A OUTPUT -d 127.0.0.1,${bridgeIp},${v.address} -j ACCEPT

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -232,6 +232,16 @@ in {
         id = 22;
         connections = [ "lnd" ];
       };
+      nbxplorer = {
+        id = 23;
+        connections = [ "bitcoind" ];
+      };
+      btcpayserver = {
+        id = 24;
+        connections = [ "nbxplorer" ]
+                      ++ optional (config.services.btcpayserver.lightningBackend == "lnd") "lnd";
+        # communicates with clightning over rpc socket
+      };
     };
 
     services.bitcoind = {
@@ -301,6 +311,9 @@ in {
     };
 
     services.lightning-loop.cliExec = mkCliExec "lightning-loop";
+
+    services.nbxplorer.bind = netns.nbxplorer.address;
+    services.btcpayserver.bind = netns.btcpayserver.address;
   }
   ]);
 }

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -48,6 +48,12 @@ let
       echo ELECTRS_ONION="$ELECTRS_ONION"
     fi
 
+    BTCPAYSERVER_ONION_FILE=/var/lib/onion-chef/${operatorName}/btcpayserver
+    if [ -e "$BTCPAYSERVER_ONION_FILE" ]; then
+      BTCPAYSERVER_ONION="$(cat $BTCPAYSERVER_ONION_FILE)"
+      echo BTCPAYSERVER_ONION="$BTCPAYSERVER_ONION"
+    fi
+
     SSHD_ONION_FILE=/var/lib/onion-chef/${operatorName}/sshd
     if [ -e "$SSHD_ONION_FILE" ]; then
     SSHD_ONION="$(cat $SSHD_ONION_FILE)"

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -128,6 +128,12 @@ in {
       port = cfg.electrs.port; toHost = cfg.electrs.address;
     });
 
+    # btcpayserver
+    # disable tor enforcement until btcpayserver can fetch rates over Tor
+    services.btcpayserver.enforceTor = false;
+    services.nbxplorer.enforceTor = true;
+    services.tor.hiddenServices.btcpayserver = mkIf cfg.btcpayserver.enable (mkHiddenService { port = 80; toPort = 23000; toHost = cfg.btcpayserver.bind; });
+
     services.spark-wallet = {
       onion-service = true;
       enforceTor = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -177,7 +177,7 @@ in {
     nix-bitcoin.netns-isolation.allowedUser = operatorName;
     # Give operator access to onion hostnames
     services.onion-chef.enable = true;
-    services.onion-chef.access.${operatorName} = [ "bitcoind" "clightning" "nginx" "liquidd" "spark-wallet" "electrs" "sshd" ];
+    services.onion-chef.access.${operatorName} = [ "bitcoind" "clightning" "nginx" "liquidd" "spark-wallet" "electrs" "btcpayserver" "sshd" ];
 
     security.sudo.configFile =
      (optionalString cfg.lnd.enable ''

--- a/pkgs/btcpayserver/default.nix
+++ b/pkgs/btcpayserver/default.nix
@@ -1,0 +1,66 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper,
+  dotnetPackages, dotnetCorePackages, writeScript, bash
+}:
+
+let
+  deps = import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  };
+  dotnetSdk = dotnetCorePackages.sdk_3_1;
+in
+
+stdenv.mkDerivation rec {
+  pname = "btcpayserver";
+  version = "1.0.5.5";
+
+  src = fetchFromGitHub {
+    owner = pname;
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "11h1nrmb7f44msbhhiz9ddqh5ss2kz6d8ysnvd070x3xj5krgnxz";
+  };
+
+  nativeBuildInputs = [ dotnetSdk dotnetPackages.Nuget ];
+
+  # Due to a bug in btcpayserver, we can't just `dotnet publish` to create a binary.
+  # Build with `dotnet build` instead and add a custom `dotnet run` script.
+  buildPhase = ''
+    export HOME=$TMP/home
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+    nuget sources Add -Name tmpsrc -Source $TMP/nuget
+    nuget init ${linkFarmFromDrvs "deps" deps} $TMP/nuget
+
+    dotnet restore --source $TMP/nuget BTCPayServer/BTCPayServer.csproj
+    dotnet build -c Release BTCPayServer/BTCPayServer.csproj
+  '';
+
+  runScript =  ''
+    #!${bash}/bin/bash
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 exec ${dotnetSdk}/bin/dotnet run --no-launch-profile --no-build \
+      -c Release -p @@SHARE@@/BTCPayServer/BTCPayServer.csproj -- "$@"
+  '';
+
+  installPhase = ''
+    cd ..
+    share=$out/share/$pname
+    mkdir -p $share
+    mv -T source $share
+    install -D -m500 <(echo "$runScript" | sed "s|@@SHARE@@|$share|") $out/bin/$pname
+  '';
+
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Self-hosted, open-source cryptocurrency payment processor";
+    homepage = "https://btcpayserver.org";
+    maintainers = with maintainers; [ kcalvinalvin earvstedt ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/btcpayserver/deps.nix
+++ b/pkgs/btcpayserver/deps.nix
@@ -1,0 +1,1937 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "AngleSharp";
+    version = "0.9.11";
+    sha256 = "17vf1bizskkxr8pf547lk2b48m12wv3si83gxk145i73bf9gi64a";
+  })
+  (fetchNuGet {
+    name = "AWSSDK.Core";
+    version = "3.3.104.14";
+    sha256 = "157694kb63z1szbsv861515fvjv7amrjrfmgbm3idpyw31afk650";
+  })
+  (fetchNuGet {
+    name = "AWSSDK.S3";
+    version = "3.3.110.10";
+    sha256 = "1lf1hfbx792dpa1hxgn0a0jrrvldd16hgbxx229dk2qcz5qlnc38";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Hwi";
+    version = "1.1.3";
+    sha256 = "1c8hfnrjh2ad8qh75d63gsl170q8czf3j1hk8sv8fnbgnxdnkm7a";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.All";
+    version = "1.2.3";
+    sha256 = "1vx47rb505904pz30n5jzc9x42pcfln695l31q4dv5p4fbf10g4q";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.Charge";
+    version = "1.2.1";
+    sha256 = "0iv9frbr6xfxif3pnfd7c87y8mv31nqkdrnhvnaswrx43nv6s272";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.CLightning";
+    version = "1.2.0";
+    sha256 = "0a47fz20ngcz90h2y01isi2h940jljcmnfy6wyknj029sii7i1zs";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.Common";
+    version = "1.2.0";
+    sha256 = "17di8ndkw8z0ci0zk15mcrqpmganwkz9ys2snr2rqpw5mrlhpwa0";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.Eclair";
+    version = "1.2.0";
+    sha256 = "0w7nwsr0n2hrqak023xa294palsk3r96wlgw2ks8d3p5kxm8kskp";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.LND";
+    version = "1.2.1";
+    sha256 = "0ql4qyvz0rms6ls46pi3bgak3r6hj2c5ivnzahiq6cb84pbl61cr";
+  })
+  (fetchNuGet {
+    name = "BTCPayServer.Lightning.Ptarmigan";
+    version = "1.2.0";
+    sha256 = "1yd6nhlssb9k08p5491knlwwjij9324ildir99sa9cp24rlq5nis";
+  })
+  (fetchNuGet {
+    name = "BuildBundlerMinifier";
+    version = "3.2.435";
+    sha256 = "0y1p226dbvs7q2ngm9w4mpkhfrhw2y122plv1yff7lx5m84ia02l";
+  })
+  (fetchNuGet {
+    name = "BundlerMinifier.Core";
+    version = "3.2.435";
+    sha256 = "17338x8ycr7hjzq16kr0ri30k19802hsn1sy259k3v694mxk59vd";
+  })
+  (fetchNuGet {
+    name = "BundlerMinifier.TagHelpers";
+    version = "3.2.435";
+    sha256 = "0ksmby0lzgsxkv0xfzr840262kcqra9vds91mcx0rf20blksfvsk";
+  })
+  (fetchNuGet {
+    name = "CsvHelper";
+    version = "15.0.5";
+    sha256 = "01y8bhsnxghn3flz0pr11vj6wjrpmia8rpdrsp7kjfc1zmhqlgma";
+  })
+  (fetchNuGet {
+    name = "DBriize";
+    version = "1.0.1.3";
+    sha256 = "0rsm68hwq2ky8i6mv3ckdjkj4vjygnkgk3disva0skl3apk833dc";
+  })
+  (fetchNuGet {
+    name = "DigitalRuby.ExchangeSharp";
+    version = "0.6.3";
+    sha256 = "1vb7ahafcd3lcbiiz552aisilwm1yq3j600gkf1wik8vhvsk02fs";
+  })
+  (fetchNuGet {
+    name = "Google.Api.Gax.Rest";
+    version = "2.5.0";
+    sha256 = "1zkjl5zh6qwdz4qmnxnk5877pas638i2qi25znilhqqf3mrkp0rp";
+  })
+  (fetchNuGet {
+    name = "Google.Api.Gax";
+    version = "2.5.0";
+    sha256 = "0q6pi53px998i3gdndla8v0zqdpyi9gnsy9mdcfpkrg09vfbdsl9";
+  })
+  (fetchNuGet {
+    name = "Google.Apis.Auth";
+    version = "1.35.1";
+    sha256 = "1qdnd1nq9bfgyljmiww91pfi0iz1n29rz2dlizhxcijqya2ldha3";
+  })
+  (fetchNuGet {
+    name = "Google.Apis.Auth";
+    version = "1.38.0";
+    sha256 = "0x3bdwiyqjxw5df99bfasmsv09kb47wzisag938631cijl0g277y";
+  })
+  (fetchNuGet {
+    name = "Google.Apis.Core";
+    version = "1.35.1";
+    sha256 = "01dfw2kxknlc5pm7x1q88lv9j979509lkkgvlffjry5bawsxsja4";
+  })
+  (fetchNuGet {
+    name = "Google.Apis.Core";
+    version = "1.38.0";
+    sha256 = "012gslhnx65vqfyzjnqx4bqk9kb8bwbx966q2f9fdgrfcn26gj9j";
+  })
+  (fetchNuGet {
+    name = "Google.Apis.Storage.v1";
+    version = "1.38.0.1470";
+    sha256 = "0mfrz7fmpfbjvp4zfpjasmnfbgxgxrrjkf8xgp9p6h9g8qh2f2h2";
+  })
+  (fetchNuGet {
+    name = "Google.Apis";
+    version = "1.35.1";
+    sha256 = "1022l8m7v9f3rkjc9l11mkzwsbmqx9sk5f4aym035vn9hdr16d49";
+  })
+  (fetchNuGet {
+    name = "Google.Apis";
+    version = "1.38.0";
+    sha256 = "01j3d1lv106cqw9n0lwgclrxghy852fsibv6av4xr03ivrkm8g40";
+  })
+  (fetchNuGet {
+    name = "Google.Cloud.Storage.V1";
+    version = "2.3.0";
+    sha256 = "01jhrd6m6md8m28chzg2dkdfd4yris79j1xi7r1ydm1cfjhmlj64";
+  })
+  (fetchNuGet {
+    name = "HtmlSanitizer";
+    version = "4.0.217";
+    sha256 = "0szay9mf5mmrp1hx0yc175aaalv76qg0j515lfs133j1d95lj26d";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNet.SignalR.Client";
+    version = "2.3.0";
+    sha256 = "1xyj8b88bc6sc7fxgqyalzfmlfgbagfk7adyk29if9hr8ki9bic4";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNet.WebApi.Client";
+    version = "5.2.7";
+    sha256 = "1j0wbdmycj5xbk06p32f7xrddc40sbj3yca4d7ywg611yk26mvi1";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Cryptography.Internal";
+    version = "3.1.4";
+    sha256 = "0d4djj073bl9kps5jkcpydh92lcp6kpa7njhypjw3myaa987dcsh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Cryptography.KeyDerivation";
+    version = "3.1.4";
+    sha256 = "1rya2775prm8ss0rz6izsqqcz96gcf1rh0bpcvnfy1mwi04rx8bl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Hosting.Abstractions";
+    version = "2.0.0";
+    sha256 = "0x6vw7kiy9z7cdmgbqav0d9wq66032wg39l2c9cv6xvxxvdpbkz7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Hosting.Server.Abstractions";
+    version = "2.0.0";
+    sha256 = "1k4dr6l32swi8zasfvzxixnjvgbrra7v6lgpri0929vb3r5lagjb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Http.Abstractions";
+    version = "2.0.0";
+    sha256 = "1hgmnd5mj35g8cqq3mdhjf9cmi3wm5lqiyrj5mgfscnig6i686xr";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Http.Features";
+    version = "2.0.0";
+    sha256 = "1zk5ad3laa7ma83md8r80kijqzps6dcrvv0k1015nddfk1qd74s6";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Identity.EntityFrameworkCore";
+    version = "3.1.4";
+    sha256 = "0smcpaqm7d95flr0k7i2psrsfvs48lv28kzqgnllv5229hhb670d";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.JsonPatch";
+    version = "3.1.1";
+    sha256 = "0c0aaz9rlh9chc53dnv5jryp0x0415hipaizrmih3kzwd3fmqpml";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Mvc.NewtonsoftJson";
+    version = "3.1.1";
+    sha256 = "1c2lrlp64kkacnjgdyygr6fqdawk10l8j4qgppii6rq61yjwhcig";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Mvc.Razor.Extensions";
+    version = "3.1.1";
+    sha256 = "1iydcr7rfzg3kqky0x70853g6lbzsl9ja9cv8ph6iwpqxnswgdkh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation";
+    version = "3.1.1";
+    sha256 = "1q1bblcj9l2dnz46frygsfq7w4v08l96clgryh78wyws83xjm43y";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Razor.Language";
+    version = "3.1.1";
+    sha256 = "0arqmy04dd0r4wm2fin66gxxwj2kirbgxyf3w7kq6f73lrnazhq0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Bcl.AsyncInterfaces";
+    version = "1.1.0";
+    sha256 = "1dq5yw7cy6s42193yl4iqscfw5vzkjkgv0zyy32scr4jza6ni1a1";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Bcl.AsyncInterfaces";
+    version = "1.1.1";
+    sha256 = "0a1ahssqds2ympr7s4xcxv5y8jgxs7ahd6ah6fbgglj4rki1f1vw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Bcl.HashCode";
+    version = "1.1.0";
+    sha256 = "1ggsadahlp76zcn1plapszd5v5ja8rh479fwrahqd3knql4dfnr0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Analyzers";
+    version = "2.9.3";
+    sha256 = "1kskwc9gyd2sx3zwx52qwfsl7s0xhaclmlnxvjsb4jgvpydv3xii";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Analyzers";
+    version = "3.0.0";
+    sha256 = "0bbl0jpqywqmzz2gagld1p2gvdfldjfjmm25hil9wj2nq1zc4di8";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Common";
+    version = "3.3.0";
+    sha256 = "1vwhsp3pjgcfnpapkps9a3z9n2ryiv5bbhzycfljngj5grj63rg2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Common";
+    version = "3.6.0";
+    sha256 = "0i8x90700jr30j580mpawj6d90fngrb2zpkjjbn7f8r2p1mz75y7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.CSharp";
+    version = "3.3.0";
+    sha256 = "09nmd5h1r2q0dwp1dfpn4anvs8sfi3rwcgpcv28lrhky8vc51424";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.CSharp";
+    version = "3.6.0";
+    sha256 = "0c44qp7lfpja6cq5nk7851qrswm2z1k2pnvsw43j9ybf10a27jrn";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeAnalysis.Razor";
+    version = "3.1.1";
+    sha256 = "03n5rli6v1kvghha82zar3dvvkbc2vb9g8zp5fjrzhvp4l74ingn";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeCoverage";
+    version = "16.6.1";
+    sha256 = "01ffm4nflqdb93vq4xl0j3377x360fgx6c6h12mpkcy85ixbv3rl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.0.1";
+    sha256 = "0zxc0apx1gcx361jlq8smc9pfdgmyjh6hpka8dypc9w23nlsh6yj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.3.0";
+    sha256 = "0gw297dgkh0al1zxvgvncqs0j15lsna9l1wpqas4rflmys440xvb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.5.0";
+    sha256 = "01i28nvzccxbqmiz217fxs6hnjwmd5fafs37rd49a6qp53y6623l";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.7.0";
+    sha256 = "0gd67zlw554j098kabg887b5a6pq9kzavpa3jjy5w53ccjzjfy8j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Data.Sqlite.Core";
+    version = "3.1.4";
+    sha256 = "1pahyqjs4l9g1wg9hvxf68kgzzf72ny2i7n7ai97a389p2c86xvh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.DotNet.PlatformAbstractions";
+    version = "2.0.4";
+    sha256 = "1fdzln4im9hb55agzwchbfgm3vmngigmbpci5j89b0gqcxixmv8j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.DotNet.PlatformAbstractions";
+    version = "3.1.4";
+    sha256 = "1s5h96zdc3vh1v03gizmqfw5hmksajw10bdrj79pm8brbyzipxia";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Abstractions";
+    version = "3.1.0";
+    sha256 = "1bd6hilnwp47z3l14qspdxi5f5nhv6rivarc6w8wil425bq0h3pd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Abstractions";
+    version = "3.1.4";
+    sha256 = "07l7137pzwh0k4m53ji5j6a2zmbbzrl164p18wxcri77ds5is4g7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Analyzers";
+    version = "3.1.0";
+    sha256 = "1pjn4wwhxgsiap7byld114kx6m0nm6696r8drspqic7lskm4y305";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Analyzers";
+    version = "3.1.4";
+    sha256 = "1zaqn9z7ns6p6jgnffzkgpziqr2wqs68g2sa0c11kaclhlhgvvbv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Design";
+    version = "3.1.4";
+    sha256 = "10mxnbiw23ia4sln86sd3gn84yhmrb6r2kipzid4h1g15paal9gi";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Relational";
+    version = "3.1.0";
+    sha256 = "0javqw6c27ppcysigjvcjcw3mk0gg1pv2pmwfpvvryr1pb4a9n55";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Relational";
+    version = "3.1.4";
+    sha256 = "1344rsavawwg69dx8xsl08hcs43lc6h7z4mn461dcx85rirlwd0v";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite.Core";
+    version = "3.1.4";
+    sha256 = "080qz0b52i7v5c1sgnqlh9px9881cfr1x06np66hdgmh0ni5c1lw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore.Sqlite";
+    version = "3.1.4";
+    sha256 = "009mcmakw0p7k8xrz920a8qc0rjv361awiz8jia5i5a8p5ihgkbx";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore";
+    version = "3.1.0";
+    sha256 = "1l12lsk1xfrv5pjnm0b9w9kncgdh0pcjcbxl4zrsg82s7bs7dhda";
+  })
+  (fetchNuGet {
+    name = "Microsoft.EntityFrameworkCore";
+    version = "3.1.4";
+    sha256 = "11w63yp7fk9qwmnq3lmpf1h30mlbzfx4zpm89vrs0lprj86g0742";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Abstractions";
+    version = "3.1.0";
+    sha256 = "0j5m2a48rwyzzvbz0hpr2md35iv78b86zyqjnrjq0y4vb7sairc0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Abstractions";
+    version = "3.1.4";
+    sha256 = "09f96pvpyzylpdaiw3lsvr7p6rs4i21mmhsxl6pkivg5lpfb79sk";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Memory";
+    version = "3.1.0";
+    sha256 = "1hi61647apn25kqjcb37nqafp8fikymdrk43j3kxjbwwwx507jy1";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Caching.Memory";
+    version = "3.1.4";
+    sha256 = "0b8ijxjd8lgq8mgnvh3wl4y4wbjj3v5b763y6gslm75fn43iyad8";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "1.1.2";
+    sha256 = "0z83kxfzsgqlshg4x1mhdnhlrprrwsgnnibvwk257drzy9079994";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "2.0.0";
+    sha256 = "1ilz2yrgg9rbjyhn6a5zh9pr51nmh11z7sixb4p7vivgydj9gxwf";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "2.1.0";
+    sha256 = "03gzlr3z9j1xnr1k6y91zgxpz3pj27i3zsvjwj7i8jqnlqmk7pxd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "3.1.0";
+    sha256 = "1f7h52kamljglx5k08ccryilvk6d6cvr9c26lcb6b2c091znzk0q";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "3.1.4";
+    sha256 = "0r33m68y1vgpmqams4sgciizl0w6y97qkp93m0hyn0nlkxqf72l6";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Binder";
+    version = "2.0.0";
+    sha256 = "1prvdbma6r18n5agbhhabv6g357p1j70gq4m9g0vs859kf44nrgc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Binder";
+    version = "3.1.0";
+    sha256 = "13jj7jxihiswmhmql7r5jydbca4x5qj6h7zq10z17gagys6dc7pw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Binder";
+    version = "3.1.4";
+    sha256 = "1bnf213zlrh0m3sbhsv601yx21l5xp254jiy2g4hm7zpm8vsz1hz";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.EnvironmentVariables";
+    version = "2.1.0";
+    sha256 = "0xx3idb1l5y1da5zynlys5gyarijmw5pc9hgci8xdxbrcv6rzbjb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.FileExtensions";
+    version = "2.1.0";
+    sha256 = "1lz2xwm63clbh9dfhmygbqvcp4dsrwh5jihv82dmqd5h7lqngl40";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Ini";
+    version = "2.1.0";
+    sha256 = "0bchsljywcq36si4zs2dcx2gj8x98ww93dh2bx2z6x5ilxyjnfip";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "2.0.0";
+    sha256 = "0yssxq9di5h6xw2cayp5hj3l9b2p0jw9wcjz73rwk4586spac9s9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "2.1.0";
+    sha256 = "04rjl38wlr1jjjpbzgf64jp0ql6sbzbil0brwq9mgr3hdgwd7vx2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "3.1.0";
+    sha256 = "1rszgz0rd5kvib5fscz6ss3pkxyjwqy0xpd4f2ypgzf5z5g5d398";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "3.1.4";
+    sha256 = "0npc18pjl86d06czb0fy6ln3prfpwfb16p6709xx2jrsl96dp9bp";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "2.0.0";
+    sha256 = "1pwrfh9b72k9rq6mb2jab5qhhi225d5rjalzkapiayggmygc8nhz";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "2.1.0";
+    sha256 = "0c0cx8r5xkjpxmcfp51959jnp55qjvq28d9vaslk08avvi1by12s";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "3.1.0";
+    sha256 = "1pvms778xkyv1a3gfwrxnh8ja769cxi416n7pcidn9wvg15ifvbh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection.Abstractions";
+    version = "3.1.4";
+    sha256 = "03ys96pqca93zwxvh0vprzms09i9y0lmq32w98m6klbizq01fc06";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection";
+    version = "2.0.0";
+    sha256 = "018izzgykaqcliwarijapgki9kp2c560qv8qsxdjywr7byws5apq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection";
+    version = "3.1.0";
+    sha256 = "1xc61dy07bn2q73mx1z3ylrw80xpa682qjby13gklnqq636a3gab";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyInjection";
+    version = "3.1.4";
+    sha256 = "0rhyjgdpjm56drvrvqd9v1xq1qhyrpwwn2pjsz17g2s462rwliqx";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyModel";
+    version = "2.0.4";
+    sha256 = "041i1vlcibpzgalxxzdk81g5pgmqvmz2g61k0rqa2sky0wpvijx9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyModel";
+    version = "3.1.1";
+    sha256 = "0qa04dspjl4qk7l8d66wqyrvhp5dxcfn2j4r8mmj362xyrp3r8sh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.DependencyModel";
+    version = "3.1.4";
+    sha256 = "0r0wv4k0ig6mrl6fr184zqbf5f010d6i2an2ws23g2bjvk8jh1bk";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileProviders.Abstractions";
+    version = "2.0.0";
+    sha256 = "0d6y5isjy6jpf4w3f3w89cwh9p40glzhwvm7cwhx05wkqd8bk9w4";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileProviders.Abstractions";
+    version = "2.1.0";
+    sha256 = "1sxls5f5cgb0wr8cwb05skqmz074683hrhmd3hhq6m5dasnzb8n3";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileProviders.Physical";
+    version = "2.1.0";
+    sha256 = "1firpsl5bk219i9gdfgiqw1zm68146h1dzx9hvawfpw9slfaa56w";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileSystemGlobbing";
+    version = "2.1.0";
+    sha256 = "1d2622qp22x1cnlwycnzjbc3sgi9jria26fk78zwzsa08npa3avv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Hosting.Abstractions";
+    version = "2.0.0";
+    sha256 = "056wgjcdzvz1qwb26xv6hgxq4xya56qiimhk30v8an8cgsrjk3mc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Hosting.Abstractions";
+    version = "2.1.0";
+    sha256 = "04vm9mdjjzg3lpp2rzpgkpn8h5bzdl3bwcr22lshd3kp602ws4k9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Identity.Core";
+    version = "3.1.4";
+    sha256 = "0kyi03l9d7pnsvrcylc86fcxwnj59mhvmbz4c1d142f8djdrqfid";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Identity.Stores";
+    version = "3.1.4";
+    sha256 = "0jb3syy0glyn4nnd7lb7aj412xnqyrwhfavh98rbc5adq9v09nbw";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "1.0.0";
+    sha256 = "1sh9bidmhy32gkz6fkli79mxv06546ybrzppfw5v2aq0bda1ghka";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "1.1.2";
+    sha256 = "0j9b4z3pf8a5xphx3ksn6jm01rf4z001vfll5kcbxw995xcidjw1";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "2.0.0";
+    sha256 = "1x5isi71z02khikzvm7vaschb006pqqrsv86ky1x08a4hir4s43h";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "2.1.0";
+    sha256 = "1gvgif1wcx4k6pv7gc00qv1hid945jdywy1s50s33q0hfd91hbnj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "3.1.0";
+    sha256 = "1zyalrcksszmn9r5xjnirfh7847axncgzxkk3k5srbvlcch8fw8g";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "3.1.4";
+    sha256 = "1rkl0yqmi5vfivn641866v2mdsgdy8amym546y6lzbab39g24b5n";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Filter";
+    version = "1.1.2";
+    sha256 = "1pip87q89376xxpi3r5pf9vxhqxx21qrp179fbldbkr2m1577k9m";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging";
+    version = "2.0.0";
+    sha256 = "1jkwjcq1ld9znz1haazk8ili2g4pzfdp6i7r7rki4hg3jcadn386";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging";
+    version = "3.1.0";
+    sha256 = "1d3yhqj1rav7vswm747j7w8fh8paybji4rz941hhlq4b12mfqfh4";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging";
+    version = "3.1.4";
+    sha256 = "04asfrhfrcl3ijilry2pr28ql5m6pgrwapadikgcg66jjxbx75zq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Options.ConfigurationExtensions";
+    version = "2.0.0";
+    sha256 = "1isc3rjbzz60f7wbmgcwslx5d10hm5hisnk7v54vfi2bz7132gll";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Options";
+    version = "2.0.0";
+    sha256 = "0g4zadlg73f507krilhaaa7h0jdga216syrzjlyf5fdk25gxmjqh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Options";
+    version = "3.1.0";
+    sha256 = "0akccwhpn93a4qrssyb3rszdsp3j4p9hlxbsb7yhqb78xydaqhyh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Options";
+    version = "3.1.4";
+    sha256 = "0jphncx82l7jm5xi49dfxhbh24wv86sy44022chd7bkizllsypp4";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.PlatformAbstractions";
+    version = "1.1.0";
+    sha256 = "0r4j8v2vvp3kalvb11ny9cvpls3nrvqj0c81rxbkh99ynd2dbscp";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "1.1.1";
+    sha256 = "0rcwxz1r89y96s8k3bmg0v6zdqanqfp09khy5l99wnl777y15g7x";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "2.0.0";
+    sha256 = "1xppr5jbny04slyjgngxjdm0maxdh47vq481ps944d7jrfs0p3mb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "2.1.0";
+    sha256 = "1r9gzwdfmb8ysnc4nzmyz5cyar1lw0qmizsvrsh252nhlyg06nmb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "3.1.0";
+    sha256 = "1w1y22njywwysi8qjnj4m83qhbq0jr4mmjib0hfawz6cwamh7xrb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "3.1.4";
+    sha256 = "12xvysk024aghrcwzv4525vznnk8lqmknl2vqqxhq4k5hjxpsysp";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.6.1";
+    sha256 = "0jjdg468jc6pv2z764f3xc19lcr772nzjm9cjfqq3bqw8vkpzmhv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NetCore.Analyzers";
+    version = "2.9.8";
+    sha256 = "1klybsdy9yw49zlpmix4vjdhmfaibg5h9yx03vszdnijzap7vpsx";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.0.1";
+    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "2.0.0";
+    sha256 = "1fk2fk2639i7nzy58m9dvpdnzql4vb8yl8vr19r2fp8lmj9w2jr0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "2.1.2";
+    sha256 = "1507hnpr9my3z4w1r6xk5n0s1j3y6a2c2cnynj76za7cphxi1141";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.0.1";
+    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.ObjectModel";
+    version = "16.6.1";
+    sha256 = "0q98q1nw6jl4bajm66z4a9vvh928w8ffsd3k6fpsps23ykpsky7h";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.TestHost";
+    version = "16.6.1";
+    sha256 = "0anzvb2mda548swb2ll1hv65knb8gwjm01hwbl0pzzr607my3lix";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.0.1";
+    sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+  })
+  (fetchNuGet {
+    name = "MySqlConnector";
+    version = "0.61.0";
+    sha256 = "0b0mc41dsih4p1ky3kcmibsz4bw14w439nraq5732wjfkq2sqdxg";
+  })
+  (fetchNuGet {
+    name = "NBitcoin.Altcoins";
+    version = "2.0.16";
+    sha256 = "0fsdb96k5lwyq4d7h7yg91qghima08yk0bsw5cvr4h2jsfphk423";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.33";
+    sha256 = "030q609b9lhapq4wfl1w3impjw5m40kz2rg1s9jn3bn8yjfmsi4a";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.4";
+    sha256 = "04iafda61izzxb691brk72qs01m5dadqb4970nw5ayck6275s71i";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.40";
+    sha256 = "1rqzn84yaww4afagwg8jg1l5qdkvqyjdfcyd5widddqwxabbsjvh";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.45";
+    sha256 = "102vwxwkg367yxv26hycnc7hjxlv2zvsgr8g6adw8dmzsxck5fwk";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.51";
+    sha256 = "0rg014sl7rqscnranwyfk41xfr5ccjqyx7aidfl5mh0znz44db2g";
+  })
+  (fetchNuGet {
+    name = "NBitpayClient";
+    version = "1.0.0.39";
+    sha256 = "1sgwradg7jnb4n3chwqfkximj1qhgl3r23p0sifmaa0kql2hlira";
+  })
+  (fetchNuGet {
+    name = "NBXplorer.Client";
+    version = "3.0.17";
+    sha256 = "0xx2xshgpci9l9883zpqnmgchpizygy0hcq2wp2ch6yf3hbrj9qq";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "1.6.1";
+    sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json.Bson";
+    version = "1.0.1";
+    sha256 = "1r1hvj5gjl466bya2bfl5aaj8rbwyf5x1msg710wf3k2llbci1xa";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json.Bson";
+    version = "1.0.2";
+    sha256 = "0c27bhy9x3c2n26inq32kmp6drpm71n6mqnmcr19wrlcaihglj35";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json.Schema";
+    version = "3.0.13";
+    sha256 = "04vzjz5fb588rh6ji5a0svfzjsdcfpr1qrz9hxpc64z5zhnh6sf4";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "10.0.3";
+    sha256 = "06vy67bkshclpz69kps4vgzc9h2cgg41c8vlqmdbwclfky7c4haq";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "11.0.1";
+    sha256 = "1z68j07if1xf71lbsrgbia52r812i2dv541sy44ph4dzjjp7pd4m";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "11.0.2";
+    sha256 = "1784xi44f4k8v1fr696hsccmwpy94bz7kixxqlri98zhcxn406b2";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.3";
+    sha256 = "17dzl305d835mzign8r15vkmav2hq8l6g7942dfjpnzr17wwl89x";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "9.0.1";
+    sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.CommandLine.Configuration";
+    version = "1.0.0.3";
+    sha256 = "0al0pd4zhjpmn8m208xjmy17cbyab68grzdvzr2lhsckwkl6b1jg";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.CommandLine";
+    version = "1.0.0.2";
+    sha256 = "08a9l18zkhcfa6f56xqylzvmqjzgxsmgkpm2r3ckvxfyml6w0qyy";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.RateLimits";
+    version = "1.1.0";
+    sha256 = "06cajxi8wnrxfwqfnk98avphwiyvg1fw428bd42lqjgq9k414rk9";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.StandardConfiguration";
+    version = "1.0.0.18";
+    sha256 = "0lgssxafv6cqlw21fb79fm0fcln0clgsk6zadcwrnjv9vampfw7b";
+  })
+  (fetchNuGet {
+    name = "NLog";
+    version = "4.5.10";
+    sha256 = "0d4yqxrhqn2k36h3v1f5pn6qqlagbzg67v6gvxqhz3s4zyc3b8rg";
+  })
+  (fetchNuGet {
+    name = "Npgsql.EntityFrameworkCore.PostgreSQL";
+    version = "3.1.4";
+    sha256 = "1ng9pbamh93g0fbnjq8ygaf40d6rs0fy4s08bjmxpa69k3s8c7a4";
+  })
+  (fetchNuGet {
+    name = "Npgsql";
+    version = "4.1.3.1";
+    sha256 = "0qk3hb8s521c2gy4k3m1i6fhpr133mnw9w85cwsy9j7ghxyca1nv";
+  })
+  (fetchNuGet {
+    name = "NuGet.Frameworks";
+    version = "5.0.0";
+    sha256 = "18ijvmj13cwjdrrm52c8fpq021531zaz4mj4b4zapxaqzzxf2qjr";
+  })
+  (fetchNuGet {
+    name = "NUglify";
+    version = "1.5.12";
+    sha256 = "0f4gs31z8dwfvd246nrv3m0qkxzav37hxynx2maykza017khynyf";
+  })
+  (fetchNuGet {
+    name = "Pomelo.EntityFrameworkCore.MySql";
+    version = "3.1.1";
+    sha256 = "1jvv2q7pmh5wzsfjim7iby4r1scb30kgj9w6sbm2dp60i6vm32dx";
+  })
+  (fetchNuGet {
+    name = "Pomelo.JsonObject";
+    version = "2.2.1";
+    sha256 = "1w6s9wjbsyvq8cnqknkdzm9chnv0g5gcsrq5i94zp6br9vg7c627";
+  })
+  (fetchNuGet {
+    name = "Portable.BouncyCastle";
+    version = "1.8.1.3";
+    sha256 = "1lv1ljaz8df835jgmp3ny1xgqqjf1s9f25baw7bf8d24qlf25i2g";
+  })
+  (fetchNuGet {
+    name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.0.1";
+    sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Security";
+    version = "4.3.0";
+    sha256 = "0dnqjhw445ay3chpia9p6vy4w2j6s9vy3hxszqvdanpvvyaxijr3";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography";
+    version = "4.0.0";
+    sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.0.0";
+    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.3.0";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
+  })
+  (fetchNuGet {
+    name = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
+  })
+  (fetchNuGet {
+    name = "Selenium.WebDriver.ChromeDriver";
+    version = "83.0.4103.3900";
+    sha256 = "17j9b637209nm5cs5sgr3vflphkhaxpm8bcjizhgj65r52gn17as";
+  })
+  (fetchNuGet {
+    name = "Selenium.WebDriver";
+    version = "3.141.0";
+    sha256 = "09g0zhz6n7yhxmxlrpzjdykfavr3m4z1gb4cmq304dw0gr8s89mq";
+  })
+  (fetchNuGet {
+    name = "Serilog.AspNetCore";
+    version = "3.2.0";
+    sha256 = "14d1lsw1djsshlkxbn5lkmdvj4372hnddb6788m6ix0mv4mhj3bj";
+  })
+  (fetchNuGet {
+    name = "Serilog.Extensions.Hosting";
+    version = "3.0.0";
+    sha256 = "1r01lsy4rp0wj7ffbjcf9dcg3aipdhy7066yjicja45m0z2y42w6";
+  })
+  (fetchNuGet {
+    name = "Serilog.Extensions.Logging";
+    version = "3.0.1";
+    sha256 = "069qy7dm5nxb372ij112ppa6m99b4iaimj3sji74m659fwrcrl9a";
+  })
+  (fetchNuGet {
+    name = "Serilog.Formatting.Compact";
+    version = "1.0.0";
+    sha256 = "0mi1yzzj33v4nkyspyshhc6nn2mx3y07z5dvv26hl7hw6kb6yazw";
+  })
+  (fetchNuGet {
+    name = "Serilog.Settings.Configuration";
+    version = "3.1.0";
+    sha256 = "1cj5am4n073331gbfm2ylqb9cadl4q3ppzgwmm5c8m1drxpiwkb5";
+  })
+  (fetchNuGet {
+    name = "Serilog.Sinks.Console";
+    version = "3.1.1";
+    sha256 = "0j99as641y1k6havwwkhyr0n08vibiblmfjj6nz051mz8g3864fn";
+  })
+  (fetchNuGet {
+    name = "Serilog.Sinks.Debug";
+    version = "1.0.1";
+    sha256 = "0969mb254kr59bgkq01ybyzca89z3f4n9ng5mdj8m53d5653zf22";
+  })
+  (fetchNuGet {
+    name = "Serilog.Sinks.File";
+    version = "4.1.0";
+    sha256 = "1ry7p9hf1zlnai1j5zjhjp4dqm2agsbpq6cvxgpf5l8m26x6mgca";
+  })
+  (fetchNuGet {
+    name = "Serilog";
+    version = "2.9.0";
+    sha256 = "0z0ib82w9b229a728bbyhzc2hnlbl0ki7nnvmgnv3l741f2vr4i6";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.bundle_e_sqlite3";
+    version = "2.0.2";
+    sha256 = "00p7n7ndmmh45fhhd3clb11igpzklm1n7r50sdrgnbi5yifv1lxl";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.core";
+    version = "2.0.2";
+    sha256 = "11mnbnsiirpgmilskqh1issvgzgg08ndq3p3nkrw73hyqr7kl958";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.lib.e_sqlite3";
+    version = "2.0.2";
+    sha256 = "0967w6r6n94hj0fma3kidb9fx1m2p3fgrw6gpsy6q6jbb33qw6vj";
+  })
+  (fetchNuGet {
+    name = "SQLitePCLRaw.provider.dynamic_cdecl";
+    version = "2.0.2";
+    sha256 = "1lzs8yfjygrwfm3hjmkhnbnpsjzq53ijwx9whmii2r9kjg2a46if";
+  })
+  (fetchNuGet {
+    name = "SSH.NET";
+    version = "2016.1.0";
+    sha256 = "0q08bf9sdf1rf9763z4bk2mr6z381iybm73823scmq9qcpr2jk4d";
+  })
+  (fetchNuGet {
+    name = "SshNet.Security.Cryptography";
+    version = "1.2.0";
+    sha256 = "1xlj8bjavpjk6lrkypk66cxpf2xa31wv73ymrk34d72f05z0xrg0";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.1.0";
+    sha256 = "0fv3cma1jp4vgj7a8hqc9n7hr1f1kjp541s6z0q1r6nazb4iz9mz";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.3.0";
+    sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.3.0";
+    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.0.12";
+    sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.3.0";
+    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.5.0";
+    sha256 = "1d5gjn5afnrf461jlxzawcvihz195gayqpcfbv6dd7pxa9ialn06";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.7.0";
+    sha256 = "1gik4sn9jsi1wcy1pyyp0r4sn2g17cwrsh24b2d52vif8p2h24zx";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Immutable";
+    version = "1.7.1";
+    sha256 = "1nh4nlxfc7lbnbl86wwk1a3jwl6myz5j6hvgh5sp4krim9901hsq";
+  })
+  (fetchNuGet {
+    name = "System.Collections.NonGeneric";
+    version = "4.3.0";
+    sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Specialized";
+    version = "4.3.0";
+    sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.0.11";
+    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.3.0";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Annotations";
+    version = "4.7.0";
+    sha256 = "06x1m46ddxj0ng28d7gry9gjkqdg2kp89jyf480g5gznyybbs49z";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Primitives";
+    version = "4.3.0";
+    sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.TypeConverter";
+    version = "4.3.0";
+    sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel";
+    version = "4.3.0";
+    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
+  })
+  (fetchNuGet {
+    name = "System.Configuration.ConfigurationManager";
+    version = "4.5.0";
+    sha256 = "1frpy24mn6q7hgwayj98kkx89z861f5dmia4j6zc0a2ydgx8x02c";
+  })
+  (fetchNuGet {
+    name = "System.Console";
+    version = "4.3.0";
+    sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.0.0";
+    sha256 = "1n6c3fbz7v8d3pn77h4v5wvsfrfg7v1c57lg3nff3cjyh597v23m";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.3.0";
+    sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.7.0";
+    sha256 = "0cr0v5dz8l5ackxv6b772fjcyj2nimqmrmzanjs4cw2668v568n1";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.7.1";
+    sha256 = "1mivaifniyrqwlnvzsfaxzrh2sd981bwzs3cbvs5wi7jjzbcqr4p";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.0.1";
+    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.3.0";
+    sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.TraceSource";
+    version = "4.0.0";
+    sha256 = "1mc7r72xznczzf6mz62dm8xhdi14if1h8qgx353xvhz89qyxsa3h";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.1.0";
+    sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.0.11";
+    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.3.0";
+    sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.0.1";
+    sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.3.0";
+    sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.0.1";
+    sha256 = "0hjhdb5ri8z9l93bw04s7ynwrjrhx2n0p34sf33a9hl9phz69fyc";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.3.0";
+    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.0.11";
+    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.3.0";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+  })
+  (fetchNuGet {
+    name = "System.Interactive.Async";
+    version = "3.1.1";
+    sha256 = "03iq20gq0n2b2sdzs5jhxf46nzkfgvzip6q5248vka2rcvn1yanh";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression.ZipFile";
+    version = "4.3.0";
+    sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.0.1";
+    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO.Pipelines";
+    version = "4.7.2";
+    sha256 = "16v4qaypm72cfsfqr8z3k6yrpzn0m3apgkh6aljfwpycdk150sf9";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.1.0";
+    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.1.0";
+    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.3.0";
+    sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.1.0";
+    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.3.0";
+    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.0";
+    sha256 = "1layqpcx1q4l805fdnj2dfqp6ncx2z42ca06rgsr6ikq4jjgbv30";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.3";
+    sha256 = "0naqahm3wljxb5a911d37mwjqjdxv9l0b49p5dmfyijvni2ppy8a";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.1.0";
+    sha256 = "1i5rqij1icg05j8rrkw4gd4pgia1978mqhjzhsjg69lvwcdfg8yb";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
+  })
+  (fetchNuGet {
+    name = "System.Net.NameResolution";
+    version = "4.0.0";
+    sha256 = "0dj3pvpv069nyia28gkl4a0fb7q33hbxz2dg25qvpah3l7pbl0qh";
+  })
+  (fetchNuGet {
+    name = "System.Net.NameResolution";
+    version = "4.3.0";
+    sha256 = "15r75pwc0rm3vvwsn8rvm2krf929mjfwliv0mpicjnii24470rkq";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.0.11";
+    sha256 = "10xzzaynkzkakp7jai1ik3r805zrqjxiz7vcagchyxs2v26a516r";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+  })
+  (fetchNuGet {
+    name = "System.Net.Requests";
+    version = "4.0.11";
+    sha256 = "13mka55sa6dg6nw4zdrih44gnp8hnj5azynz47ljsh2791lz3d9h";
+  })
+  (fetchNuGet {
+    name = "System.Net.Security";
+    version = "4.3.0";
+    sha256 = "1aa5igz31ivk6kpgsrwck3jccab7wd88wr52lddmgypmbh9mmf87";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.1.0";
+    sha256 = "1385fvh8h29da5hh58jm1v78fzi9fi5vj93vhlm2kvqpfahvpqls";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.3.0";
+    sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebHeaderCollection";
+    version = "4.0.1";
+    sha256 = "10bxpxj80c4z00z3ksrfswspq9qqsw8jwxcbzvymzycb97m9b55q";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebHeaderCollection";
+    version = "4.3.0";
+    sha256 = "0ms3ddjv1wn8sqa5qchm245f3vzzif6l6fx5k92klqpn7zf4z562";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets.Client";
+    version = "4.3.2";
+    sha256 = "103y8lfsfa5xd1sqmq9sml4qyp4rij2i3fnnw119h119hb04l0rk";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets";
+    version = "4.3.0";
+    sha256 = "1gfj800078kggcgl0xyl00a6y5k4wwh2k2qm69rjy22wbmq7fy4p";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.0.12";
+    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.3.0";
+    sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.0.1";
+    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.3.0";
+    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.0.1";
+    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.3.0";
+    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.0.1";
+    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.3.0";
+    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.0.1";
+    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.3.0";
+    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Metadata";
+    version = "1.6.0";
+    sha256 = "1wdbavrrkajy7qbdblpbpbalbdl48q3h34cchz24gvdgyrlf15r4";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.0.1";
+    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.1.0";
+    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.3.0";
+    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.1.0";
+    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.0.1";
+    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.3.0";
+    sha256 = "149xcsa1pphlrc2zfmca9n822g4mxk7s2a44phvf34r0fajm3hk8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.4.0";
+    sha256 = "0a6ahgi5b148sl5qyfpyw383p3cb4yrkm802k29fsi4mxkiwir29";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.0";
+    sha256 = "17labczwqk3jng3kkky73m0jhi8wc21vbl7cz5c0hj2p1dswin43";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.2";
+    sha256 = "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.6.0";
+    sha256 = "0xmzi2gpbmgyfr75p24rqqsba3cmrqgmcv45lsqp5amgrdwd0f0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.7.0";
+    sha256 = "16r6sn4czfjk8qhnz7bnqlyiaaszr0ihinb7mq9zzr1wba257r54";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.0.1";
+    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.0.0";
+    sha256 = "0glmvarf3jz5xh22iy3w9v3wyragcm4hfdr17v90vs7vcrm7fgp6";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.0.1";
+    sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.3.0";
+    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Formatters";
+    version = "4.3.0";
+    sha256 = "114j35n8gcvn3sqv9ar36r1jjq0y1yws9r0yk8i6wm4aq7n9rs0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.1.1";
+    sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.3.0";
+    sha256 = "01vv2p8h4hsz217xxs0rixvb7f2xzbh6wv1gzbfykcbfrza6dvnf";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.1.0";
+    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Security.AccessControl";
+    version = "4.5.0";
+    sha256 = "1wvwanz33fzzbnd2jalar0p0z3x0ba53vzx1kazlskp7pwyhlnq0";
+  })
+  (fetchNuGet {
+    name = "System.Security.Claims";
+    version = "4.0.1";
+    sha256 = "03dw0ls49bvsrffgwycyifjgz0qzr9r85skqhdyhfd51fqf398n6";
+  })
+  (fetchNuGet {
+    name = "System.Security.Claims";
+    version = "4.3.0";
+    sha256 = "0jvfn7j22l3mm28qjy3rcw287y9h65ha4m940waaxah07jnbzrhn";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.2.0";
+    sha256 = "148s9g5dgm33ri7dnh19s4lgnlxbpwvrw2jnzllq2kijj4i4vs85";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.3.0";
+    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.2.0";
+    sha256 = "118jijz446kix20blxip0f0q8mhsh9bz118mwc2ch1p6g7facpzc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.3.0";
+    sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.0.0";
+    sha256 = "1cwv8lqj8r15q81d2pz2jwzzbaji0l28xfrpw29kdpsaypm92z2q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.3.0";
+    sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.0.0";
+    sha256 = "0a8y1a5wkmpawc787gfmnrnbzdgxmx1a14ax43jf3rj9gxmy3vk4";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.3.0";
+    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.0.0";
+    sha256 = "16sx3cig3d0ilvzl8xxgffmxbiqx87zdi8fc73i3i7zjih1a7f4q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.0.0";
+    sha256 = "0i7cfnwph9a10bm26m538h5xcr8b36jscp9sy1zhgifksxz4yixh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.3.0";
+    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.ProtectedData";
+    version = "4.5.0";
+    sha256 = "11qlc8q6b7xlspayv07718ibzvlj6ddqqxkvcbxv5b24d5kzbrb7";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.1.0";
+    sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.3.0";
+    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+  })
+  (fetchNuGet {
+    name = "System.Security.Permissions";
+    version = "4.5.0";
+    sha256 = "192ww5rm3c9mirxgl1nzyrwd18am3izqls0hzm0fvcdjl5grvbhm";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.0.0";
+    sha256 = "1d3vc8i0zss9z8p4qprls4gbh7q4218l9845kclx7wvw41809k6z";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.3.0";
+    sha256 = "00a0a7c40i3v4cb20s2cmh9csb5jv2l0frvnlzyfxh848xalpdwr";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.5.0";
+    sha256 = "0rmj89wsl5yzwh0kqjgx45vzf694v9p92r4x4q6yxldk1cv1hi86";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal";
+    version = "4.0.1";
+    sha256 = "1nbzdfqvzzbgsfdd5qsh94d7dbg2v4sw0yx6himyn52zf8z6007p";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal";
+    version = "4.3.0";
+    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.CodePages";
+    version = "4.5.1";
+    sha256 = "1z21qyfs6sg76rp68qdx0c9iy57naan89pg7p6i3qpj8kyzn921w";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encodings.Web";
+    version = "4.4.0";
+    sha256 = "05qp3yivh6gz0vva0v3wjlj3g1b45d5jmz362f2y8ah6yb3rx088";
+  })
+  (fetchNuGet {
+    name = "System.Text.Json";
+    version = "4.7.0";
+    sha256 = "0fp3xrysccm5dkaac4yb51d793vywxks978kkl5x4db9gw29rfdr";
+  })
+  (fetchNuGet {
+    name = "System.Text.Json";
+    version = "4.7.2";
+    sha256 = "10xj1pw2dgd42anikvj9qm23ccssrcp7dpznpj4j7xjp1ikhy3y4";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.1.0";
+    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.3.0";
+    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Channels";
+    version = "4.5.0";
+    sha256 = "0n6z3wjia7h2a5vl727p97riydnb6jhhkb1pdcnizza02dwkz0nz";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.0.0";
+    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.3.0";
+    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.5.3";
+    sha256 = "0g7r6hm572ax8v28axrdxz1gnsblg6kszq17g51pj14a5rn2af7i";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Thread";
+    version = "4.0.0";
+    sha256 = "1gxxm5fl36pjjpnx1k688dcw8m9l7nmf802nxis6swdaw8k54jzc";
+  })
+  (fetchNuGet {
+    name = "System.Threading.ThreadPool";
+    version = "4.0.10";
+    sha256 = "0fdr61yjcxh5imvyf93n2m3n5g9pp54bnw2l1d2rdl9z6dd31ypx";
+  })
+  (fetchNuGet {
+    name = "System.Threading.ThreadPool";
+    version = "4.3.0";
+    sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.0.1";
+    sha256 = "15n54f1f8nn3mjcjrlzdg6q3520571y012mx7v991x2fvp73lmg6";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.3.0";
+    sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.0.11";
+    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.0.11";
+    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.3.0";
+    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.0.11";
+    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.3.0";
+    sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.0.1";
+    sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.3.0";
+    sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath.XmlDocument";
+    version = "4.0.1";
+    sha256 = "0l7yljgif41iv5g56l3nxy97hzzgck2a7rhnfnljhx9b0ry41bvc";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XPath";
+    version = "4.0.1";
+    sha256 = "0fjqgb6y66d72d5n8qq1h213d9nv2vi8mpv8p28j3m9rccmsh04m";
+  })
+  (fetchNuGet {
+    name = "Text.Analyzers";
+    version = "2.6.4";
+    sha256 = "1fm3gjnbfnjap3wphx5x48awriy14a2g3s9c1nc4m8w85k8mqdsl";
+  })
+  (fetchNuGet {
+    name = "TwentyTwenty.Storage.Amazon";
+    version = "2.12.1";
+    sha256 = "03nrkvhki35w1rqx94s97rwxl0qwqlczyiimhrkc72vjppn5p6ph";
+  })
+  (fetchNuGet {
+    name = "TwentyTwenty.Storage.Azure";
+    version = "2.12.1";
+    sha256 = "10q7gpr8kmgzmxrzj3paqlnw4d8li8scwpxkzs11ildscfp6hvlv";
+  })
+  (fetchNuGet {
+    name = "TwentyTwenty.Storage.Google";
+    version = "2.12.1";
+    sha256 = "0d8s7p9brp03h9dpv3wxnqg0xsm7d9p4k6dpxpb9jak535khxzhp";
+  })
+  (fetchNuGet {
+    name = "TwentyTwenty.Storage.Local";
+    version = "2.12.1";
+    sha256 = "1zmjqwd1v3z78ab4vdmaadh94465k1qgpv7ylv8x3sdx4z78yjm8";
+  })
+  (fetchNuGet {
+    name = "TwentyTwenty.Storage";
+    version = "2.12.1";
+    sha256 = "0m41dxzc3hh0f4j1k4q915pvcq6zr0hv1pj6b3sayrn8vjhk64qb";
+  })
+  (fetchNuGet {
+    name = "U2F.Core";
+    version = "1.0.4";
+    sha256 = "0mk32yyihigp9njs54z411fswgzr6x3kw134c7ylwy2d2wmq2n9b";
+  })
+  (fetchNuGet {
+    name = "WindowsAzure.Storage";
+    version = "9.3.3";
+    sha256 = "14b0b0nj85yvyn0h8ghr3kj6di2nkbzjxc2q98f1wcr0151xvdfx";
+  })
+  (fetchNuGet {
+    name = "xunit.abstractions";
+    version = "2.0.3";
+    sha256 = "00wl8qksgkxld76fgir3ycc5rjqv1sqds6x8yx40927q5py74gfh";
+  })
+  (fetchNuGet {
+    name = "xunit.analyzers";
+    version = "0.10.0";
+    sha256 = "15n02q3akyqbvkp8nq75a8rd66d4ax0rx8fhdcn8j78pi235jm7j";
+  })
+  (fetchNuGet {
+    name = "xunit.assert";
+    version = "2.4.1";
+    sha256 = "1imynzh80wxq2rp9sc4gxs4x1nriil88f72ilhj5q0m44qqmqpc6";
+  })
+  (fetchNuGet {
+    name = "xunit.core";
+    version = "2.4.1";
+    sha256 = "1nnb3j4kzmycaw1g76ii4rfqkvg6l8gqh18falwp8g28h802019a";
+  })
+  (fetchNuGet {
+    name = "xunit.extensibility.core";
+    version = "2.4.1";
+    sha256 = "103qsijmnip2pnbhciqyk2jyhdm6snindg5z2s57kqf5pcx9a050";
+  })
+  (fetchNuGet {
+    name = "xunit.extensibility.execution";
+    version = "2.4.1";
+    sha256 = "1pbilxh1gp2ywm5idfl0klhl4gb16j86ib4x83p8raql1dv88qia";
+  })
+  (fetchNuGet {
+    name = "xunit.runner.visualstudio";
+    version = "2.4.2";
+    sha256 = "0fi85h43nyrhfc5jzg07znh01r7cpb7bpjdc6mzb9z1pm14ppfm6";
+  })
+  (fetchNuGet {
+    name = "xunit";
+    version = "2.4.1";
+    sha256 = "0xf3kaywpg15flqaqfgywqyychzk15kz0kz34j21rcv78q9ywq20";
+  })
+  (fetchNuGet {
+    name = "YamlDotNet";
+    version = "8.0.0";
+    sha256 = "09hr1jimmfhcpk97p963y94h2k5p7wzcj4mpwqpdnwzbyrp2flpm";
+  })
+]

--- a/pkgs/btcpayserver/update.sh
+++ b/pkgs/btcpayserver/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+
+"$scriptDir"/../nbxplorer/util/update-common.sh btcpayserver "$scriptDir"/deps.nix

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {} }:
-{
+let self = {
   lightning-charge = pkgs.callPackage ./lightning-charge { };
   nanopos = pkgs.callPackage ./nanopos { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
@@ -12,8 +12,13 @@
   nixops19_09 = pkgs.callPackage ./nixops { };
   netns-exec = pkgs.callPackage ./netns-exec { };
   lightning-loop = pkgs.callPackage ./lightning-loop { };
+  btcpayserver = pkgs.callPackage ./btcpayserver { inherit (self) linkFarmFromDrvs; };
+  nbxplorer = pkgs.callPackage ./nbxplorer { inherit (self) linkFarmFromDrvs; };
+
+  # Temporary backport for btcpayserver
+  linkFarmFromDrvs = pkgs.linkFarmFromDrvs or self.pinned.nixpkgsUnstable.linkFarmFromDrvs;
 
   pinned = import ./pinned.nix;
 
   lib = import ./lib.nix { inherit (pkgs) lib; };
-}
+}; in self

--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -11,6 +11,7 @@ makeHMAC() {
 }
 
 makePasswordSecret bitcoin-rpcpassword-privileged
+makePasswordSecret bitcoin-rpcpassword-btcpayserver
 makePasswordSecret bitcoin-rpcpassword-public
 makePasswordSecret lnd-wallet-password
 makePasswordSecret liquid-rpcpassword
@@ -20,6 +21,7 @@ makePasswordSecret backup-encryption-password
 
 [[ -e bitcoin-HMAC-privileged ]] || makeHMAC privileged
 [[ -e bitcoin-HMAC-public ]] || makeHMAC public
+[[ -e bitcoin-HMAC-btcpayserver ]] || makeHMAC btcpayserver
 [[ -e lightning-charge-env ]] || echo "API_TOKEN=$(cat lightning-charge-token)" > lightning-charge-env
 [[ -e nanopos-env          ]] || echo "CHARGE_TOKEN=$(cat lightning-charge-token)" > nanopos-env
 [[ -e spark-wallet-login   ]] || echo "login=spark-wallet:$(cat spark-wallet-password)" > spark-wallet-login

--- a/pkgs/nbxplorer/default.nix
+++ b/pkgs/nbxplorer/default.nix
@@ -1,0 +1,54 @@
+{ lib, stdenv, fetchFromGitHub, fetchurl, linkFarmFromDrvs, makeWrapper,
+  dotnetPackages, dotnetCorePackages
+}:
+
+let
+  deps = import ./deps.nix {
+    fetchNuGet = { name, version, sha256 }: fetchurl {
+      name = "nuget-${name}-${version}.nupkg";
+      url = "https://www.nuget.org/api/v2/package/${name}/${version}";
+      inherit sha256;
+    };
+  };
+  dotnetSdk = dotnetCorePackages.sdk_3_1;
+in
+
+stdenv.mkDerivation rec {
+  pname = "nbxplorer";
+  version = "2.1.42";
+
+  src = fetchFromGitHub {
+    owner = "dgarage";
+    repo = "NBXplorer";
+    rev = "v${version}";
+    sha256 = "01q6n7095rrha00xs3l7igzfb9rd743z8crxa2dcz4q5srapfzpi";
+  };
+
+  nativeBuildInputs = [ dotnetSdk dotnetPackages.Nuget makeWrapper ];
+
+  buildPhase = ''
+    export HOME=$TMP/home
+    export DOTNET_CLI_TELEMETRY_OPTOUT=1
+    export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+    nuget sources Add -Name tmpsrc -Source $TMP/nuget
+    nuget init ${linkFarmFromDrvs "deps" deps} $TMP/nuget
+
+    dotnet restore --source $TMP/nuget NBXplorer/NBXplorer.csproj
+    dotnet publish --no-restore --output $out/share/$pname -c Release NBXplorer/NBXplorer.csproj
+  '';
+
+  installPhase = ''
+    makeWrapper $out/share/$pname/NBXplorer $out/bin/$pname \
+      --set DOTNET_ROOT "${dotnetSdk}"
+  '';
+
+  dontStrip = true;
+
+  meta = with lib; {
+    description = "Minimalist UTXO tracker for HD Cryptocurrency Wallets";
+    maintainers = with maintainers; [ kcalvinalvin earvstedt ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/nbxplorer/deps.nix
+++ b/pkgs/nbxplorer/deps.nix
@@ -1,0 +1,1072 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    name = "DBTrie";
+    version = "1.0.38";
+    sha256 = "09n9f2j0pha2np9cpbgjfs19jwvfmrglws89izarq71gl8jia6d9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.JsonPatch";
+    version = "3.1.5";
+    sha256 = "0agcp9c8zf59bliybjfg5whby7k1i1xc4sccyyyj3qcx1snf6lfx";
+  })
+  (fetchNuGet {
+    name = "Microsoft.AspNetCore.Mvc.NewtonsoftJson";
+    version = "3.1.5";
+    sha256 = "1n76xr3jn4bcxm9f3lk8k76zn39mhyqcj5b0dqhi2xykyvvrqjgc";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Azure.Amqp";
+    version = "2.4.2";
+    sha256 = "0pfgl6fnw3apwasfg1dp5pvi5h0z0vmznhn2bfsgwndn1xlfw1g9";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Azure.ServiceBus";
+    version = "4.1.3";
+    sha256 = "1mj21nal3hv8b5678rah808521c5rkb0yh6hrlqirsdgxwnl6z6g";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Azure.Services.AppAuthentication";
+    version = "1.0.3";
+    sha256 = "0as64agcsilwgbvwx7iw3abdxyp9cbfpczbagjz49mqmmgnqp899";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CodeCoverage";
+    version = "16.6.1";
+    sha256 = "01ffm4nflqdb93vq4xl0j3377x360fgx6c6h12mpkcy85ixbv3rl";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.0.1";
+    sha256 = "0zxc0apx1gcx361jlq8smc9pfdgmyjh6hpka8dypc9w23nlsh6yj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.3.0";
+    sha256 = "0gw297dgkh0al1zxvgvncqs0j15lsna9l1wpqas4rflmys440xvb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.CSharp";
+    version = "4.7.0";
+    sha256 = "0gd67zlw554j098kabg887b5a6pq9kzavpa3jjy5w53ccjzjfy8j";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Abstractions";
+    version = "2.1.0";
+    sha256 = "03gzlr3z9j1xnr1k6y91zgxpz3pj27i3zsvjwj7i8jqnlqmk7pxd";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.EnvironmentVariables";
+    version = "2.1.0";
+    sha256 = "0xx3idb1l5y1da5zynlys5gyarijmw5pc9hgci8xdxbrcv6rzbjb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.FileExtensions";
+    version = "2.1.0";
+    sha256 = "1lz2xwm63clbh9dfhmygbqvcp4dsrwh5jihv82dmqd5h7lqngl40";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration.Ini";
+    version = "2.1.0";
+    sha256 = "0bchsljywcq36si4zs2dcx2gj8x98ww93dh2bx2z6x5ilxyjnfip";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Configuration";
+    version = "2.1.0";
+    sha256 = "04rjl38wlr1jjjpbzgf64jp0ql6sbzbil0brwq9mgr3hdgwd7vx2";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileProviders.Abstractions";
+    version = "2.1.0";
+    sha256 = "1sxls5f5cgb0wr8cwb05skqmz074683hrhmd3hhq6m5dasnzb8n3";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileProviders.Physical";
+    version = "2.1.0";
+    sha256 = "1firpsl5bk219i9gdfgiqw1zm68146h1dzx9hvawfpw9slfaa56w";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.FileSystemGlobbing";
+    version = "2.1.0";
+    sha256 = "1d2622qp22x1cnlwycnzjbc3sgi9jria26fk78zwzsa08npa3avv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "1.0.0";
+    sha256 = "1sh9bidmhy32gkz6fkli79mxv06546ybrzppfw5v2aq0bda1ghka";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Logging.Abstractions";
+    version = "2.1.0";
+    sha256 = "1gvgif1wcx4k6pv7gc00qv1hid945jdywy1s50s33q0hfd91hbnj";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Extensions.Primitives";
+    version = "2.1.0";
+    sha256 = "1r9gzwdfmb8ysnc4nzmyz5cyar1lw0qmizsvrsh252nhlyg06nmb";
+  })
+  (fetchNuGet {
+    name = "Microsoft.IdentityModel.Clients.ActiveDirectory";
+    version = "3.14.2";
+    sha256 = "0g9a2z1qjxd71lqqghp0a542xk9jkvz951bbnnnw43is4hlnqncq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.IdentityModel.JsonWebTokens";
+    version = "5.4.0";
+    sha256 = "0a5fn0p10dmkwa7vvbq28xw78aq33xm7c82l7vhla95n0lr178n8";
+  })
+  (fetchNuGet {
+    name = "Microsoft.IdentityModel.Logging";
+    version = "5.4.0";
+    sha256 = "1idlpyg3q3syam6aflfbnsa7iql685mjralr1cnfpryf00lm59v0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.IdentityModel.Tokens";
+    version = "5.4.0";
+    sha256 = "0gpdh5rs0p97zm41pphha8n3ccd50b1iszikj3917f111khpw8l0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NET.Test.Sdk";
+    version = "16.6.1";
+    sha256 = "0jjdg468jc6pv2z764f3xc19lcr772nzjm9cjfqq3bqw8vkpzmhv";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.0.1";
+    sha256 = "01al6cfxp68dscl15z7rxfw9zvhm64dncsw09a1vmdkacsa2v6lr";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.0.2";
+    sha256 = "17rrj0awknxx6rpdxr7yijdxqdmbbpdlcf2nsadjbd4d2gw7dck0";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    sha256 = "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.0.1";
+    sha256 = "0ppdkwy6s9p7x9jix3v4402wb171cdiibq7js7i13nxpdky7074p";
+  })
+  (fetchNuGet {
+    name = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    sha256 = "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.ObjectModel";
+    version = "16.6.1";
+    sha256 = "0q98q1nw6jl4bajm66z4a9vvh928w8ffsd3k6fpsps23ykpsky7h";
+  })
+  (fetchNuGet {
+    name = "Microsoft.TestPlatform.TestHost";
+    version = "16.6.1";
+    sha256 = "0anzvb2mda548swb2ll1hv65knb8gwjm01hwbl0pzzr607my3lix";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.0.1";
+    sha256 = "1n8ap0cmljbqskxpf8fjzn7kh1vvlndsa75k01qig26mbw97k2q7";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    sha256 = "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq";
+  })
+  (fetchNuGet {
+    name = "Microsoft.Win32.Registry";
+    version = "4.3.0";
+    sha256 = "1gxyzxam8163vk1kb6xzxjj4iwspjsz9zhgn1w9rjzciphaz0ig7";
+  })
+  (fetchNuGet {
+    name = "NBitcoin.Altcoins";
+    version = "2.0.19";
+    sha256 = "12a3bf1pi6sq78z6h3clyczvycx7cjry8fby4fyi748wjwljjizz";
+  })
+  (fetchNuGet {
+    name = "NBitcoin.TestFramework";
+    version = "2.0.11";
+    sha256 = "09jrbq9p5k67kdic2038s7q299y2nc8ij6m55m3m8hys7jdrrv05";
+  })
+  (fetchNuGet {
+    name = "NBitcoin";
+    version = "5.0.54";
+    sha256 = "0mx2gr8j8bc4mf1vi1fvqj3672qalxvzvincc61if79p46cik24b";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "1.6.1";
+    sha256 = "1z70wvsx2d847a2cjfii7b83pjfs34q05gb037fdjikv5kbagml8";
+  })
+  (fetchNuGet {
+    name = "NETStandard.Library";
+    version = "2.0.3";
+    sha256 = "1fn9fxppfcg4jgypp2pmrpr6awl3qz1xmnri0cygpkwvyx27df1y";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json.Bson";
+    version = "1.0.2";
+    sha256 = "0c27bhy9x3c2n26inq32kmp6drpm71n6mqnmcr19wrlcaihglj35";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "10.0.3";
+    sha256 = "06vy67bkshclpz69kps4vgzc9h2cgg41c8vlqmdbwclfky7c4haq";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "11.0.1";
+    sha256 = "1z68j07if1xf71lbsrgbia52r812i2dv541sy44ph4dzjjp7pd4m";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "12.0.2";
+    sha256 = "0w2fbji1smd2y7x25qqibf1qrznmv4s6s0jvrbvr6alb7mfyqvh5";
+  })
+  (fetchNuGet {
+    name = "Newtonsoft.Json";
+    version = "9.0.1";
+    sha256 = "0mcy0i7pnfpqm4pcaiyzzji4g0c8i3a5gjz28rrr28110np8304r";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.CommandLine.Configuration";
+    version = "1.0.0.3";
+    sha256 = "0al0pd4zhjpmn8m208xjmy17cbyab68grzdvzr2lhsckwkl6b1jg";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.CommandLine";
+    version = "1.0.0.2";
+    sha256 = "08a9l18zkhcfa6f56xqylzvmqjzgxsmgkpm2r3ckvxfyml6w0qyy";
+  })
+  (fetchNuGet {
+    name = "NicolasDorier.StandardConfiguration";
+    version = "1.0.0.18";
+    sha256 = "0lgssxafv6cqlw21fb79fm0fcln0clgsk6zadcwrnjv9vampfw7b";
+  })
+  (fetchNuGet {
+    name = "NuGet.Frameworks";
+    version = "5.0.0";
+    sha256 = "18ijvmj13cwjdrrm52c8fpq021531zaz4mj4b4zapxaqzzxf2qjr";
+  })
+  (fetchNuGet {
+    name = "RabbitMQ.Client";
+    version = "5.1.2";
+    sha256 = "195nxmnva1z2p0ahvn0kswv4d39f5bdy2sl3cxcvfziamc21xrmd";
+  })
+  (fetchNuGet {
+    name = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "16rnxzpk5dpbbl1x354yrlsbvwylrq456xzpsha1n9y3glnhyx9d";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0hkg03sgm2wyq8nqk6dbm9jh5vcq57ry42lkqdmfklrw89lsmr59";
+  })
+  (fetchNuGet {
+    name = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0c2p354hjx58xhhz7wv6div8xpi90sc6ibdm40qin21bvi7ymcaa";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "1vvivbqsk6y4hzcid27pqpm5bsi6sc50hvqwbcx8aap5ifrxfs8d";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.0.1";
+    sha256 = "1hgv2bmbaskx77v8glh7waxws973jn4ah35zysnkxmf0196sfxg6";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Net.Security";
+    version = "4.3.0";
+    sha256 = "0dnqjhw445ay3chpia9p6vy4w2j6s9vy3hxszqvdanpvvyaxijr3";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "18pzfdlwsg2nb1jjjjzyb5qlgy6xjxzmhnfaijq5s2jw3cm3ab97";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System.Security.Cryptography";
+    version = "4.0.0";
+    sha256 = "0k57aa2c3b10wl3hfqbgrl7xq7g8hh3a3ir44b31dn5p61iiw3z9";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.0.0";
+    sha256 = "1ppk69xk59ggacj9n7g6fyxvzmk1g5p4fkijm0d7xqfkig98qrkf";
+  })
+  (fetchNuGet {
+    name = "runtime.native.System";
+    version = "4.3.0";
+    sha256 = "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0qyynf9nz5i7pc26cwhgi8j62ps27sqmf78ijcfgzab50z9g8ay3";
+  })
+  (fetchNuGet {
+    name = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1klrs545awhayryma6l7g2pvnp9xy4z0r1i40r80zb45q3i9nbyf";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    sha256 = "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi";
+  })
+  (fetchNuGet {
+    name = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0zcxjv5pckplvkg0r6mw3asggm7aqzbdjimhvsasb0cgm59x09l3";
+  })
+  (fetchNuGet {
+    name = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0vhynn79ih7hw7cwjazn87rm9z9fj0rvxgzlab36jybgcpcgphsn";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "160p68l2c7cqmyqjwxydcvgw7lvl1cr0znkw8fp24d1by9mqc8p3";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "15zrc8fgd8zx28hdghcj5f5i34wf3l6bq5177075m2bc2j34jrqy";
+  })
+  (fetchNuGet {
+    name = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "1p4dgxax6p7rlgj4q73k73rslcnz4wdcv8q2flg1s8ygwcm58ld5";
+  })
+  (fetchNuGet {
+    name = "System.AppContext";
+    version = "4.3.0";
+    sha256 = "1649qvy3dar900z3g817h17nl8jp4ka5vcfmsr05kh0fshn7j3ya";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.3.0";
+    sha256 = "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.4.0";
+    sha256 = "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19";
+  })
+  (fetchNuGet {
+    name = "System.Buffers";
+    version = "4.5.0";
+    sha256 = "1ywfqn4md6g3iilpxjn5dsr0f5lx6z0yvhqp4pgjcamygg73cz2c";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.0.12";
+    sha256 = "07y08kvrzpak873pmyxs129g1ch8l27zmg51pcyj2jvq03n0r0fc";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Concurrent";
+    version = "4.3.0";
+    sha256 = "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8";
+  })
+  (fetchNuGet {
+    name = "System.Collections.NonGeneric";
+    version = "4.3.0";
+    sha256 = "07q3k0hf3mrcjzwj8fwk6gv3n51cb513w4mgkfxzm3i37sc9kz7k";
+  })
+  (fetchNuGet {
+    name = "System.Collections.Specialized";
+    version = "4.3.0";
+    sha256 = "1sdwkma4f6j85m3dpb53v9vcgd0zyc9jb33f8g63byvijcj39n20";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.0.11";
+    sha256 = "1ga40f5lrwldiyw6vy67d0sg7jd7ww6kgwbksm19wrvq9hr0bsm6";
+  })
+  (fetchNuGet {
+    name = "System.Collections";
+    version = "4.3.0";
+    sha256 = "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.Primitives";
+    version = "4.3.0";
+    sha256 = "1svfmcmgs0w0z9xdw2f2ps05rdxmkxxhf0l17xk9l1l8xfahkqr0";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel.TypeConverter";
+    version = "4.3.0";
+    sha256 = "17ng0p7v3nbrg3kycz10aqrrlw4lz9hzhws09pfh8gkwicyy481x";
+  })
+  (fetchNuGet {
+    name = "System.ComponentModel";
+    version = "4.3.0";
+    sha256 = "0986b10ww3nshy30x9sjyzm0jx339dkjxjj3401r3q0f6fx2wkcb";
+  })
+  (fetchNuGet {
+    name = "System.Console";
+    version = "4.3.0";
+    sha256 = "1flr7a9x920mr5cjsqmsy9wgnv3lvd0h1g521pdr1lkb2qycy7ay";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.0.11";
+    sha256 = "0gmjghrqmlgzxivd2xl50ncbglb7ljzb66rlx8ws6dv8jm0d5siz";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    sha256 = "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.3.0";
+    sha256 = "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.DiagnosticSource";
+    version = "4.5.1";
+    sha256 = "1j8dgilsgd0n7y87wq1cdlnwck96wijhbyhdp4d01l1gzm3074c1";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Process";
+    version = "4.3.0";
+    sha256 = "0g4prsbkygq8m21naqmcp70f24a1ksyix3dihb1r1f71lpi3cfj7";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.0.1";
+    sha256 = "19cknvg07yhakcvpxg3cxa0bwadplin6kyxd8mpjjpwnp56nl85x";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tools";
+    version = "4.3.0";
+    sha256 = "0in3pic3s2ddyibi8cvgl102zmvp9r9mchh82ns9f0ms4basylw1";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.1.0";
+    sha256 = "1d2r76v1x610x61ahfpigda89gd13qydz6vbwzhpqlyvq8jj6394";
+  })
+  (fetchNuGet {
+    name = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    sha256 = "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.0.11";
+    sha256 = "1pla2dx8gkidf7xkciig6nifdsb494axjvzvann8g2lp3dbqasm9";
+  })
+  (fetchNuGet {
+    name = "System.Dynamic.Runtime";
+    version = "4.3.0";
+    sha256 = "1d951hrvrpndk7insiag80qxjbf2y0y39y8h5hnq9612ws661glk";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.0.1";
+    sha256 = "0bv0alrm2ck2zk3rz25lfyk9h42f3ywq77mx1syl6vvyncnpg4qh";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Calendars";
+    version = "4.3.0";
+    sha256 = "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq";
+  })
+  (fetchNuGet {
+    name = "System.Globalization.Extensions";
+    version = "4.3.0";
+    sha256 = "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.0.11";
+    sha256 = "070c5jbas2v7smm660zaf1gh0489xanjqymkvafcs4f8cdrs1d5d";
+  })
+  (fetchNuGet {
+    name = "System.Globalization";
+    version = "4.3.0";
+    sha256 = "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki";
+  })
+  (fetchNuGet {
+    name = "System.IdentityModel.Tokens.Jwt";
+    version = "5.4.0";
+    sha256 = "05f91fjn054bwphmbbg7c38ipl4i81v73j232jgcq6y16dx6ifyc";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression.ZipFile";
+    version = "4.3.0";
+    sha256 = "1yxy5pq4dnsm9hlkg9ysh5f6bf3fahqqb6p8668ndy5c0lk7w2ar";
+  })
+  (fetchNuGet {
+    name = "System.IO.Compression";
+    version = "4.3.0";
+    sha256 = "084zc82yi6yllgda0zkgl2ys48sypiswbiwrv7irb3r0ai1fp4vz";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.0.1";
+    sha256 = "1s0mniajj3lvbyf7vfb5shp4ink5yibsx945k6lvxa96r8la1612";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    sha256 = "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.0.1";
+    sha256 = "0kgfpw6w4djqra3w5crrg8xivbanh1w9dh3qapb28q060wb9flp1";
+  })
+  (fetchNuGet {
+    name = "System.IO.FileSystem";
+    version = "4.3.0";
+    sha256 = "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.1.0";
+    sha256 = "1g0yb8p11vfd0kbkyzlfsbsp5z44lwsvyc0h3dpw6vqnbi035ajp";
+  })
+  (fetchNuGet {
+    name = "System.IO";
+    version = "4.3.0";
+    sha256 = "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.1.0";
+    sha256 = "1gpdxl6ip06cnab7n3zlcg6mqp7kknf73s8wjinzi4p0apw82fpg";
+  })
+  (fetchNuGet {
+    name = "System.Linq.Expressions";
+    version = "4.3.0";
+    sha256 = "0ky2nrcvh70rqq88m9a5yqabsl4fyd17bpr63iy2mbivjs2nyypv";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.1.0";
+    sha256 = "1ppg83svb39hj4hpp5k7kcryzrf3sfnm08vxd5sm2drrijsla2k5";
+  })
+  (fetchNuGet {
+    name = "System.Linq";
+    version = "4.3.0";
+    sha256 = "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7";
+  })
+  (fetchNuGet {
+    name = "System.Memory";
+    version = "4.5.0";
+    sha256 = "1layqpcx1q4l805fdnj2dfqp6ncx2z42ca06rgsr6ikq4jjgbv30";
+  })
+  (fetchNuGet {
+    name = "System.Net.Http";
+    version = "4.3.0";
+    sha256 = "1i4gc757xqrzflbk7kc5ksn20kwwfjhw9w7pgdkn19y3cgnl302j";
+  })
+  (fetchNuGet {
+    name = "System.Net.NameResolution";
+    version = "4.3.0";
+    sha256 = "15r75pwc0rm3vvwsn8rvm2krf929mjfwliv0mpicjnii24470rkq";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.0.11";
+    sha256 = "10xzzaynkzkakp7jai1ik3r805zrqjxiz7vcagchyxs2v26a516r";
+  })
+  (fetchNuGet {
+    name = "System.Net.Primitives";
+    version = "4.3.0";
+    sha256 = "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii";
+  })
+  (fetchNuGet {
+    name = "System.Net.Security";
+    version = "4.3.0";
+    sha256 = "1aa5igz31ivk6kpgsrwck3jccab7wd88wr52lddmgypmbh9mmf87";
+  })
+  (fetchNuGet {
+    name = "System.Net.Sockets";
+    version = "4.3.0";
+    sha256 = "1ssa65k6chcgi6mfmzrznvqaxk8jp0gvl77xhf1hbzakjnpxspla";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebHeaderCollection";
+    version = "4.0.1";
+    sha256 = "10bxpxj80c4z00z3ksrfswspq9qqsw8jwxcbzvymzycb97m9b55q";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebHeaderCollection";
+    version = "4.3.0";
+    sha256 = "0ms3ddjv1wn8sqa5qchm245f3vzzif6l6fx5k92klqpn7zf4z562";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets.Client";
+    version = "4.0.2";
+    sha256 = "0p8m9h94h9za8281hngpi6awka6v26s1gkk0npmxzqq4ilas6b4s";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets.Client";
+    version = "4.3.2";
+    sha256 = "103y8lfsfa5xd1sqmq9sml4qyp4rij2i3fnnw119h119hb04l0rk";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets";
+    version = "4.0.0";
+    sha256 = "04jdhq9dp43x1m6hddn06sq74skc50i1yk6hip0224pj6fwxa4k2";
+  })
+  (fetchNuGet {
+    name = "System.Net.WebSockets";
+    version = "4.3.0";
+    sha256 = "1gfj800078kggcgl0xyl00a6y5k4wwh2k2qm69rjy22wbmq7fy4p";
+  })
+  (fetchNuGet {
+    name = "System.Numerics.Vectors";
+    version = "4.4.0";
+    sha256 = "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.0.12";
+    sha256 = "1sybkfi60a4588xn34nd9a58png36i0xr4y4v4kqpg8wlvy5krrj";
+  })
+  (fetchNuGet {
+    name = "System.ObjectModel";
+    version = "4.3.0";
+    sha256 = "191p63zy5rpqx7dnrb3h7prvgixmk168fhvvkkvhlazncf8r3nc2";
+  })
+  (fetchNuGet {
+    name = "System.Private.DataContractSerialization";
+    version = "4.1.1";
+    sha256 = "1xk9wvgzipssp1393nsg4n16zbr5481k03nkdlj954hzq5jkx89r";
+  })
+  (fetchNuGet {
+    name = "System.Private.DataContractSerialization";
+    version = "4.3.0";
+    sha256 = "06fjipqvjp559rrm825x6pll8gimdj9x1n3larigh5hsm584gndw";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.0.1";
+    sha256 = "1pcd2ig6bg144y10w7yxgc9d22r7c7ww7qn1frdfwgxr24j9wvv0";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.ILGeneration";
+    version = "4.3.0";
+    sha256 = "0w1n67glpv8241vnpz1kl14sy7zlnw414aqwj4hcx5nd86f6994q";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.0.1";
+    sha256 = "1s4b043zdbx9k39lfhvsk68msv1nxbidhkq6nbm27q7sf8xcsnxr";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit.Lightweight";
+    version = "4.3.0";
+    sha256 = "0ql7lcakycrvzgi9kxz1b3lljd990az1x6c4jsiwcacrvimpib5c";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.0.1";
+    sha256 = "0ydqcsvh6smi41gyaakglnv252625hf29f7kywy2c70nhii2ylqp";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Emit";
+    version = "4.3.0";
+    sha256 = "11f8y3qfysfcrscjpjym9msk7lsfxkk4fmz9qq95kn3jd0769f74";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.0.1";
+    sha256 = "0m7wqwq0zqq9gbpiqvgk3sr92cbrw7cp3xn53xvw7zj6rz6fdirn";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Extensions";
+    version = "4.3.0";
+    sha256 = "02bly8bdc98gs22lqsfx9xicblszr2yan7v2mmw3g7hy6miq5hwq";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.0.1";
+    sha256 = "1bangaabhsl4k9fg8khn83wm6yial8ik1sza7401621jc6jrym28";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.Primitives";
+    version = "4.3.0";
+    sha256 = "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.1.0";
+    sha256 = "1bjli8a7sc7jlxqgcagl9nh8axzfl11f4ld3rjqsyxc516iijij7";
+  })
+  (fetchNuGet {
+    name = "System.Reflection.TypeExtensions";
+    version = "4.3.0";
+    sha256 = "0y2ssg08d817p0vdag98vn238gyrrynjdj4181hdg780sif3ykp1";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.1.0";
+    sha256 = "1js89429pfw79mxvbzp8p3q93il6rdff332hddhzi5wqglc4gml9";
+  })
+  (fetchNuGet {
+    name = "System.Reflection";
+    version = "4.3.0";
+    sha256 = "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.0.1";
+    sha256 = "0b4i7mncaf8cnai85jv3wnw6hps140cxz8vylv2bik6wyzgvz7bi";
+  })
+  (fetchNuGet {
+    name = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    sha256 = "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.0";
+    sha256 = "17labczwqk3jng3kkky73m0jhi8wc21vbl7cz5c0hj2p1dswin43";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.1.0";
+    sha256 = "0rw4rm4vsm3h3szxp9iijc3ksyviwsv6f63dng3vhqyg4vjdkc2z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Extensions";
+    version = "4.3.0";
+    sha256 = "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.0.1";
+    sha256 = "1g0zrdi5508v49pfm3iii2hn6nm00bgvfpjq1zxknfjrxxa20r4g";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Handles";
+    version = "4.3.0";
+    sha256 = "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    sha256 = "0q18r1sh4vn7bvqgd6dmqlw5v28flbpj349mkdish2vjyvmnb2ii";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    sha256 = "01kxqppx3dr3b6b286xafqilv4s2n0gqvfgzfd4z943ga9i81is1";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    sha256 = "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.0.1";
+    sha256 = "1y308zfvy0l5nrn46mqqr4wb4z1xk758pkk8svbz8b5ij7jnv4nn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Numerics";
+    version = "4.3.0";
+    sha256 = "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Formatters";
+    version = "4.3.0";
+    sha256 = "114j35n8gcvn3sqv9ar36r1jjq0y1yws9r0yk8i6wm4aq7n9rs0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Json";
+    version = "4.0.2";
+    sha256 = "08ypbzs0sb302ga04ds5b2wxa2gg0q50zpa0nvc87ipjhs0v66dn";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.1.1";
+    sha256 = "042rfjixknlr6r10vx2pgf56yming8lkjikamg3g4v29ikk78h7k";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Primitives";
+    version = "4.3.0";
+    sha256 = "01vv2p8h4hsz217xxs0rixvb7f2xzbh6wv1gzbfykcbfrza6dvnf";
+  })
+  (fetchNuGet {
+    name = "System.Runtime.Serialization.Xml";
+    version = "4.3.0";
+    sha256 = "1b2cxl2h7s8cydbhbmxhvvq071n9ck61g08npg4gyw7nvg37rfni";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.1.0";
+    sha256 = "02hdkgk13rvsd6r9yafbwzss8kr55wnj8d5c7xjnp8gqrwc8sn0m";
+  })
+  (fetchNuGet {
+    name = "System.Runtime";
+    version = "4.3.0";
+    sha256 = "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7";
+  })
+  (fetchNuGet {
+    name = "System.Security.Claims";
+    version = "4.3.0";
+    sha256 = "0jvfn7j22l3mm28qjy3rcw287y9h65ha4m940waaxah07jnbzrhn";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.2.0";
+    sha256 = "148s9g5dgm33ri7dnh19s4lgnlxbpwvrw2jnzllq2kijj4i4vs85";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Algorithms";
+    version = "4.3.0";
+    sha256 = "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.2.0";
+    sha256 = "118jijz446kix20blxip0f0q8mhsh9bz118mwc2ch1p6g7facpzc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Cng";
+    version = "4.3.0";
+    sha256 = "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.0.0";
+    sha256 = "1cwv8lqj8r15q81d2pz2jwzzbaji0l28xfrpw29kdpsaypm92z2q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Csp";
+    version = "4.3.0";
+    sha256 = "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.0.0";
+    sha256 = "0a8y1a5wkmpawc787gfmnrnbzdgxmx1a14ax43jf3rj9gxmy3vk4";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Encoding";
+    version = "4.3.0";
+    sha256 = "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.0.0";
+    sha256 = "16sx3cig3d0ilvzl8xxgffmxbiqx87zdi8fc73i3i7zjih1a7f4q";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    sha256 = "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.0.0";
+    sha256 = "0i7cfnwph9a10bm26m538h5xcr8b36jscp9sy1zhgifksxz4yixh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.Primitives";
+    version = "4.3.0";
+    sha256 = "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.1.0";
+    sha256 = "0clg1bv55mfv5dq00m19cp634zx6inm31kf8ppbq1jgyjf2185dh";
+  })
+  (fetchNuGet {
+    name = "System.Security.Cryptography.X509Certificates";
+    version = "4.3.0";
+    sha256 = "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal.Windows";
+    version = "4.3.0";
+    sha256 = "00a0a7c40i3v4cb20s2cmh9csb5jv2l0frvnlzyfxh848xalpdwr";
+  })
+  (fetchNuGet {
+    name = "System.Security.Principal";
+    version = "4.3.0";
+    sha256 = "12cm2zws06z4lfc4dn31iqv7072zyi4m910d4r6wm8yx85arsfxf";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    sha256 = "08nsfrpiwsg9x5ml4xyl3zyvjfdi4mvbqf93kjdh11j4fwkznizs";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    sha256 = "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.0.11";
+    sha256 = "1dyqv0hijg265dwxg6l7aiv74102d6xjiwplh2ar1ly6xfaa4iiw";
+  })
+  (fetchNuGet {
+    name = "System.Text.Encoding";
+    version = "4.3.0";
+    sha256 = "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.1.0";
+    sha256 = "1mw7vfkkyd04yn2fbhm38msk7dz2xwvib14ygjsb8dq2lcvr18y7";
+  })
+  (fetchNuGet {
+    name = "System.Text.RegularExpressions";
+    version = "4.3.0";
+    sha256 = "1bgq51k7fwld0njylfn7qc5fmwrk2137gdq7djqdsw347paa9c2l";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Channels";
+    version = "4.7.1";
+    sha256 = "038fyrriypwzsj5fwgnkw79hm5ya0x63r724yizgahbxf512chr2";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.0.0";
+    sha256 = "1cb51z062mvc2i8blpzmpn9d9mm4y307xrwi65di8ri18cz5r1zr";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks.Extensions";
+    version = "4.3.0";
+    sha256 = "1xxcx2xh8jin360yjwm4x4cf5y3a2bwpn2ygkfkwkicz7zk50s2z";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.0.11";
+    sha256 = "0nr1r41rak82qfa5m0lhk9mp0k93bvfd7bbd9sdzwx9mb36g28p5";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Tasks";
+    version = "4.3.0";
+    sha256 = "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Thread";
+    version = "4.3.0";
+    sha256 = "0y2xiwdfcph7znm2ysxanrhbqqss6a3shi1z3c779pj2s523mjx4";
+  })
+  (fetchNuGet {
+    name = "System.Threading.ThreadPool";
+    version = "4.3.0";
+    sha256 = "027s1f4sbx0y1xqw2irqn6x161lzj8qwvnh2gn78ciiczdv10vf1";
+  })
+  (fetchNuGet {
+    name = "System.Threading.Timer";
+    version = "4.3.0";
+    sha256 = "1nx773nsx6z5whv8kaa1wjh037id2f1cxhb69pvgv12hd2b6qs56";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.0.11";
+    sha256 = "19x946h926bzvbsgj28csn46gak2crv2skpwsx80hbgazmkgb1ls";
+  })
+  (fetchNuGet {
+    name = "System.Threading";
+    version = "4.3.0";
+    sha256 = "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.0.11";
+    sha256 = "0c6ky1jk5ada9m94wcadih98l6k1fvf6vi7vhn1msjixaha419l5";
+  })
+  (fetchNuGet {
+    name = "System.Xml.ReaderWriter";
+    version = "4.3.0";
+    sha256 = "0c47yllxifzmh8gq6rq6l36zzvw4kjvlszkqa9wq3fr59n0hl3s1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.0.11";
+    sha256 = "0n4lvpqzy9kc7qy1a4acwwd7b7pnvygv895az5640idl2y9zbz18";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XDocument";
+    version = "4.3.0";
+    sha256 = "08h8fm4l77n0nd4i4fk2386y809bfbwqb7ih9d7564ifcxr5ssxd";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.0.1";
+    sha256 = "0ihsnkvyc76r4dcky7v3ansnbyqjzkbyyia0ir5zvqirzan0bnl1";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlDocument";
+    version = "4.3.0";
+    sha256 = "0bmz1l06dihx52jxjr22dyv5mxv6pj4852lx68grjm7bivhrbfwi";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlSerializer";
+    version = "4.0.11";
+    sha256 = "01nzc3gdslw90qfykq4qzr2mdnqxjl4sj0wp3fixiwdmlmvpib5z";
+  })
+  (fetchNuGet {
+    name = "System.Xml.XmlSerializer";
+    version = "4.3.0";
+    sha256 = "07pa4sx196vxkgl3csvdmw94nydlsm9ir38xxcs84qjn8cycd912";
+  })
+  (fetchNuGet {
+    name = "xunit.abstractions";
+    version = "2.0.3";
+    sha256 = "00wl8qksgkxld76fgir3ycc5rjqv1sqds6x8yx40927q5py74gfh";
+  })
+  (fetchNuGet {
+    name = "xunit.analyzers";
+    version = "0.10.0";
+    sha256 = "15n02q3akyqbvkp8nq75a8rd66d4ax0rx8fhdcn8j78pi235jm7j";
+  })
+  (fetchNuGet {
+    name = "xunit.assert";
+    version = "2.4.1";
+    sha256 = "1imynzh80wxq2rp9sc4gxs4x1nriil88f72ilhj5q0m44qqmqpc6";
+  })
+  (fetchNuGet {
+    name = "xunit.core";
+    version = "2.4.1";
+    sha256 = "1nnb3j4kzmycaw1g76ii4rfqkvg6l8gqh18falwp8g28h802019a";
+  })
+  (fetchNuGet {
+    name = "xunit.extensibility.core";
+    version = "2.4.1";
+    sha256 = "103qsijmnip2pnbhciqyk2jyhdm6snindg5z2s57kqf5pcx9a050";
+  })
+  (fetchNuGet {
+    name = "xunit.extensibility.execution";
+    version = "2.4.1";
+    sha256 = "1pbilxh1gp2ywm5idfl0klhl4gb16j86ib4x83p8raql1dv88qia";
+  })
+  (fetchNuGet {
+    name = "xunit.runner.visualstudio";
+    version = "2.4.2";
+    sha256 = "0fi85h43nyrhfc5jzg07znh01r7cpb7bpjdc6mzb9z1pm14ppfm6";
+  })
+  (fetchNuGet {
+    name = "xunit";
+    version = "2.4.1";
+    sha256 = "0xf3kaywpg15flqaqfgywqyychzk15kz0kz34j21rcv78q9ywq20";
+  })
+]

--- a/pkgs/nbxplorer/update.sh
+++ b/pkgs/nbxplorer/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+
+getVersionFromTags=1 "$scriptDir"/util/update-common.sh nbxplorer "$scriptDir"/deps.nix

--- a/pkgs/nbxplorer/util/create-deps.sh
+++ b/pkgs/nbxplorer/util/create-deps.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p dotnet-sdk_3
+set -euo pipefail
+
+# Writes deps for dotnet package in $pkgSrc to $depsFile.
+# Expects $pkgSrc to contain a single .sln file.
+
+pkgSrc=$1
+depsFile=$2
+
+sln=$(cd "$pkgSrc"; find * -maxdepth 0 -name '*.sln' | head -1)
+[[ $sln ]] || { echo "No .sln file in $pkgSrc" ; exit 1; }
+
+tmpdir=$(mktemp -d /tmp/$pkgName-src.XXX)
+trap "rm -rf $tmpdir" EXIT
+echo "Using tmp dir: $tmpdir"
+cp -rT "$pkgSrc" "$tmpdir"
+chmod -R +w "$tmpdir"
+
+pushd "$tmpdir" > /dev/null
+mkdir home
+echo "Running dotnet restore for $sln"
+HOME=home DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+  dotnet restore -v normal --no-cache "$sln" > restore_log
+
+echo "{ fetchNuGet }: [" > "$depsFile"
+while read pkgSpec; do
+  { read name; read version; } < <(
+    # Ignore build version part: 1.0.0-beta2+77df2220 -> 1.0.0-beta2
+    sed -nE 's/.*<id>([^<]*).*/\1/p; s/.*<version>([^<+]*).*/\1/p' "$pkgSpec"
+  )
+  sha256=$(nix-hash --type sha256 --flat --base32 "$(dirname "$pkgSpec")"/*.nupkg)
+  cat >> "$depsFile" <<EOF
+  (fetchNuGet {
+    name = "$name";
+    version = "$version";
+    sha256 = "$sha256";
+  })
+EOF
+done < <(find home/.nuget/packages -name '*.nuspec' | LC_ALL=C sort)
+echo "]" >> "$depsFile"
+
+echo "Created $depsFile"
+
+popd > /dev/null

--- a/pkgs/nbxplorer/util/update-common.sh
+++ b/pkgs/nbxplorer/util/update-common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl jq common-updater-scripts dotnet-sdk_3
+set -euo pipefail
+
+# This script uses the following env vars:
+# getVersionFromTags
+# onlyCreateDeps
+
+pkgName=$1
+depsFile=$2
+
+: ${getVersionFromTags:=}
+: ${onlyCreateDeps:=}
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nbPkgs=$(realpath "$scriptDir"/../..)
+
+evalNbPkgs() {
+  nix eval --raw "(with import \"$nbPkgs\" {}; $1)"
+}
+
+getRepo() {
+  url=$(evalNbPkgs $pkgName.src.meta.homepage)
+  echo $(basename $(dirname $url))/$(basename $url)
+}
+
+getLatestVersionTag() {
+  unstable=$(nix eval --raw "(import \"$nbPkgs/nixpkgs-pinned.nix\").nixpkgs-unstable")
+  $unstable/pkgs/common-updater/scripts/list-git-tags https://github.com/$(getRepo) 2>/dev/null \
+    | sort -V | tail -1 | sed 's|^v||'
+}
+
+if [[ ! $onlyCreateDeps ]]; then
+  oldVersion=$(evalNbPkgs "$pkgName.version")
+  if [[ $getVersionFromTags ]]; then
+    newVersion=$(getLatestVersionTag)
+  else
+    newVersion=$(curl -s "https://api.github.com/repos/$(getRepo)/releases" | jq -r '.[0].name')
+  fi
+
+  if [[ $newVersion == $oldVersion ]]; then
+    echo "$pkgName is up to date: $newVersion"
+  else
+    echo "Please manually update $pkgName: $oldVersion -> $newVersion"
+  fi
+fi
+
+echo "Creating deps.nix"
+storeSrc="$(nix-build "$nbPkgs" -A $pkgName.src --no-out-link)"
+. "$scriptDir"/create-deps.sh "$storeSrc" "$depsFile"

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -17,4 +17,5 @@ in
 
   stable = nixBitcoinPkgsStable;
   unstable = nixBitcoinPkgsUnstable;
+  inherit nixpkgsUnstable;
 }

--- a/test/base.py
+++ b/test/base.py
@@ -84,6 +84,13 @@ def run_tests(extra_tests):
         )
     )
 
+    assert_running("nbxplorer")
+    machine.wait_until_succeeds(log_has_string("nbxplorer", "BTC: RPC connection successful"))
+    extra_tests.pop("nbxplorer")()
+    assert_running("btcpayserver")
+    machine.wait_until_succeeds(log_has_string("btcpayserver", "Listening on"))
+    extra_tests.pop("btcpayserver")()
+
     assert_running("spark-wallet")
     extra_tests.pop("spark-wallet")()
 

--- a/test/scenarios/default.py
+++ b/test/scenarios/default.py
@@ -2,6 +2,19 @@ def electrs():
     machine.wait_for_open_port(4224)  # prometeus metrics provider
 
 
+def nbxplorer():
+    machine.wait_for_open_port(24444)
+
+
+def btcpayserver():
+    machine.wait_for_open_port(23000)
+    # test lnd custom macaroon
+    assert_matches(
+        'sudo -u btcpayserver curl -s --cacert /secrets/lnd-cert --header "Grpc-Metadata-macaroon: $(xxd -ps -u -c 1000 /run/lnd/btcpayserver.macaroon)" -X GET https://127.0.0.1:8080/v1/getinfo | jq',
+        '"version"',
+    )
+
+
 def spark_wallet():
     machine.wait_for_open_port(9737)
     spark_auth = re.search("login=(.*)", succeed("cat /secrets/spark-wallet-login"))[1]
@@ -31,6 +44,8 @@ def prestop():
 
 extra_tests = {
     "electrs": electrs,
+    "nbxplorer": nbxplorer,
+    "btcpayserver": btcpayserver,
     "spark-wallet": spark_wallet,
     "lightning-charge": lightning_charge,
     "nanopos": nanopos,

--- a/test/test.nix
+++ b/test/test.nix
@@ -52,6 +52,11 @@ import ./make-test.nix rec {
 
     services.backups.enable = true;
 
+    services.btcpayserver.enable = true;
+    services.btcpayserver.lightningBackend = "lnd";
+    # needed to test macaroon creation
+    environment.systemPackages = with pkgs; [ openssl xxd ];
+
     # to test that unused secrets are made inaccessible by 'setup-secrets'
     systemd.services.generate-secrets.postStart = ''
       install -o nobody -g nogroup -m777 <(:) /secrets/dummy


### PR DESCRIPTION
Builds on https://github.com/fort-nix/nix-bitcoin/pull/220

Notes
* enforceTor is currently disabled for `systemd.services.btcpayserver` because BTCPayServer needs to fetch price rates from outside and doing this over Tor isn't supported yet. Maybe we need to implement a Tor transparent proxy and custom routing rules.
* I'm generating a custom macaroon with limited permissions à la https://github.com/Kixunil/cryptoanarchy-deb-repo-builder/blob/216a581f3296bfe37438f13def88a160a2f83509/lnd/gen_macaroons.sh#L34 and placing it inside `/var/lib/lnd/invoice+readonly.macaroon` because `/var/lib/lnd/chain/bitcoin/mainnet` is user-readable-only and I don't want to start changing folder permissions. Maybe there is a better place?
* I added a drive-by fix to `netns-isolation.nix` allowing return traffic to outgoing connections initiated by the service itself in the iptables rules. I think this is harmless.
* I'm using BTCPayServer's internal webserver over a Tor v3 HS. I think we should use a custom nginx with tls when https://github.com/fort-nix/nix-bitcoin/issues/193 is implemented.