### PR TITLE
Add module 'versioning'

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -209,4 +209,9 @@
   # servers. You should change this only after NixOS release notes say you
   # should.
   system.stateVersion = "18.09"; # Did you read the comment?
+
+  # The nix-bitcoin release version that your config is compatible with.
+  # When upgrading to a backwards-incompatible release, nix-bitcoin will display an
+  # an error and provide hints for migrating your config to the new release.
+  nix-bitcoin.configVersion = "0.0.18";
 }

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -22,6 +22,7 @@
     ./recurring-donations.nix
 
     # Support features
+    ./versioning.nix
     ./security.nix
     ./netns-isolation.nix
     ./backups.nix

--- a/modules/versioning.nix
+++ b/modules/versioning.nix
@@ -1,0 +1,59 @@
+{ config, pkgs, lib, ... }:
+
+with lib;
+let
+  version = config.nix-bitcoin.configVersion;
+
+  # Sorted by increasing version numbers
+  changes = [
+    # None yet
+    # {
+    #   version = "0.1";
+    #   condition = config.services.foo.enabled;
+    #   message = ''
+    #     demo message
+    #   '';
+    # }
+  ];
+
+  incompatibleChanges = optionals
+    (version != null && versionOlder lastChange)
+    (builtins.filter (change: versionOlder change && (change.condition or true)) changes);
+
+  errorMsg = ''
+
+    This version of nix-bitcoin contains the following changes
+    that are incompatible with your config (version ${version}):
+
+    ${concatMapStringsSep "\n" (change: ''
+      - ${change.message}(This change was introduced in version ${change.version})
+    '') incompatibleChanges}
+    After addressing the above changes, set nix-bitcoin.configVersion = "${lastChange.version}";
+    in your nix-bitcoin configuration.
+  '';
+
+  versionOlder = change: (builtins.compareVersions change.version version) > 0;
+  lastChange = builtins.elemAt changes (builtins.length changes - 1);
+in
+{
+  options = {
+    nix-bitcoin.configVersion = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Set this option to the nix-bitcoin release version that your config is
+        compatible with.
+
+        When upgrading to a backwards-incompatible release, nix-bitcoin will throw an
+        error during evaluation and provide hints for migrating your config to the
+        new release.
+      '';
+    };
+  };
+
+  ## No config because there are no backwards incompatible releases yet
+  # config = {
+  #   # Force evaluation. An actual option value is never assigned
+  #   system.extraDependencies = optional (builtins.length incompatibleChanges > 0) (builtins.throw errorMsg);
+  # };
+}


### PR DESCRIPTION
This PR adds option `nix-bitcoin.configVersion` to inform users about backwards-incompatible changes and to provide migration hints.

### Example
A notification about the recent lightning-loop update could have been implemented like this:
```nix
{
  version = "0.0.18";
  condition = config.services.lightning-loop.enable;
  message = ''
    The lightning-loop data dir location was changed.
    To move it to the new location, run the following shell command on your nix-bitcoin node:
    sudo mv ${config.services.lnd.dataDir}/.loop ${config.services.lightning-loop.dataDir}
  '';
}
```
To see it in action, checkout [this example branch](https://github.com/erikarvstedt/nix-bitcoin/commits/versioning-example) and run `test/run-tests.sh eval`

Example output:
```
This version of nix-bitcoin contains the following changes
that are incompatible with your config (version 0.0.17):

- The lightning-loop data dir location was changed.
To move it to the new location, run the following shell command on your nix-bitcoin node:
sudo mv /var/lib/lnd/.loop /var/lib/lightning-loop
(This change was introduced in version 0.0.18)

- dummy
(This change was introduced in version 0.1)

After addressing the above changes, set nix-bitcoin.configVersion = "0.1";
in your nix-bitcoin configuration.
```

### Details

Note that `nix-bitcoin.configVersion` in `examples/configuration.nix` only needs to
be updated after adding new breaking changes.