### PR TITLE
joinmarket: 0.7.4 -> 0.8.0-bcfa7eb

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -221,5 +221,5 @@
   # The nix-bitcoin release version that your config is compatible with.
   # When upgrading to a backwards-incompatible release, nix-bitcoin will display an
   # an error and provide hints for migrating your config to the new release.
-  nix-bitcoin.configVersion = "0.0.18";
+  nix-bitcoin.configVersion = "0.0.26";
 }

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -50,7 +50,7 @@ let
 
     [POLICY]
     segwit = true
-    native = false
+    native = true
     merge_algorithm = default
     tx_fees = 3
     absurd_fee_per_kb = 350000

--- a/modules/versioning.nix
+++ b/modules/versioning.nix
@@ -6,14 +6,54 @@ let
 
   # Sorted by increasing version numbers
   changes = [
-    # None yet
-    # {
-    #   version = "0.1";
-    #   condition = config.services.foo.enabled;
-    #   message = ''
-    #     demo message
-    #   '';
-    # }
+    {
+      version = "0.0.26";
+      condition = config.services.joinmarket.enable;
+      message = let
+        inherit (config.services.joinmarket) dataDir;
+      in ''
+        JoinMarket 0.8.0 moves from wrapped segwit wallets to native segwit wallets.
+
+        If you have an existing wrapped segwit wallet, you have to manually migrate
+        your funds to a new native segwit wallet.
+
+        To migrate, you first have to deploy the new JoinMarket version:
+        1. Set `nix-bitcoin.configVersion = "0.0.26";` in your configuration.nix
+        2. Deploy the new configuration
+
+        Then run the following on your nix-bitcoin node:
+        1. Move your wallet:
+           mv ${dataDir}/wallets/wallet.jmdat ${dataDir}/wallets/old.jmdat
+        2. Autogenerate a new p2wpkh wallet:
+           systemctl restart joinmarket
+        3. Transfer your funds manually by doing sweeps for each mixdepth:
+           jm-sendpayment -m <mixdepth> -N 0 old.jmdat 0 <destaddr>
+
+           Run this command for every available mixdepth (`-m 0`, `-m 1`, ...).
+           IMPORTANT: Use a different <destaddr> for every run.
+
+           Explanation of the options:
+           -m <mixdepth>: spend from given mixdepth.
+           -N 0: don't coinjoin on this spend
+           old.jmdat: spend from old wallet
+           0: set amount to zero to do a sweep, i.e. transfer all funds at given mixdepth
+           <destaddr>: destination p2wpkh address from wallet.jmdat with mixdepth 0
+
+        Privacy Notes:
+        - This method transfers all funds to the same mixdepth 0.
+          Because wallet inputs at the same mixdepth can be considered to be linked, this undoes
+          the unlinking effects of previous coinjoins and resets all funds to mixdepth 0.
+          This only applies in case that the inputs to the new wallet are used for further coinjoins.
+          When inputs are instead kept separate in future transactions, the unlinking effects of
+          different mixdepths are preserved.
+        - A different <destaddr> should be used for every transaction.
+        - You might want to time stagger the transactions.
+        - Additionally, you can use coin-freezing to exclude specific inputs from the sweep.
+
+        More information at
+        https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/v0.8.0/docs/NATIVE-SEGWIT-UPGRADE.md
+      '';
+    }
   ];
 
   incompatibleChanges = optionals
@@ -51,9 +91,8 @@ in
     };
   };
 
-  ## No config because there are no backwards incompatible releases yet
-  # config = {
-  #   # Force evaluation. An actual option value is never assigned
-  #   system.extraDependencies = optional (builtins.length incompatibleChanges > 0) (builtins.throw errorMsg);
-  # };
+  config = {
+    # Force evaluation. An actual option value is never assigned
+    system.extraDependencies = optional (builtins.length incompatibleChanges > 0) (builtins.throw errorMsg);
+  };
 }

--- a/pkgs/joinmarket/default.nix
+++ b/pkgs/joinmarket/default.nix
@@ -1,10 +1,10 @@
 { stdenv, lib, fetchurl, python3, nbPython3Packages, pkgs }:
 
 let
-  version = "0.7.2";
+  version = "0.8.0-bcfa7eb";
   src = fetchurl {
-    url = "https://github.com/JoinMarket-Org/joinmarket-clientserver/archive/v${version}.tar.gz";
-    sha256 = "03gvs20d2cfzy9x82l6v4c69w0j9mr4p9zj2hpymnb6xs1yq6dr1";
+    url = "https://github.com/JoinMarket-Org/joinmarket-clientserver/archive/bcfa7eb4ea3ca51b7ecae9aebe65c634a4ab8b0e.tar.gz";
+    sha256 = "05akzaxi2vqh3hln6qkr6frfas9xd0d95xa3wd56pj8bzknd410m";
   };
 
   runtimePackages = with nbPython3Packages; [

--- a/pkgs/joinmarket/get-sha256.sh
+++ b/pkgs/joinmarket/get-sha256.sh
@@ -9,17 +9,19 @@ cd $TMPDIR
 echo "Fetching latest release"
 git clone https://github.com/joinmarket-org/joinmarket-clientserver 2> /dev/null
 cd joinmarket-clientserver
-latest=$(git describe --tags `git rev-list --tags --max-count=1`)
+latest=bcfa7eb4ea3ca51b7ecae9aebe65c634a4ab8b0e
 echo "Latest release is ${latest}"
 
 # GPG verification
 export GNUPGHOME=$TMPDIR
 echo "Fetching Adam Gibson's key"
 gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys 2B6FC204D9BF332D062B461A141001A1AF77F20B 2> /dev/null
+echo "Fetching Kristaps Kaupe's key"
+gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys BF60DF964F88DD88174089A2D47B1B4232B55437 2> /dev/null
 echo "Verifying latest release"
-git verify-tag ${latest}
+git verify-commit ${latest}
 
-echo "tag: ${latest}"
+echo "commit: ${latest}"
 # The prefix option is necessary because GitHub prefixes the archive contents in this format
 echo "sha256: $(nix-hash --type sha256 --flat --base32 \
                 <(git archive --format tar.gz --prefix=joinmarket-clientserver-"${latest//v}"/ ${latest}))"


### PR DESCRIPTION
This PR updates JoinMarket to 0.8.0 plus a hotfix for the genwallet script that I wrote myself. It includes a warning about the necessary migration steps. This warning isn't something for config versioning, right?

I had to temporarily change `get-sha256.sh` for the pinned commit. We can revert all this with version 0.8.1.
