### PR TITLE
Deprecate lightning-charge and nanopos

### DIFF
--- a/modules/lightning-charge.nix
+++ b/modules/lightning-charge.nix
@@ -35,6 +35,9 @@ in {
   };
 
   config = mkIf cfg.enable {
+    warnings = [''
+      The lightning-charge module is deprecated and will be removed soon.
+    ''];
     assertions = [
       { assertion = config.services.clightning.enable;
         message = "lightning-charge requires clightning.";

--- a/modules/nanopos.nix
+++ b/modules/nanopos.nix
@@ -72,6 +72,10 @@ in {
   };
 
   config = mkIf cfg.enable {
+    warnings = [''
+      The nanopos module is deprecated and will be removed soon. You can use the
+      btcpayserver module instead.
+    ''];
     assertions = [
       { assertion = config.services.lightning-charge.enable;
         message = "nanopos requires lightning-charge.";


### PR DESCRIPTION
Fixes #233 

Because we have btcpayserver now, nanopos is not really needed any more. Nanopos
was meant to be just a PoC. Lightning charge can be removed because nanopos is
the only module that depends on it.