### PR TITLE
Fix netns restart

### DIFF
--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -152,7 +152,6 @@ in {
           requiredBy = bindsTo;
           before = bindsTo;
           script = ''
-            ${ip} netns delete ${netnsName} 2> /dev/null || true
             ${ip} netns add ${netnsName}
             ${ipNetns} link set lo up
             ${ip} link add ${veth} type veth peer name ${peer}

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -172,8 +172,13 @@ in {
             ${netnsIptables} -w -A INPUT -s ${allowedAddresses} -j ACCEPT
             ${netnsIptables} -w -A OUTPUT -d ${allowedAddresses} -j ACCEPT
           '';
+          # Link deletion is implicit in netns deletion, but it sometimes only happens
+          # after `netns delete` finishes. Add an extra `link del` to ensure that
+          # the link is deleted before the service stops, which is needed for service
+          # restart to succeed.
           preStop = ''
             ${ip} netns delete ${netnsName}
+            ${ip} link del ${peer} 2> /dev/null || true
           '';
           serviceConfig = {
             Type = "oneshot";


### PR DESCRIPTION
This fixes netns service restarts on Travis, which were [broken in the test](https://github.com/fort-nix/nix-bitcoin/pull/258#issuecomment-721039403) for #256.
Because I didn't succeed in locally reproducing the error and because of Travis' long queue times, I couldn't determine the true cause of the error with certainty.
But empirically this patch seems to work: Here's the successful [CI test](https://travis-ci.org/github/erikarvstedt/nix-bitcoin/builds/741241894) with #256 applied on top of this PR.
We should merge this PR before #256.