### PR TITLE
Fix containers for nixpkgs 20.09

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -59,7 +59,7 @@ in {
       enable = mkEnableOption "Bitcoin daemon";
       package = mkOption {
         type = types.package;
-        default = pkgs.nix-bitcoin.bitcoind;
+        default = config.nix-bitcoin.pkgs.bitcoind;
         defaultText = "pkgs.blockchains.bitcoind";
         description = "The package providing bitcoin binaries.";
       };

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -5,13 +5,13 @@ with lib;
 let
   cfg = config.services;
   inherit (config) nix-bitcoin-services;
+  nbPkgs = config.nix-bitcoin.pkgs;
 in {
   options.services = {
     nbxplorer = {
       package = mkOption {
         type = types.package;
-        default = pkgs.nix-bitcoin.nbxplorer;
-        defaultText = "pkgs.nix-bitcoin.nbxplorer";
+        default = nbPkgs.nbxplorer;
         description = "The package providing nbxplorer binaries.";
       };
       dataDir = mkOption {
@@ -51,8 +51,7 @@ in {
       enable = mkEnableOption "btcpayserver";
       package = mkOption {
         type = types.package;
-        default = pkgs.nix-bitcoin.btcpayserver;
-        defaultText = "pkgs.nix-bitcoin.btcpayserver";
+        default = nbPkgs.btcpayserver;
         description = "The package providing btcpayserver binaries.";
       };
       dataDir = mkOption {

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -81,7 +81,7 @@ in {
         RuntimeDirectoryMode = "700";
         WorkingDirectory = "/run/electrs";
         ExecStart = ''
-          ${pkgs.nix-bitcoin.electrs}/bin/electrs -vvv \
+          ${config.nix-bitcoin.pkgs.electrs}/bin/electrs -vvv \
           ${if cfg.high-memory then
               traceIf (!bitcoind.dataDirReadableByGroup) ''
                 Warning: For optimal electrs syncing performance, enable services.bitcoind.dataDirReadableByGroup.

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -63,8 +63,6 @@ in {
 
     services.bitcoind.enable = true;
 
-    environment.systemPackages = [ pkgs.nix-bitcoin.electrs ];
-
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
     ];

--- a/modules/hardware-wallets.nix
+++ b/modules/hardware-wallets.nix
@@ -42,10 +42,10 @@ in {
         }
       ];
 
-      environment.systemPackages = with pkgs; [
-        nix-bitcoin.hwi
+      environment.systemPackages = [
+        config.nix-bitcoin.pkgs.hwi
         # Provides lsusb for debugging
-        usbutils
+        pkgs.usbutils
       ];
       users.groups."${cfg.group}" = {};
       nix-bitcoin.operator.groups = [ cfg.group ];

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.services.joinmarket;
   inherit (config) nix-bitcoin-services;
+  nbPkgs = config.nix-bitcoin.pkgs;
   secretsDir = config.nix-bitcoin.secretsDir;
 
   inherit (config.services) bitcoind;
@@ -77,7 +78,7 @@ let
    # so run them inside dataDir.
    cli = pkgs.runCommand "joinmarket-cli" {} ''
      mkdir -p $out/bin
-     jm=${pkgs.nix-bitcoin.joinmarket}/bin
+     jm=${nbPkgs.joinmarket}/bin
      cd $jm
      for bin in jm-*; do
        {
@@ -181,13 +182,13 @@ in {
             # (like with pipes)
             cd ${cfg.dataDir} && \
               out=$(sudo -u ${cfg.user} \
-              ${pkgs.nix-bitcoin.joinmarket}/bin/jm-genwallet \
+              ${nbPkgs.joinmarket}/bin/jm-genwallet \
               --datadir=${cfg.dataDir} $walletname $pw)
             recoveryseed=$(echo "$out" | grep 'recovery_seed')
             echo "$recoveryseed" | cut -d ':' -f2 > $mnemonic
           fi
         '');
-        ExecStart = "${pkgs.nix-bitcoin.joinmarket}/bin/joinmarketd";
+        ExecStart = "${nbPkgs.joinmarket}/bin/joinmarketd";
         WorkingDirectory = "${cfg.dataDir}"; # The service creates 'commitmentlist' in the working dir
         User = "${cfg.user}";
         Restart = "on-failure";
@@ -201,7 +202,7 @@ in {
     nix-bitcoin.secrets.jm-wallet-password.user = cfg.user;
 
     systemd.services.joinmarket-yieldgenerator = let
-      ygDefault = "${pkgs.nix-bitcoin.joinmarket}/bin/jm-yg-privacyenhanced";
+      ygDefault = "${nbPkgs.joinmarket}/bin/jm-yg-privacyenhanced";
       ygBinary = if cfg.yieldgenerator.customParameters == "" then
         ygDefault
       else

--- a/modules/lightning-charge.nix
+++ b/modules/lightning-charge.nix
@@ -51,7 +51,6 @@ in {
       "d '${cfg.dataDir}' 0700 ${user} ${group} - -"
     ];
 
-    environment.systemPackages = [ pkgs.nix-bitcoin.lightning-charge ];
     systemd.services.lightning-charge = {
       description = "Run lightning-charge";
       wantedBy = [ "multi-user.target" ];

--- a/modules/lightning-charge.nix
+++ b/modules/lightning-charge.nix
@@ -69,7 +69,7 @@ in {
           # Needed to access clightning.dataDir in preStart
           PermissionsStartOnly = "true";
           EnvironmentFile = "${config.nix-bitcoin.secretsDir}/lightning-charge-env";
-          ExecStart = "${pkgs.nix-bitcoin.lightning-charge}/bin/charged -l ${config.services.clightning.dataDir}/bitcoin -d ${cfg.dataDir}/lightning-charge.db -i ${cfg.host} ${cfg.extraArgs}";
+          ExecStart = "${config.nix-bitcoin.pkgs.lightning-charge}/bin/charged -l ${config.services.clightning.dataDir}/bitcoin -d ${cfg.dataDir}/lightning-charge.db -i ${cfg.host} ${cfg.extraArgs}";
           User = user;
           Restart = "on-failure";
           RestartSec = "10s";

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -50,8 +50,7 @@ in {
     };
     package = mkOption {
       type = types.package;
-      default = pkgs.nix-bitcoin.lightning-loop;
-      defaultText = "pkgs.nix-bitcoin.lightning-loop";
+      default = config.nix-bitcoin.pkgs.lightning-loop;
       description = "The package providing lightning-loop binaries.";
     };
     dataDir = mkOption {

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -5,6 +5,7 @@ with lib;
 let
   cfg = config.services.liquidd;
   inherit (config) nix-bitcoin-services;
+  nbPkgs = config.nix-bitcoin.pkgs;
   secretsDir = config.nix-bitcoin.secretsDir;
   pidFile = "${cfg.dataDir}/liquidd.pid";
   configFile = pkgs.writeText "elements.conf" ''
@@ -206,13 +207,13 @@ in {
       cli = mkOption {
         readOnly = true;
         default = pkgs.writeScriptBin "elements-cli" ''
-          ${pkgs.nix-bitcoin.elementsd}/bin/elements-cli -datadir='${cfg.dataDir}' "$@"
+          ${nbPkgs.elementsd}/bin/elements-cli -datadir='${cfg.dataDir}' "$@"
         '';
         description = "Binary to connect with the liquidd instance.";
       };
       swapCli = mkOption {
         default = pkgs.writeScriptBin "liquidswap-cli" ''
-          ${pkgs.nix-bitcoin.liquid-swap}/bin/liquidswap-cli -c '${cfg.dataDir}/elements.conf' "$@"
+          ${nbPkgs.liquid-swap}/bin/liquidswap-cli -c '${cfg.dataDir}/elements.conf' "$@"
         '';
         description = "Binary for managing liquid swaps.";
       };
@@ -224,7 +225,7 @@ in {
     services.bitcoind.enable = true;
 
     environment.systemPackages = [
-      pkgs.nix-bitcoin.elementsd
+      nbPkgs.elementsd
       (hiPrio cfg.cli)
       (hiPrio cfg.swapCli)
     ];
@@ -249,7 +250,7 @@ in {
         Type = "simple";
         User = "${cfg.user}";
         Group = "${cfg.group}";
-        ExecStart = "${pkgs.nix-bitcoin.elementsd}/bin/elementsd ${cmdlineOptions}";
+        ExecStart = "${nbPkgs.elementsd}/bin/elementsd ${cmdlineOptions}";
         PIDFile = "${pidFile}";
         Restart = "on-failure";
         ReadWritePaths = "${cfg.dataDir}";

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -171,7 +171,6 @@ in {
     services.onion-chef.access.lnd = if cfg.announce-tor then [ "lnd" ] else [];
     systemd.services.lnd = {
       description = "Run LND";
-      path  = [ pkgs.nix-bitcoin.bitcoind ];
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ] ++ onion-chef-service;
       after = [ "bitcoind.service" ] ++ onion-chef-service;

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -56,7 +56,7 @@ in {
       description = "The network data directory.";
     };
     listen = mkOption {
-      type = pkgs.nix-bitcoin.lib.ipv4Address;
+      type = config.nix-bitcoin.pkgs.lib.ipv4Address;
       default = "localhost";
       description = "Bind to given address to listen to peer connections";
     };
@@ -130,8 +130,7 @@ in {
     };
     package = mkOption {
       type = types.package;
-      default = pkgs.nix-bitcoin.lnd;
-      defaultText = "pkgs.nix-bitcoin.lnd";
+      default = config.nix-bitcoin.pkgs.lnd;
       description = "The package providing lnd binaries.";
     };
     cli = mkOption {

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -36,6 +36,11 @@
       readOnly = true;
       default = import ./nix-bitcoin-services.nix lib pkgs;
     };
+
+    nix-bitcoin.pkgs = lib.mkOption {
+      type = lib.types.attrs;
+      default = (import ../pkgs { inherit pkgs; }).modulesPkgs;
+    };
   };
 
   config = {
@@ -48,12 +53,5 @@
         '';
       }
     ];
-
-    nixpkgs.overlays = [ (self: super: {
-      nix-bitcoin = let
-        pkgs = import ../pkgs { pkgs = super; };
-      in
-        pkgs // pkgs.pinned;
-    }) ];
   };
 }

--- a/modules/nanopos.nix
+++ b/modules/nanopos.nix
@@ -99,7 +99,7 @@ in {
       after = [ "lightning-charge.service" ];
       serviceConfig = nix-bitcoin-services.defaultHardening // {
         EnvironmentFile = "${config.nix-bitcoin.secretsDir}/nanopos-env";
-        ExecStart = "${pkgs.nix-bitcoin.nanopos}/bin/nanopos -y ${cfg.itemsFile} -i ${toString cfg.host} -p ${toString cfg.port} -c ${toString cfg.charged-url} --show-bolt11 ${cfg.extraArgs}";
+        ExecStart = "${config.nix-bitcoin.pkgs.nanopos}/bin/nanopos -y ${cfg.itemsFile} -i ${toString cfg.host} -p ${toString cfg.port} -c ${toString cfg.charged-url} --show-bolt11 ${cfg.extraArgs}";
         User = "nanopos";
         Restart = "on-failure";
         RestartSec = "10s";

--- a/modules/nanopos.nix
+++ b/modules/nanopos.nix
@@ -79,8 +79,6 @@ in {
 
     services.lightning-charge.enable = true;
 
-    environment.systemPackages = [ pkgs.nix-bitcoin.nanopos ];
-
     services.nginx = {
       enable = true;
       virtualHosts."_" = {

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -102,7 +102,7 @@ in {
     boot.kernel.sysctl."net.ipv4.ip_forward" = true;
 
     security.wrappers.netns-exec = {
-      source = pkgs.nix-bitcoin.netns-exec;
+      source = config.nix-bitcoin.pkgs.netns-exec;
       capabilities = "cap_sys_admin=ep";
       owner = cfg.allowedUser;
       permissions = "u+rx,g+rx,o-rwx";

--- a/modules/recurring-donations.nix
+++ b/modules/recurring-donations.nix
@@ -6,7 +6,7 @@ let
   cfg = config.services.recurring-donations;
   inherit (config) nix-bitcoin-services;
   recurring-donations-script = pkgs.writeScript "recurring-donations.sh" ''
-    LNCLI="${pkgs.nix-bitcoin.clightning}/bin/lightning-cli --lightning-dir=${config.services.clightning.dataDir}"
+    LNCLI="${config.nix-bitcoin.pkgs.clightning}/bin/lightning-cli --lightning-dir=${config.services.clightning.dataDir}"
     pay_tallycoin() {
       NAME=$1
       AMOUNT=$2

--- a/modules/secrets/generate-secrets.nix
+++ b/modules/secrets/generate-secrets.nix
@@ -20,7 +20,7 @@ with lib;
       cd "${config.nix-bitcoin.secretsDir}"
       chown root: .
       chmod 0700 .
-      ${pkgs.nix-bitcoin.generate-secrets}
+      ${config.nix-bitcoin.pkgs.generate-secrets}
     '';
   };
 }

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -14,7 +14,7 @@ let
     ${optionalString cfg.onion-service ''
       publicURL="--public-url http://$(cat /var/lib/onion-chef/spark-wallet/spark-wallet)"
     ''}
-    exec ${pkgs.nix-bitcoin.spark-wallet}/bin/spark-wallet \
+    exec ${config.nix-bitcoin.pkgs.spark-wallet}/bin/spark-wallet \
       --ln-path '${config.services.clightning.networkDir}'  \
       --host ${cfg.host} \
       --config '${config.nix-bitcoin.secretsDir}/spark-wallet-login' \

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -54,7 +54,6 @@ in {
   config = mkIf cfg.enable {
     services.clightning.enable = true;
 
-    environment.systemPackages = [ pkgs.nix-bitcoin.spark-wallet ];
     users.users.spark-wallet = {
       description = "spark-wallet User";
       group = "spark-wallet";

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,5 @@
 { pkgs ? import <nixpkgs> {} }:
-{
+let self = {
   lightning-charge = pkgs.callPackage ./lightning-charge { };
   nanopos = pkgs.callPackage ./nanopos { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
@@ -18,4 +18,6 @@
   pinned = import ./pinned.nix;
 
   lib = import ./lib.nix { inherit (pkgs) lib; };
-}
+
+  modulesPkgs = self // self.pinned;
+}; in self


### PR DESCRIPTION
Nixpkgs 20.09 introduced a bug where nixpkgs overlays are ignored in containers. This breaks our `pkgs.nix-bitcoin` overlay:
```bash
$ test/run-tests.sh container
error: attribute 'nix-bitcoin' missing, at /home/main/d/nix-bitcoin/src/modules/bitcoind.nix:62:19
```
[My upstream bugfix PR](https://github.com/NixOS/nixpkgs/pull/98655) has not been merged yet.

Work around this by providing nix-bitcoin pkgs via an option instead of an overlay (in `modules.nix`).
This also has the advantage to slightly speed-up container builds because the `pkgs` of the host system can be reused in the container.