### PR TITLE
Fix containers

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,5 +32,3 @@
     * **A:** Check your clightning logs with `journalctl -eu clightning`. Do you see something like `bitcoin-cli getblock ... false` failed? Are you using pruned mode? That means that clightning hasn't seen all the blocks it needs to and it can't get that block because your node is pruned. If you're just setting up a new node you can `systemctl stop clightning` and wipe your `/var/lib/clightning` directory. Otherwise you need to reindex the Bitcoin node.
 * **Q:** My disk space is getting low due to nix.
     * **A:** run `nix-collect-garbage -d`
-* **Q:** `nix-shell` takes too long and doesn't finish generating `/secrets`
-    * **A:** This might be the result of low system entropy. Check your entropy with `cat /proc/sys/kernel/random/entropy_avail`. If necessary, take steps to increase entropy like performing some tasks on the system or acquiring a hardware true random number generator.

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -9,8 +9,7 @@
     # FIXME: The hardened kernel profile improves security but
     # decreases performance by ~50%.
     # Turn it off when not needed.
-    # Source: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/hardened.nix
-    <nixpkgs/nixos/modules/profiles/hardened.nix>
+    <nix-bitcoin/modules/presets/hardened.nix>
 
     # FIXME: Uncomment next line to import your hardware configuration. If so,
     # add the hardware configuration file to the same directory as this file.
@@ -207,10 +206,6 @@
 
   # FIXME: Add custom options (like boot options, output of
   # nixos-generate-config, etc.):
-
-  # If the hardened profile is imported above, we need to explicitly allow
-  # user namespaces to enable sanboxed builds and services.
-  security.allowUserNamespaces = true;
 
   # This value determines the NixOS release with which your system is to be
   # compatible, in order to avoid breaking some software such as database

--- a/examples/deploy-qemu-vm.sh
+++ b/examples/deploy-qemu-vm.sh
@@ -17,6 +17,8 @@ if [[ ! -v IN_NIX_SHELL ]]; then
     exec nix-shell --run "./${BASH_SOURCE[0]##*/} $*"
 fi
 
+cd "${BASH_SOURCE[0]%/*}"
+
 tmpDir=/tmp/nix-bitcoin-qemu-vm
 mkdir -p $tmpDir
 

--- a/modules/presets/hardened.nix
+++ b/modules/presets/hardened.nix
@@ -1,0 +1,14 @@
+{
+  imports = [
+    # Source: https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/profiles/hardened.nix
+    <nixpkgs/nixos/modules/profiles/hardened.nix>
+  ];
+
+  ## Reset some options set by the hardened profile
+
+  # Needed for sandboxed builds and services
+  security.allowUserNamespaces = true;
+
+  # The "scudo" allocator is broken on NixOS 20.09
+  environment.memoryAllocator.provider = "libc";
+}

--- a/pkgs/extra-container/default.nix
+++ b/pkgs/extra-container/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   name = "extra-container-${version}";
-  version = "0.5-pre";
+  version = "0.5";
 
   src = builtins.fetchTarball {
     url = "https://github.com/erikarvstedt/extra-container/archive/${version}.tar.gz";
-    sha256 = "0gdy2dpqrdv7f4kyqz88j34x1p2fpav04kznv41hwqq88hmzap90";
+    sha256 = "12xqa11v583ajdv51g1833rxvrndmly9h4r62wc3llm8xs6k7ais";
   };
 
   buildCommand = ''
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
     share=$out/share/extra-container
     install $src/eval-config.nix -Dt $share
 
-    # Use existing PATH for systemctl and machinectl (for nixos-container)
+    # Use existing PATH for systemctl and machinectl
     scriptPath="export PATH=${lib.makeBinPath [ nixos-container openssh ]}:\$PATH"
 
     sed -i \

--- a/pkgs/generate-secrets/default.nix
+++ b/pkgs/generate-secrets/default.nix
@@ -10,6 +10,6 @@ let
   '';
 in
 writers.writeBash "generate-secrets" ''
-  export PATH=${lib.makeBinPath [ coreutils apg openssl gnugrep rpcauth ]}
+  export PATH=${lib.makeBinPath [ coreutils pwgen openssl gnugrep rpcauth ]}
   . ${./generate-secrets.sh} ${./openssl.cnf}
 ''

--- a/pkgs/generate-secrets/generate-secrets.sh
+++ b/pkgs/generate-secrets/generate-secrets.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 opensslConf=${1:-openssl.cnf}
 
 makePasswordSecret() {
-    [[ -e $1 ]] || apg -m 20 -x 20 -M Ncl -n 1 > "$1"
+    # Passwords have alphabet {a-z, A-Z, 0-9} and ~119 bits of entropy
+    [[ -e $1 ]] || pwgen -s 20 1 > "$1"
 }
 makeHMAC() {
     user=$1

--- a/test/lib/make-container.sh
+++ b/test/lib/make-container.sh
@@ -28,7 +28,7 @@
 #         This args disables auto-destructing containers.
 #
 #
-#   run-tests.sh container --run|-r c systemctl status bitcoind
+#   run-tests.sh container --run c systemctl status bitcoind
 #
 #     Run a command in the shell session environmentand exit.
 #     Destroy the container afterwards.
@@ -39,7 +39,7 @@
 #     run-tests.sh container --run c
 #
 #
-#   run-tests.sh [--scenario|-s <scenario>] container --command|--c
+#   run-tests.sh [--scenario|-s <scenario>] container --command|-c
 #
 #     Provide a custom extra-container command.
 #

--- a/test/lib/make-container.sh
+++ b/test/lib/make-container.sh
@@ -57,8 +57,8 @@ if [[ $EUID != 0 ]]; then
     # NixOS containers require root permissions.
     # By using sudo here and not at the user's call-site extra-container can detect if it is running
     # inside an existing shell session (by checking an internal environment variable).
-    exec sudo scenario="$scenario" testDir="$testDir" NIX_PATH="$NIX_PATH" PATH="$PATH" \
-         scenarioOverridesFile="${scenarioOverridesFile:-}" "$testDir/lib/make-container.sh" "$@"
+    exec sudo scenario="$scenario" scriptDir="$scriptDir" NIX_PATH="$NIX_PATH" PATH="$PATH" \
+         scenarioOverridesFile="${scenarioOverridesFile:-}" "$scriptDir/lib/make-container.sh" "$@"
 fi
 
 export containerName=nb-test
@@ -79,11 +79,11 @@ done
 containerBin=$(type -P extra-container) || true
 if [[ ! ($containerBin && $(realpath $containerBin) == *extra-container-0.5*) ]]; then
     echo "Building extra-container. Skip this step by adding extra-container 0.5 to PATH."
-    nix-build --out-link /tmp/extra-container "$testDir"/../pkgs -A extra-container >/dev/null
+    nix-build --out-link /tmp/extra-container "$scriptDir"/../pkgs -A extra-container >/dev/null
     export PATH="/tmp/extra-container/bin${PATH:+:}$PATH"
 fi
 
 read -d '' src <<EOF || true
-(import "$testDir/tests.nix" { scenario = "$scenario"; }).container
+(import "$scriptDir/tests.nix" { scenario = "$scenario"; }).container
 EOF
 exec extra-container $containerCommand -E "$src" "$@"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -206,6 +206,7 @@ all() {
     basic
     scenario=full buildTest "$@"
     scenario=regtest buildTest "$@"
+    scenario=hardened buildTest "$@"
 }
 
 # An alias for buildTest

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -202,11 +202,27 @@ basic() {
     pkgsUnstable
 }
 
-all() {
+# All tests that only consist of building a nix derivation.
+# Their output is cached in /nix/store.
+buildable() {
     basic
     scenario=full buildTest "$@"
     scenario=regtest buildTest "$@"
     scenario=hardened buildTest "$@"
+}
+
+examples() {
+    script="
+      set -e
+      ./deploy-container.sh
+      ./deploy-qemu-vm.sh
+    "
+    (cd $scriptDir/../examples && nix-shell --run "$script")
+}
+
+all() {
+    buildable
+    examples
 }
 
 # An alias for buildTest

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -165,6 +165,13 @@ let testEnv = rec {
       imports = with scenarios; [ netnsBase regtest ];
     };
 
+    hardened = {
+      imports = [
+        scenarios.secureNode
+        ../modules/presets/hardened.nix
+      ];
+    };
+
     netnsBase = {
       nix-bitcoin.netns-isolation.enable = true;
       test.data.netns = config.nix-bitcoin.netns-isolation.netns;


### PR DESCRIPTION
#### Commit `generate-secrets: use pwgen`

To compare the password output, run
```
nix run -f '<nixpkgs>' apg -c apg -m 20 -x 20 -M Ncl -n 1
nix run -f '<nixpkgs>' pwgen -c pwgen -s 20 1
```

#### Commit `extra-container: 0.5-pre -> 0.5`

Use this for auditing:
```
tmp=$(mktemp -d -p /tmp)
mkdir -p $tmp/{old,new}
fetchAndCheck() {
    local url=https://github.com/erikarvstedt/extra-container/archive/$1.tar.gz
    curl -sSL $url | tar xz --strip-components=1 -C $2;
    echo "sha256 for $1 is $(nix hash-path --base32 "$2")"
}
fetchAndCheck 0.5-pre $tmp/old
fetchAndCheck 0.5     $tmp/new
git diff --no-index $tmp/{old,new}
rm -rf $tmp
```