### PR TITLE
Fix typo in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/example/secrets/
+/examples/secrets/


### PR DESCRIPTION
Instead of excluding `examples/secrets` `example/secret` was excluded