### PR TITLE
Services: Auto-enable dependencies

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -65,7 +65,7 @@
   ### SPARK WALLET
   # Enable this module to use spark-wallet, a minimalistic wallet GUI for
   # c-lightning, accessible over the web or through mobile and desktop apps.
-  # Only available if clightning is enabled.
+  # Automatically enables clightning.
   # services.spark-wallet.enable = true;
 
   ### ELECTRS
@@ -87,6 +87,7 @@
   # services.btcpayserver.lightningBackend = "clightning";
   # Enable this option to connect BTCPayServert to lnd.
   # services.btcpayserver.lightningBackend = "lnd";
+  # The lightning backend service automatically enabled.
   # Afterwards you need to go into Store > General Settings > Lightning Nodes
   # and click to use "the internal lightning node of this BTCPay Server".
 
@@ -99,13 +100,14 @@
 
   ### LIGHTNING CHARGE
   # Enable this module to use lightning-charge, a simple drop-in solution for
-  # accepting lightning payments. Only available if clightning is enabled.
+  # accepting lightning payments.
+  # Automatically enables clightning.
   # services.lightning-charge.enable = true;
 
   ### NANOPOS
   # Enable this module to use nanopos, a simple Lightning point-of-sale
-  # system, powered by Lightning Charge. Only available if clightning and
-  # lightning-charge are enabled.
+  # system, powered by Lightning Charge.
+  # Automatically enables lightning-charge.
   # services.nanopos.enable = true;
 
   ### WEBINDEX
@@ -117,7 +119,8 @@
   ### RECURRING-DONATIONS
   # Enable this module to send recurring donations. This is EXPERIMENTAL; it's
   # not guaranteed that payments are succeeding or that you will notice payment
-  # failure. Only available if clightning is enabled.
+  # failure.
+  # Automatically enables clightning.
   # services.recurring-donations.enable = true;
   # Specify the receivers of the donations. By default donations are every
   # Monday at a randomized time. Check `journalctl -eu recurring-donations` or
@@ -149,6 +152,7 @@
   # Enable this module to use lightninglab's non-custodial off/on chain bridge.
   # loopd (lightning-loop daemon) will be started automatically. Users can
   # interact with off/on chain bridge using `loop in` and `loop out`.
+  # Automatically enables lnd.
   # services.lightning-loop.enable = true;
 
   ### Backups

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -90,13 +90,9 @@ in {
   };
 
   config = mkIf cfg.btcpayserver.enable {
-    assertions = let
-      backend = cfg.btcpayserver.lightningBackend;
-    in [
-      { assertion = (backend != null) -> cfg.${backend}.enable;
-        message = "btcpayserver requires ${backend}.";
-      }
-    ];
+    services.bitcoind.enable = true;
+    services.clightning.enable = mkIf (cfg.btcpayserver.lightningBackend == "clightning") true;
+    services.lnd.enable = mkIf (cfg.btcpayserver.lightningBackend == "lnd") true;
 
     systemd.tmpfiles.rules = [
       "d '${cfg.nbxplorer.dataDir}' 0770 ${cfg.nbxplorer.user} ${cfg.nbxplorer.group} - -"

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -100,6 +100,8 @@ in {
   };
 
   config = mkIf cfg.enable {
+    services.bitcoind.enable = true;
+
     environment.systemPackages = [ pkgs.nix-bitcoin.clightning (hiPrio cfg.cli) ];
     users.users.${cfg.user} = {
         description = "clightning User";

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -61,6 +61,8 @@ in {
       }
     ];
 
+    services.bitcoind.enable = true;
+
     environment.systemPackages = [ pkgs.nix-bitcoin.electrs ];
 
     systemd.tmpfiles.rules = [

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -117,6 +117,8 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [{
+    services.bitcoind.enable = true;
+
     environment.systemPackages = [
       (hiPrio cfg.cli)
     ];

--- a/modules/lightning-charge.nix
+++ b/modules/lightning-charge.nix
@@ -38,11 +38,7 @@ in {
     warnings = [''
       The lightning-charge module is deprecated and will be removed soon.
     ''];
-    assertions = [
-      { assertion = config.services.clightning.enable;
-        message = "lightning-charge requires clightning.";
-      }
-    ];
+    services.clightning.enable = true;
 
     users.users.lightning-charge = {
       description = "lightning-charge User";

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -59,11 +59,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = config.services.lnd.enable;
-        message = "lightning-loop requires lnd.";
-      }
-    ];
+    services.lnd.enable = true;
 
     environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
 

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -221,6 +221,8 @@ in {
   };
 
   config = mkIf cfg.enable {
+    services.bitcoind.enable = true;
+
     environment.systemPackages = [
       pkgs.nix-bitcoin.elementsd
       (hiPrio cfg.cli)

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -154,6 +154,8 @@ in {
       }
     ];
 
+    services.bitcoind.enable = true;
+
     environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
 
     systemd.tmpfiles.rules = [

--- a/modules/nanopos.nix
+++ b/modules/nanopos.nix
@@ -76,11 +76,8 @@ in {
       The nanopos module is deprecated and will be removed soon. You can use the
       btcpayserver module instead.
     ''];
-    assertions = [
-      { assertion = config.services.lightning-charge.enable;
-        message = "nanopos requires lightning-charge.";
-      }
-    ];
+
+    services.lightning-charge.enable = true;
 
     environment.systemPackages = [ pkgs.nix-bitcoin.nanopos ];
 

--- a/modules/recurring-donations.nix
+++ b/modules/recurring-donations.nix
@@ -79,11 +79,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = config.services.clightning.enable;
-        message = "recurring-donations requires clightning.";
-      }
-    ];
+    services.clightning.enable = true;
 
     users.users.recurring-donations = {
         description = "recurring-donations User";

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -52,11 +52,7 @@ in {
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      { assertion = config.services.clightning.enable;
-        message = "spark-wallet requires clightning.";
-      }
-    ];
+    services.clightning.enable = true;
 
     environment.systemPackages = [ pkgs.nix-bitcoin.spark-wallet ];
     users.users.spark-wallet = {


### PR DESCRIPTION
Also, add missing dependencies to bitcoind, because `bitcoind.enable` is `false` outside of `secure-node.nix`.

### Comparison: auto-enable vs. using assertions
Pros:
- Less code
- Adheres to the NixOS philosophy that services should automatically enable their dependencies
- Works like [cryptoanarchy-deb-repo-builder](https://github.com/Kixunil/cryptoanarchy-deb-repo-builder), where, e.g., `sudo apt install btcpayserver` automatically installs all deps, including `lnd`.
- Enables auto-scenarios for all services, like `run-tests.sh -s btcpayserver` or `run-tests.sh -s spark-wallet`

Cons:
- The user might implicitly enable a lightning service and forget to back up its data. This is taken care of by the backup module.


### Details
Note that we can't use the following elegant definition in btcpayserver:
```
services.${cfg.btcpayserver.lightningBackend}.enable = true;
```
This leads to infinite recursion due to the intricacies of module evaluation.
Instead, we use
```
services.clightning.enable = mkIf (cfg.btcpayserver.lightningBackend == "clightning") true;
services.lnd.enable = mkIf (cfg.btcpayserver.lightningBackend == "lnd") true;
```