### PR TITLE
Fix lnd nodeinfo

### DIFF
--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -13,7 +13,7 @@ let
           info["id"] = f"{info['nodeid']}@{info['onion_address']}"
     '';
     lnd = mkInfo ''
-      info["nodeid"] = shell("lightning-cli getinfo | jq -r '.id'")
+      info["nodeid"] = shell("lncli getinfo | jq -r '.identity_pubkey'")
     '';
     electrs = mkInfo "";
     spark-wallet = mkInfo "";


### PR DESCRIPTION
```nodeinfo``` used ```lightning-cli``` for getting the pubkey.

Now the output is the pubkey as expected.