### PR TITLE
Madaidan hardening

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -210,7 +210,7 @@
   # services.joinmarket-ob-watcher.enable = true;
 
   # FIXME: Define your hostname.
-  networking.hostName = "nix-bitcoin";
+  networking.hostName = "host";
   time.timeZone = "UTC";
 
   # FIXME: Add your SSH pubkey

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -10,6 +10,11 @@
     # decreases performance by ~50%.
     # Turn it off when not needed.
     <nix-bitcoin/modules/presets/hardened.nix>
+    #
+    # You can enable the hardened-extended preset instead to further improve security
+    # at the cost of functionality and performance.
+    # See the comments at the top of `hardened-extended.nix` for further details.
+    # <nix-bitcoin/modules/presets/hardened-extended.nix>
 
     # FIXME: Uncomment next line to import your hardware configuration. If so,
     # add the hardware configuration file to the same directory as this file.

--- a/modules/presets/hardened-extended.nix
+++ b/modules/presets/hardened-extended.nix
@@ -1,0 +1,141 @@
+# This preset adds additional hardening settings on top of the
+# default ./hardened.nix preset.
+# These settings trade even more functionality and performance for increased security.
+
+# This preset enables usbguard. Use `services.usbguard.rules` to whitelist
+# select devices.
+#
+# See madaidan's Linux Hardening Guide for detailed explanations:
+# https://madaidans-insecurities.github.io/guides/linux-hardening.html
+
+{
+  imports = [
+    # Build on standard hardened preset
+    ./hardened.nix
+  ];
+
+  boot.kernel.sysctl = {
+    # Prevent boot console kernel log information leaks
+    "kernel.printk" = "3 3 3 3";
+
+    # Restrict loading TTY line disciplines to the CAP_SYS_MODULE capability to
+    # prevent unprivileged attackers from loading vulnerable line disciplines with
+    # the TIOCSETD ioctl
+    "dev.tty.ldisc_autoload" = "0";
+
+    # The SysRq key exposes a lot of potentially dangerous debugging functionality
+    # to unprivileged users
+    "kernel.sysrq" = "4";
+
+    # Protect against time-wait assassination by dropping RST packets for sockets
+    # in the time-wait state
+    "net.ipv4.tcp_rfc1337" = "1";
+
+    # Disable accepting IPv6 router advertisements
+    "net.ipv6.conf.all.accept_ra" = "0";
+    "net.ipv6.default.accept_ra" = "0";
+
+    # Disable TCP SACK. SACK is commonly exploited and unnecessary for many
+    # circumstances so it should be disabled if you don't require it
+    "net.ipv4.tcp_sack" = "0";
+    "net.ipv4.tcp_dsack" = "0";
+
+    # Restrict usage of ptrace to only processes with the CAP_SYS_PTRACE
+    # capability
+    "kernel.yama.ptrace_scope" = "2";
+
+    # Prevent creating files in potentially attacker-controlled environments such
+    # as world-writable directories to make data spoofing attacks more difficult
+    "fs.protected_fifos" = "2";
+    "fs.protected_regular" = "2";
+
+    # Avoid leaking system time with TCP timestamps
+    "net.ipv4.tcp_timestamps" = "0";
+
+    # Disable core dumps
+    "syskernel.core_pattern" = "|/bin/false";
+    "fs.suid_dumpable" = "0";
+
+    # Only swap when absolutely necessary
+    "vm.swappiness" = "1";
+  };
+
+  boot.kernelParams = [
+    # Disable slab merging which significantly increases the difficulty of heap
+    # exploitation by preventing overwriting objects from merged caches and by
+    # making it harder to influence slab cache layout
+    "slab_nomerge"
+
+    # Disable vsyscalls as they are obsolete and have been replaced with vDSO.
+    # vsyscalls are also at fixed addresses in memory, making them a potential
+    # target for ROP attacks
+    "vsyscall=none"
+
+    # Disable debugfs which exposes a lot of sensitive information about the
+    # kernel
+    "debugfs=off"
+
+    # Sometimes certain kernel exploits will cause what is known as an "oops".
+    # This parameter will cause the kernel to panic on such oopses, thereby
+    # preventing those exploits
+    "oops=panic"
+
+    # Only allow kernel modules that have been signed with a valid key to be
+    # loaded, which increases security by making it much harder to load a
+    # malicious kernel module
+    "module.sig_enforce=1"
+
+    # The kernel lockdown LSM can eliminate many methods that user space code
+    # could abuse to escalate to kernel privileges and extract sensitive
+    # information. This LSM is necessary to implement a clear security boundary
+    # between user space and the kernel
+    "lockdown=confidentiality"
+
+    # These parameters prevent information leaks during boot and must be used
+    # in combination with the kernel.printk
+    "quiet loglevel=0"
+  ];
+
+  boot.blacklistedKernelModules = [
+    # Obscure networking protocols
+    "dccp"
+    "sctp"
+    "rds"
+    "tipc"
+    "n-hdlc"
+    "x25"
+    "decnet"
+    "econet"
+    "af_802154"
+    "ipx"
+    "appletalk"
+    "psnap"
+    "p8023"
+    "p8022"
+    "can"
+    "atm"
+    # Various rare filesystems
+    "jffs2"
+    "hfsplus"
+    "squashfs"
+    "udf"
+    "cifs"
+    "nfs"
+    "nfsv3"
+    "nfsv4"
+    "gfs2"
+    # vivid driver is only useful for testing purposes and has been the cause
+    # of privilege escalation vulnerabilities
+    "vivid"
+    # Disable Bluetooth
+    "bluetooth"
+    "btusb"
+    # Disable webcam
+    "uvcvideo"
+    # Disable Thunderbolt and FireWire to prevent DMA attacks
+    "thunderbolt"
+    "firewire-core"
+  ];
+
+  services.usbguard.enable = true;
+}

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -15,6 +15,11 @@ let self = {
       MemoryDenyWriteExecute = "true";
       ProtectKernelTunables = "true";
       ProtectKernelModules = "true";
+      ProtectKernelLogs = "true";
+      ProtectClock = "true";
+      # Test and enable these when systemd v247 is available
+      # ProtectProc = "invisible";
+      # ProcSubset = "pid";
       ProtectControlGroups = "true";
       RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
       RestrictNamespaces = "true";

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -188,7 +188,7 @@ let
     hardened = {
       imports = [
         scenarios.secureNode
-        ../modules/presets/hardened.nix
+        ../modules/presets/hardened-extended.nix
       ];
     };
 


### PR DESCRIPTION
This PR implements a number of hardening measures from @madaidan's [Linux Hardening Guide](https://madaidans-insecurities.github.io/guides/linux-hardening.html).

It also replaces sudo with doas because of the recent CVE-2021-3156. Sudo is simply [too complex](https://lobste.rs/s/efsvqu/heap_based_buffer_overflow_sudo_cve_2021#c_c6fcfa) and includes features that a SETUID program should never have. Furthermore, it lets the operator user control selected services so we can discourage users from ssh'ing into the root user at all and instead recommend using the operator user for all normal system management tasks.

I have saved the remaining improvements from @madaidan's [Linux Hardening Guide](https://madaidans-insecurities.github.io/guides/linux-hardening.html), like system-wide AppArmor and LibreSSL, for future PRs because of their complexity.