### PR TITLE
push-release: fix bug where assets are not pushed

### DIFF
--- a/helper/push-release.sh
+++ b/helper/push-release.sh
@@ -68,8 +68,8 @@ fi
 
 post_asset() {
     GH_ASSET="https://uploads.github.com/repos/$REPO/releases/$ID/assets?name="
-    curl -H "Authorization: token $OAUTH_TOKEN" --data-binary "@$TAG_NAME" -H "Content-Type: application/octet-stream" \
-         $GH_ASSET/$(basename $TAG_NAME) &> /dev/null
+    curl -H "Authorization: token $OAUTH_TOKEN" --data-binary "@$1" -H "Content-Type: application/octet-stream" \
+         $GH_ASSET/$(basename $1) &> /dev/null
 }
 post_asset $ARCHIVE
 post_asset $SHA256SUMS


### PR DESCRIPTION
In a previous commit we found and replaced $1 with $TAG_NAME, but that wasn't
correct for the post_asset() function.