### PR TITLE
lnd: fix rpc/rest port configuration

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -18,8 +18,8 @@ let
     tlskeypath=${secretsDir}/lnd-key
 
     listen=${toString cfg.listen}:${toString cfg.listenPort}
-    rpclisten=${cfg.rpclisten}
-    restlisten=${cfg.restlisten}
+    rpclisten=${cfg.rpclisten}:${toString cfg.rpcPort}
+    restlisten=${cfg.restlisten}:${toString cfg.restPort}
 
     bitcoin.${bitcoind.network}=1
     bitcoin.active=1


### PR DESCRIPTION
Setting `lnd.restPort` currently causes lnd not to start because it does not get written into the config. Probably introduced in de23fdd37780406c9b09e9f0528d8f7ae7cf1a76. Did not test with netns-isolation.