### PR TITLE
testing framework: re-add features removed in nixpkgs 20.09

### DIFF
--- a/test/lib/make-test-vm.nix
+++ b/test/lib/make-test-vm.nix
@@ -19,7 +19,19 @@ let
            '';
          };
        };
+       test' = test (args // { pkgs = pkgsFixed; });
     in
-      test (args // { pkgs = pkgsFixed; });
+      # See nixpkgs/nixos/lib/testing-python.nix for the original definition
+      test'.overrideAttrs (_: {
+        # 1. Save test output
+        # 2. Add link to driver so that a gcroot to a test prevents the driver from
+        #    being garbage-collected
+        buildCommand = ''
+          mkdir $out
+          LOGFILE=$out/output.xml tests='exec(os.environ["testScript"])' ${test'.driver}/bin/nixos-test-driver
+          ln -s ${test'.driver} $out/driver
+        '';
+      }) // { inherit (test') nodes driver; } ;
+
 in
   fixedTest


### PR DESCRIPTION
##### Copy of commit message
Since nixpks 20.09, the test output is just an empty directory.
Restore saving the log output and linking to the driver.

Without linking to the driver, the driver is eligible for garbage collection after running a test via `run-tests.sh --out-link-prefix`, which implies lengthy driver rebuilds.