### PR TITLE
joinmarket: add enforceTor to firewall scripts on netns-level

### DIFF
--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -124,6 +124,11 @@ in {
     cli = mkOption {
       default = cli;
     };
+    # This option is only used by netns-isolation
+    enforceTor = mkOption {
+      readOnly = true;
+      default = true;
+    };
     inherit (nix-bitcoin-services) cliExec;
   };
 


### PR DESCRIPTION
Fix from 6af5238dfc6816568a3bf0c32285b5ccf012786f applied to `joinmarket` module.