### PR TITLE
electrs: v0.8.6 -> v0.8.7

### DIFF
--- a/pkgs/electrs/default.nix
+++ b/pkgs/electrs/default.nix
@@ -1,19 +1,19 @@
 { lib, rustPlatform, llvmPackages, fetchurl, pkgs }:
 rustPlatform.buildRustPackage rec {
   pname = "electrs";
-  version = "0.8.6";
+  version = "0.8.7";
 
   src = fetchurl {
     url = "https://github.com/romanz/electrs/archive/v${version}.tar.gz";
     # Use ./get-sha256.sh to fetch latest (verified) sha256
-    sha256 = "cad47cb01efa7172cc5a1bde8c1a5daea95fab664eae9f38df4d4ac7defcf9de";
+    sha256 = "f967f322ebf86dd32d291716fa8e8b155da4b35d003b116b4e7007054d6b515e";
   };
 
   # Needed for librocksdb-sys
   nativeBuildInputs = [ llvmPackages.clang ];
   LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
 
-  cargoSha256 = "11xwjcfc3kqjyp94qzmyb26xwynf4f1q3ac3rp7l7qq1njly07gr";
+  cargoSha256 = "12ypx0rkpbjl4awzx8ga30qhiqqd56a24q4jwlxxnfpw9ks1z252";
 
   meta = with lib; {
     description = "An efficient Electrum Server in Rust";


### PR DESCRIPTION
This PR updates our electrs package. Eventhough this release [doesn't bring significant new features](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md) I still think its good to keep up-to-date.