### PR TITLE
Improve netns-isolation and Tor config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
   jobs:
   - TestModules=1 STABLE=1 SCENARIO=default
   - TestModules=1 STABLE=1 SCENARIO=netns
-  - EvalModules=1 STABLE=1
+  - TestModules=1 STABLE=1 SCENARIO=netnsRegtest
   - PKG=hwi STABLE=1
   - PKG=hwi STABLE=0
   - PKG=lightning-charge STABLE=1
@@ -35,12 +35,6 @@ env:
   - PKG=joinmarket STABLE=0
 script:
   - printf '%s (%s)\n' "$NIX_PATH" "$VER"
-  #
-  - |
-    if [[ $EvalModules ]]; then
-      test/run-tests.sh --scenario full eval
-      travis_terminate 0
-    fi
   - |
     getBuildExpr() {
         if [[ $TestModules ]]; then

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -182,7 +182,7 @@ in {
       };
       proxy = mkOption {
         type = types.nullOr types.str;
-        default = null;
+        default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
         description = "Connect through SOCKS5 proxy";
       };
       listen = mkOption {

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -39,8 +39,8 @@ let
           "rpcwhitelist=${user.name}:${lib.strings.concatStringsSep "," user.rpcwhitelist}"}
       '') (builtins.attrValues cfg.rpc.users)
     }
-    ${lib.concatMapStrings (rpcbind: "rpcbind=${rpcbind}\n") cfg.rpcbind}
-    rpcconnect=${builtins.elemAt cfg.rpcbind 0}
+    rpcbind=${cfg.rpcbind}
+    rpcconnect=${cfg.rpcbind}
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
 
     # Wallet options
@@ -150,8 +150,8 @@ in {
         description = "Set the number of threads to service RPC calls";
       };
       rpcbind = mkOption {
-        type = types.listOf types.str;
-        default = [ "127.0.0.1" ];
+        type = types.str;
+        default = "127.0.0.1";
         description = ''
           Bind to given address to listen for JSON-RPC connections.
         '';

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -40,6 +40,7 @@ let
       '') (builtins.attrValues cfg.rpc.users)
     }
     ${lib.concatMapStrings (rpcbind: "rpcbind=${rpcbind}\n") cfg.rpcbind}
+    rpcconnect=${builtins.elemAt cfg.rpcbind 0}
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
 
     # Wallet options
@@ -275,17 +276,12 @@ in {
         description = "What type of addresses to use";
       };
       cli = mkOption {
-        type = types.package;
-        # Overriden on netns-isolation
-        default = cfg.cliBase;
-        description = "Binary to connect with the bitcoind instance.";
-      };
-      cliBase = mkOption {
         readOnly = true;
         type = types.package;
         default = pkgs.writeScriptBin "bitcoin-cli" ''
           exec ${cfg.package}/bin/bitcoin-cli -datadir='${cfg.dataDir}' "$@"
         '';
+        description = "Binary to connect with the bitcoind instance.";
       };
       enforceTor =  nix-bitcoin-services.enforceTor;
     };
@@ -341,9 +337,8 @@ in {
         fi
       '';
       postStart = ''
-        cd ${cfg.cliBase}/bin
         # Poll until bitcoind accepts commands. This can take a long time.
-        while ! ./bitcoin-cli getnetworkinfo &> /dev/null; do
+        while ! ${cfg.cli}/bin/bitcoin-cli getnetworkinfo &> /dev/null; do
           sleep 1
         done
       '';
@@ -368,7 +363,7 @@ in {
       bindsTo = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];
       script = ''
-        cd ${cfg.cliBase}/bin
+        cd ${cfg.cli}/bin
         echo "Importing node banlist..."
         cat ${./banlist.cli.txt} | while read line; do
             if ! err=$(eval "$line" 2>&1) && [[ $err != *already\ banned* ]]; then

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -112,7 +112,7 @@ in {
       configFile = builtins.toFile "config" ''
         network=${config.services.bitcoind.network}
         btcrpcuser=${cfg.bitcoind.rpc.users.btcpayserver.name}
-        btcrpcurl=http://${builtins.elemAt config.services.bitcoind.rpcbind 0}:${toString cfg.bitcoind.rpc.port}
+        btcrpcurl=http://${config.services.bitcoind.rpcbind}:${toString cfg.bitcoind.rpc.port}
         btcnodeendpoint=${config.services.bitcoind.bind}:8333
         bind=${cfg.nbxplorer.bind}
         port=${toString cfg.nbxplorer.port}

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -38,12 +38,12 @@ in {
     };
     proxy = mkOption {
       type = types.nullOr types.str;
-      default = null;
+      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
       description = "Set a socks proxy to use to connect to Tor nodes (or for all connections if *always-use-proxy* is set)";
     };
     always-use-proxy = mkOption {
       type = types.bool;
-      default = false;
+      default = cfg.enforceTor;
       description = ''
         Always use the *proxy*, even to connect to normal IP addresses (you can still connect to Unix domain sockets manually). This also disables all DNS lookups, to avoid leaking information.
       '';

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -13,7 +13,7 @@ let
     ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
     always-use-proxy=${if cfg.always-use-proxy then "true" else "false"}
     bind-addr=${cfg.bind-addr}:${toString cfg.bindport}
-    bitcoin-rpcconnect=${builtins.elemAt config.services.bitcoind.rpcbind 0}
+    bitcoin-rpcconnect=${config.services.bitcoind.rpcbind}
     bitcoin-rpcport=${toString config.services.bitcoind.rpc.port}
     bitcoin-rpcuser=${config.services.bitcoind.rpc.users.public.name}
     rpc-file-mode=0660

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -97,7 +97,7 @@ in {
           --daemon-dir='${bitcoind.dataDir}' \
           --electrum-rpc-addr=${cfg.address}:${toString cfg.port} \
           --monitoring-addr=${cfg.address}:${toString cfg.monitoringPort} \
-          --daemon-rpc-addr=${builtins.elemAt bitcoind.rpcbind 0}:${toString bitcoind.rpc.port} \
+          --daemon-rpc-addr=${bitcoind.rpcbind}:${toString bitcoind.rpc.port} \
           ${cfg.extraArgs}
         '';
         User = cfg.user;

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -20,7 +20,7 @@ let
     [BLOCKCHAIN]
     blockchain_source = bitcoin-rpc
     network = ${bitcoind.network}
-    rpc_host = ${builtins.elemAt bitcoind.rpcbind 0}
+    rpc_host = ${bitcoind.rpcbind}
     rpc_port = ${toString bitcoind.rpc.port}
     rpc_user = ${bitcoind.rpc.users.privileged.name}
     @@RPC_PASSWORD@@

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -38,7 +38,7 @@ in {
     };
     proxy = mkOption {
       type = types.nullOr types.str;
-      default = null;
+      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
       description = "host:port of SOCKS5 proxy for connnecting to the loop server.";
     };
     extraConfig = mkOption {

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -74,14 +74,13 @@ in {
     };
     cli = mkOption {
       default = pkgs.writeScriptBin "loop" ''
-        ${cfg.cliExec} ${cfg.package}/bin/loop \
+        ${cfg.package}/bin/loop \
         --rpcserver ${rpclisten} \
         --macaroonpath '${cfg.dataDir}/${network}/loop.macaroon' \
         --tlscertpath '${secretsDir}/loop-cert' "$@"
       '';
       description = "Binary to connect with the lightning-loop instance.";
     };
-    inherit (nix-bitcoin-services) cliExec;
     enforceTor = nix-bitcoin-services.enforceTor;
   };
 

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -14,7 +14,7 @@ let
     tlscertpath=${secretsDir}/loop-cert
     tlskeypath=${secretsDir}/loop-key
 
-    lnd.host=${builtins.elemAt config.services.lnd.rpclisten 0}:${toString config.services.lnd.rpcPort}
+    lnd.host=${config.services.lnd.rpclisten}:${toString config.services.lnd.rpcPort}
     lnd.macaroondir=${config.services.lnd.networkDir}
     lnd.tlspath=${secretsDir}/lnd-cert
 

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -27,6 +27,7 @@ let
       (attrValues cfg.rpc.users)
     }
     ${lib.concatMapStrings (rpcbind: "rpcbind=${rpcbind}\n") cfg.rpcbind}
+    rpcconnect=${builtins.elemAt cfg.rpcbind 0}
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
     ${optionalString (cfg.rpcuser != null) "rpcuser=${cfg.rpcuser}"}
     ${optionalString (cfg.rpcpassword != null) "rpcpassword=${cfg.rpcpassword}"}
@@ -205,17 +206,16 @@ in {
       cli = mkOption {
         readOnly = true;
         default = pkgs.writeScriptBin "elements-cli" ''
-          ${cfg.cliExec} ${pkgs.nix-bitcoin.elementsd}/bin/elements-cli -datadir='${cfg.dataDir}' "$@"
+          ${pkgs.nix-bitcoin.elementsd}/bin/elements-cli -datadir='${cfg.dataDir}' "$@"
         '';
         description = "Binary to connect with the liquidd instance.";
       };
       swapCli = mkOption {
         default = pkgs.writeScriptBin "liquidswap-cli" ''
-          ${cfg.cliExec} ${pkgs.nix-bitcoin.liquid-swap}/bin/liquidswap-cli -c '${cfg.dataDir}/elements.conf' "$@"
+          ${pkgs.nix-bitcoin.liquid-swap}/bin/liquidswap-cli -c '${cfg.dataDir}/elements.conf' "$@"
         '';
         description = "Binary for managing liquid swaps.";
       };
-      inherit (nix-bitcoin-services) cliExec;
       enforceTor =  nix-bitcoin-services.enforceTor;
     };
   };

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -26,8 +26,8 @@ let
       (rpcUser: "rpcauth=${rpcUser.name}:${rpcUser.passwordHMAC}")
       (attrValues cfg.rpc.users)
     }
-    ${lib.concatMapStrings (rpcbind: "rpcbind=${rpcbind}\n") cfg.rpcbind}
-    rpcconnect=${builtins.elemAt cfg.rpcbind 0}
+    rpcbind=${cfg.rpcbind}
+    rpcconnect=${cfg.rpcbind}
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
     ${optionalString (cfg.rpcuser != null) "rpcuser=${cfg.rpcuser}"}
     ${optionalString (cfg.rpcpassword != null) "rpcpassword=${cfg.rpcpassword}"}
@@ -126,8 +126,8 @@ in {
       };
 
       rpcbind = mkOption {
-        type = types.listOf types.str;
-        default = [ "127.0.0.1" ];
+        type = types.str;
+        default = "127.0.0.1";
         description = ''
           Bind to given address to listen for JSON-RPC connections.
         '';

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -31,7 +31,7 @@ let
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
     ${optionalString (cfg.rpcuser != null) "rpcuser=${cfg.rpcuser}"}
     ${optionalString (cfg.rpcpassword != null) "rpcpassword=${cfg.rpcpassword}"}
-    mainchainrpchost=${builtins.elemAt config.services.bitcoind.rpcbind 0}
+    mainchainrpchost=${config.services.bitcoind.rpcbind}
     mainchainrpcport=${toString config.services.bitcoind.rpc.port}
     mainchainrpcuser=${config.services.bitcoind.rpc.users.public.name}
 

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -160,7 +160,7 @@ in {
       };
       proxy = mkOption {
         type = types.nullOr types.str;
-        default = null;
+        default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
         description = "Connect through SOCKS5 proxy";
       };
       listen = mkOption {

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -91,7 +91,7 @@ in {
     };
     tor-socks = mkOption {
       type = types.nullOr types.str;
-      default = null;
+      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
       description = "Set a socks proxy to use to connect to Tor nodes";
     };
     announce-tor = mkOption {

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -25,7 +25,7 @@ let
     bitcoin.active=1
     bitcoin.node=bitcoind
 
-    tor.active=true
+    ${optionalString (cfg.enforceTor) "tor.active=true"}
     ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
 
     bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -8,7 +8,7 @@ let
   secretsDir = config.nix-bitcoin.secretsDir;
 
   bitcoind = config.services.bitcoind;
-  bitcoindRpcAddress = builtins.elemAt bitcoind.rpcbind 0;
+  bitcoindRpcAddress = bitcoind.rpcbind;
   onion-chef-service = (if cfg.announce-tor then [ "onion-chef.service" ] else []);
   networkDir = "${cfg.dataDir}/chain/bitcoin/${bitcoind.network}";
   configFile = pkgs.writeText "lnd.conf" ''

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -264,15 +264,8 @@ in {
 
     services.lnd = {
       listen = netns.lnd.address;
-      rpclisten = [
-        "${netns.lnd.address}"
-        "127.0.0.1"
-      ];
-      restlisten = [
-        "${netns.lnd.address}"
-        "127.0.0.1"
-      ];
-      cliExec = mkCliExec "lnd";
+      rpclisten = [ netns.lnd.address ];
+      restlisten = [ netns.lnd.address ];
     };
 
     services.liquidd = {

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -291,7 +291,7 @@ in {
       host = netns.nanopos.address;
     };
 
-    services.lightning-loop.cliExec = mkCliExec "lightning-loop";
+    services.lightning-loop.rpcAddress = netns.lightning-loop.address;
 
     services.nbxplorer.bind = netns.nbxplorer.address;
     services.btcpayserver.bind = netns.btcpayserver.address;

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -270,7 +270,7 @@ in {
 
     services.liquidd = {
       bind = netns.liquidd.address;
-      rpcbind = [ netns.liquidd.address ];
+      rpcbind = netns.liquidd.address;
       rpcallowip = [
         bridgeIp # For operator user
         netns.liquidd.address

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -264,8 +264,8 @@ in {
 
     services.lnd = {
       listen = netns.lnd.address;
-      rpclisten = [ netns.lnd.address ];
-      restlisten = [ netns.lnd.address ];
+      rpclisten = netns.lnd.address;
+      restlisten = netns.lnd.address;
     };
 
     services.liquidd = {

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -270,14 +270,11 @@ in {
 
     services.liquidd = {
       bind = netns.liquidd.address;
-      rpcbind = [
-        "${netns.liquidd.address}"
-        "127.0.0.1"
-      ];
+      rpcbind = [ netns.liquidd.address ];
       rpcallowip = [
-        "127.0.0.1"
-      ] ++ map (n: "${netns.${n}.address}") netns.liquidd.availableNetns;
-      cliExec = mkCliExec "liquidd";
+        bridgeIp # For operator user
+        netns.liquidd.address
+      ] ++ map (n: netns.${n}.address) netns.liquidd.availableNetns;
     };
 
     services.electrs.address = netns.electrs.address;

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -175,7 +175,6 @@ in {
           '') v.availableNetns;
           preStop = ''
             ${ip} netns delete ${netnsName}
-            ${ip} link del ${peer}
           '';
           serviceConfig = {
             Type = "oneshot";

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -50,7 +50,7 @@ in {
 
     addressblock = mkOption {
       type = types.ints.u8;
-      default = "1";
+      default = 1;
       description = ''
         The address block N in 169.254.N.0/24, used as the prefix for netns addresses.
       '';

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -252,18 +252,11 @@ in {
 
     services.bitcoind = {
       bind = netns.bitcoind.address;
-      rpcbind = [
-        "${netns.bitcoind.address}"
-        "127.0.0.1"
-      ];
+      rpcbind = [ netns.bitcoind.address ];
       rpcallowip = [
-        "127.0.0.1"
-      ] ++ map (n: "${netns.${n}.address}") netns.bitcoind.availableNetns;
-      cli = let
-        inherit (config.services.bitcoind) cliBase;
-      in pkgs.writeScriptBin cliBase.name ''
-        exec netns-exec ${netns.bitcoind.netnsName} ${cliBase}/bin/${cliBase.name} "$@"
-      '';
+        bridgeIp # For operator user
+        netns.bitcoind.address
+      ] ++ map (n: netns.${n}.address) netns.bitcoind.availableNetns;
     };
     systemd.services.bitcoind-import-banlist.serviceConfig.NetworkNamespacePath = "/var/run/netns/nb-bitcoind";
 

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -252,7 +252,7 @@ in {
 
     services.bitcoind = {
       bind = netns.bitcoind.address;
-      rpcbind = [ netns.bitcoind.address ];
+      rpcbind = netns.bitcoind.address;
       rpcallowip = [
         bridgeIp # For operator user
         netns.bitcoind.address

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -151,6 +151,7 @@ in {
           requiredBy = bindsTo;
           before = bindsTo;
           script = ''
+            ${ip} netns delete ${netnsName} 2> /dev/null || true
             ${ip} netns add ${netnsName}
             ${ipNetns} link set lo up
             ${ip} link add ${veth} type veth peer name ${peer}
@@ -179,7 +180,6 @@ in {
           serviceConfig = {
             Type = "oneshot";
             RemainAfterExit = "yes";
-            ExecStartPre = "-${ip} netns delete ${netnsName}";
           };
         };
       };

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -49,11 +49,6 @@ in {
       hiddenServices.sshd = mkHiddenService { port = 22; };
     };
 
-    # netns-isolation
-    nix-bitcoin.netns-isolation = {
-      addressblock = 1;
-    };
-
     # bitcoind
     services.bitcoind = {
       enable = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -54,7 +54,6 @@ in {
       enable = true;
       listen = true;
       dataDirReadableByGroup = mkIf cfg.electrs.high-memory true;
-      proxy = cfg.tor.client.socksListenAddress;
       enforceTor = true;
       port = 8333;
       assumevalid = "00000000000000000000e5abc3a74fe27dc0ead9c70ea1deb456f11c15fd7bc6";
@@ -69,11 +68,7 @@ in {
     services.tor.hiddenServices.bitcoind = mkHiddenService { port = cfg.bitcoind.port; toHost = cfg.bitcoind.bind; };
 
     # clightning
-    services.clightning = {
-      proxy = cfg.tor.client.socksListenAddress;
-      enforceTor = true;
-      always-use-proxy = true;
-    };
+    services.clightning.enforceTor = true;
     services.tor.hiddenServices.clightning = mkIf cfg.clightning.enable (mkHiddenService {
       port = cfg.clightning.onionport;
       toHost = cfg.clightning.bind-addr;
@@ -81,17 +76,11 @@ in {
     });
 
     # lnd
-    services.lnd = {
-      tor-socks = cfg.tor.client.socksListenAddress;
-      enforceTor = true;
-    };
+    services.lnd.enforceTor = true;
     services.tor.hiddenServices.lnd = mkIf cfg.lnd.enable (mkHiddenService { port = cfg.lnd.onionport; toHost = cfg.lnd.listen; toPort = cfg.lnd.listenPort; });
 
     # lightning-loop
-    services.lightning-loop = {
-      proxy = cfg.tor.client.socksListenAddress;
-      enforceTor = true;
-    };
+    services.lightning-loop.enforceTor = true;
 
     # liquidd
     services.liquidd = {
@@ -99,7 +88,6 @@ in {
       prune = 1000;
       validatepegin = true;
       listen = true;
-      proxy = cfg.tor.client.socksListenAddress;
       enforceTor = true;
       port = 7042;
     };

--- a/pkgs/netns-exec/src/main.c
+++ b/pkgs/netns-exec/src/main.c
@@ -10,7 +10,6 @@
 #include <sys/capability.h>
 
 static char *allowed_netns[] = {
-    "nb-lightning-loop",
     "nb-joinmarket"
 };
 

--- a/pkgs/netns-exec/src/main.c
+++ b/pkgs/netns-exec/src/main.c
@@ -11,7 +11,6 @@
 
 static char *allowed_netns[] = {
     "nb-lightning-loop",
-    "nb-liquidd",
     "nb-joinmarket"
 };
 

--- a/pkgs/netns-exec/src/main.c
+++ b/pkgs/netns-exec/src/main.c
@@ -12,7 +12,6 @@
 static char *allowed_netns[] = {
     "nb-lnd",
     "nb-lightning-loop",
-    "nb-bitcoind",
     "nb-liquidd",
     "nb-joinmarket"
 };

--- a/pkgs/netns-exec/src/main.c
+++ b/pkgs/netns-exec/src/main.c
@@ -10,7 +10,6 @@
 #include <sys/capability.h>
 
 static char *allowed_netns[] = {
-    "nb-lnd",
     "nb-lightning-loop",
     "nb-liquidd",
     "nb-joinmarket"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -169,12 +169,12 @@ EOF
 }
 
 # A basic subset of tests to keep the total runtime within
-# manageable bounds (<3 min on desktop systems).
+# manageable bounds (<4 min on desktop systems).
 # These are also run on the CI server.
 basic() {
     scenario=default buildTest "$@"
     scenario=netns buildTest "$@"
-    scenario=full evalTest "$@"
+    scenario=netnsRegtest buildTest "$@"
 }
 
 all() {
@@ -182,6 +182,7 @@ all() {
     scenario=netns buildTest "$@"
     scenario=full buildTest "$@"
     scenario=regtest buildTest "$@"
+    scenario=netnsRegtest buildTest "$@"
 }
 
 build() {

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -115,6 +115,7 @@ let testEnv = rec {
       nix-bitcoin.netns-isolation.enable = true;
       test.data.netns = config.nix-bitcoin.netns-isolation.netns;
       tests.netns-isolation = true;
+      environment.systemPackages = [ pkgs.fping ];
 
       # This test is rather slow and unaffected by netns settings
       tests.backups = mkForce false;

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -145,7 +145,7 @@ let testEnv = rec {
 
       services.bitcoind.regtest = true;
       systemd.services.bitcoind.postStart = mkAfter ''
-        cli=${config.services.bitcoind.cliBase}/bin/bitcoin-cli
+        cli=${config.services.bitcoind.cli}/bin/bitcoin-cli
         address=$($cli getnewaddress)
         $cli generatetoaddress 10 $address
       '';

--- a/test/tests.py
+++ b/test/tests.py
@@ -337,7 +337,7 @@ def _():
         machine.wait_until_succeeds(
             log_has_string("lightning-loop", "Starting event loop at height 10")
         )
-        succeed("sudo -u operator loop getparams | jq -e '.rules'")
+        succeed("sudo -u operator loop getparams")
 
 
 if "netns-isolation" in enabled_tests:

--- a/test/tests.py
+++ b/test/tests.py
@@ -259,16 +259,17 @@ def _():
     assert_unreachable("bitcoind", ["btcpayserver", "spark-wallet", "lightning-loop"])
     assert_unreachable("btcpayserver", ["bitcoind", "lightning-loop", "liquidd"])
 
-    # test that netns-exec can't be run for unauthorized namespace
-    machine.fail("netns-exec nb-electrs ip a")
-
-    # test that netns-exec drops capabilities
+    # netns-exec should drop capabilities
     assert_full_match(
         "su operator -c 'netns-exec nb-bitcoind capsh --print | grep Current '", "Current: =\n"
     )
 
-    # test that netns-exec can not be executed by users that are not operator
-    machine.fail("sudo -u clightning netns-exec nb-bitcoind ip a")
+    if "clightning" in enabled_tests:
+        # netns-exec should fail for unauthorized namespaces
+        machine.fail("netns-exec nb-clightning ip a")
+
+        # netns-exec should only be executable by the operator user
+        machine.fail("sudo -u clightning netns-exec nb-bitcoind ip a")
 
 
 # Impure: stops bitcoind (and dependent services)

--- a/test/tests.py
+++ b/test/tests.py
@@ -259,10 +259,11 @@ def _():
     assert_unreachable("bitcoind", ["btcpayserver", "spark-wallet", "lightning-loop"])
     assert_unreachable("btcpayserver", ["bitcoind", "lightning-loop", "liquidd"])
 
-    # netns-exec should drop capabilities
-    assert_full_match(
-        "su operator -c 'netns-exec nb-bitcoind capsh --print | grep Current '", "Current: =\n"
-    )
+    if "joinmarket" in enabled_tests:
+        # netns-exec should drop capabilities
+        assert_full_match(
+            "su operator -c 'netns-exec nb-joinmarket capsh --print | grep Current'", "Current: =\n"
+        )
 
     if "clightning" in enabled_tests:
         # netns-exec should fail for unauthorized namespaces

--- a/test/tests.py
+++ b/test/tests.py
@@ -259,6 +259,12 @@ def _():
     assert_unreachable("bitcoind", ["btcpayserver", "spark-wallet", "lightning-loop"])
     assert_unreachable("btcpayserver", ["bitcoind", "lightning-loop", "liquidd"])
 
+    # netns addresses can not be bound to in the main netns.
+    # This prevents processes in the main netns from impersonating nix-bitcoin services.
+    assert_matches(
+        f"nc -l {ip('bitcoind')} 1080 2>&1 || true", "nc: Cannot assign requested address"
+    )
+
     if "joinmarket" in enabled_tests:
         # netns-exec should drop capabilities
         assert_full_match(


### PR DESCRIPTION
## Topic: Allow RPC access from the main netns
This is implemented by commits starting with `netns-bitcoind: allow RPC access from main netns`.

Pros:
- Much reduced implementation complexity: No extra CLI, no multiple service listen addresses.
- Improved usability: The `service.cli` binary will always work from all allowed namespaces, including the service's own netns.\
  The previous CLI separation led to a bug in `regtestBase` because I inadvertently used `bitcoind.cli` instead of `bitcoind.cliBase` in `bitcoind.postStart` for generating regtest blocks.

Cons:
- Insignificantly decreased security for bitcoind and liquidd (not for lnd):\
  Previously, attackers from the main netns had to pass the allowip and the rpcauth
  checks to gain RPC access.\
  Now, it's just rpcauth, like for connections from all other allowed netns.