### PR TITLE
loop: v0.8.1 -> v0.9.0

### DIFF
--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -34,3 +34,10 @@ if [[ ! -e lnd-key || ! -e lnd-cert ]]; then
     openssl req -config $opensslConf -x509 -sha256 -days 1825 -key lnd-key -in lnd.csr -out lnd-cert
     rm lnd.csr
 fi
+
+if [[ ! -e loop-key || ! -e loop-cert ]]; then
+    openssl ecparam -genkey -name prime256v1 -out loop-key
+    openssl req -config $opensslConf -new -sha256 -key loop-key -out loop.csr -subj '/CN=localhost/O=loopd'
+    openssl req -config $opensslConf -x509 -sha256 -days 1825 -key loop-key -in loop.csr -out loop-cert
+    rm loop.csr
+fi

--- a/pkgs/generate-secrets/openssl.cnf
+++ b/pkgs/generate-secrets/openssl.cnf
@@ -32,3 +32,5 @@ IP.1 = 127.0.0.1
 DNS.1 = localhost
 # TODO: Remove hardcoded lnd IP
 IP.2 = 169.254.1.14
+# TODO: Remove hardcoded loopd IP
+IP.3 = 169.254.1.22

--- a/pkgs/lightning-loop/default.nix
+++ b/pkgs/lightning-loop/default.nix
@@ -2,17 +2,17 @@
 
 buildGoModule rec {
   pname = "lightning-loop";
-  version = "0.8.1-beta";
+  version = "0.9.0-beta";
 
   src = fetchurl {
     url = "https://github.com/lightninglabs/loop/archive/v${version}.tar.gz";
     # Use ./get-sha256.sh to fetch latest (verified) sha256
-    sha256 = "36815049c7807b1f0b2b0694ae64b2ec23819240952cb327c9b9e0d530ac4696";
+    sha256 = "82f7c1c0c1d2ddec59c7c5e0780ae645f97ecdaca00b397cd533b27db7a6b7ca";
   };
 
   subPackages = [ "cmd/loop" "cmd/loopd" ];
 
-  vendorSha256 = "0y1j4ca4njx9fyyq3qv8hmcvs5ig6kyx6hhp1bdby7wgmlc0s5vp";
+  vendorSha256 = "1dmiiyp38biyrlmwxbrh3k8w7mxv0lsvf5qnzjrrxy6qbmglmk0l";
 
   meta = with lib; {
     description = " Lightning Loop: A Non-Custodial Off/On Chain Bridge";

--- a/test/base.py
+++ b/test/base.py
@@ -73,7 +73,7 @@ def run_tests(extra_tests):
     assert_matches("su operator -c 'lncli getinfo' | jq", '"version"')
     assert_no_failure("lnd")
 
-    succeed("systemctl start lightning-loop")
+    assert_running("lightning-loop")
     assert_matches("su operator -c 'loop --version'", "version")
     # Check that lightning-loop fails with the right error, making sure
     # lightning-loop can connect to lnd

--- a/test/test.nix
+++ b/test/test.nix
@@ -19,6 +19,9 @@ import ./make-test.nix rec {
       # hardened
     ];
 
+    # needed because duplicity requires 270 MB of free temp space, regardless of backup size.
+    virtualisation.diskSize = 1024;
+
     nix-bitcoin.netns-isolation.enable = (scenario == "withnetns");
 
     services.bitcoind.extraConfig = mkForce "connect=0";

--- a/test/test.nix
+++ b/test/test.nix
@@ -31,9 +31,6 @@ import ./make-test.nix rec {
     services.lnd.enable = true;
     services.lnd.listenPort = 9736;
     services.lightning-loop.enable = true;
-    # needed because we must control when lightning-loop starts so it doesn't
-    # fail before we run commands in the nb-lightning-loop netns
-    systemd.services.lightning-loop.wantedBy = mkForce [];
 
     services.electrs.enable = true;
 


### PR DESCRIPTION
This PR updates the loop pkg. It also updates the module package to fully utilize the changes introduced in v0.9.0.

When we release this we need to include instructions, ideally a one-line command, to migrate existing loop directories from `/var/lib/lnd/.loop/ to `/var/lib/lightning-loop`.