### PR TITLE
joinmarket: always synchronize secrets.jm-wallet-password

### DIFF
--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -196,11 +196,11 @@ in {
         ReadWritePaths = "${cfg.dataDir}";
       } // nix-bitcoin-services.allowTor;
     };
+
+    nix-bitcoin.secrets.jm-wallet-password.user = cfg.user;
   }
 
   (mkIf cfg.yieldgenerator.enable {
-    nix-bitcoin.secrets.jm-wallet-password.user = cfg.user;
-
     systemd.services.joinmarket-yieldgenerator = let
       ygDefault = "${nbPkgs.joinmarket}/bin/jm-yg-privacyenhanced";
       ygBinary = if cfg.yieldgenerator.customParameters == "" then


### PR DESCRIPTION
`secrets.jm-wallet-password` is always needed by joinmarket, not just when `joinmarket.yieldgenerator.enable`