### PR TITLE
generate-secrets: fix python version for rpcauth

### DIFF
--- a/pkgs/generate-secrets/default.nix
+++ b/pkgs/generate-secrets/default.nix
@@ -6,7 +6,7 @@ let
     sha256 = "189mpplam6yzizssrgiyv70c9899ggh8cac76j4n7v0xqzfip07n";
   };
   rpcauth = pkgs.writeScriptBin "rpcauth" ''
-    exec ${pkgs.python35}/bin/python ${rpcauthSrc} "$@"
+    exec ${pkgs.python3}/bin/python ${rpcauthSrc} "$@"
   '';
 in
 writeScript "generate-secrets" ''


### PR DESCRIPTION
I accidentally included the minor version number.
Version 3.5 has been removed from nixpkgs unstable.

This helps fixing #241.