### PR TITLE
Update nixpkgs-unstable, bitcoind

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,4 +39,4 @@ task:
   build_script:
     - echo "sandbox = true" >> /etc/nix/nix.conf
     - export NIX_PATH="nixpkgs=$(nix eval --raw -f pkgs/nixpkgs-pinned.nix $nixpkgs)"
-    - nix run -f '<nixpkgs>' bash cachix -c ./ci/build.sh
+    - nix run -f '<nixpkgs>' bash coreutils cachix -c ./ci/build.sh

--- a/ci/build-to-cachix.sh
+++ b/ci/build-to-cachix.sh
@@ -13,10 +13,16 @@ trap 'echo Error at line $LINENO' ERR
 
 atExit() {
     rm -rf $tmpDir
-    if [[ -v cachixPid ]]; then kill $cachixPid; fi
+    if [[ -v cachixPid ]]; then stopCachix; fi
 }
 tmpDir=$(mktemp -d -p /tmp)
 trap atExit EXIT
+
+stopCachix() {
+    kill $cachixPid 2>/dev/null || true
+    # Wait for cachix to finish
+    tail --pid=$cachixPid -f /dev/null
+}
 
 ## Instantiate
 
@@ -44,6 +50,7 @@ fi
 nix-build --out-link $tmpDir/result $tmpDir/drv >/dev/null
 
 if [[ $CACHIX_SIGNING_KEY ]]; then
+    stopCachix
     cachix push $cachixCache $outPath
 fi
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -55,5 +55,11 @@ c systemctl status bitcoind
 
 # Explore a single feature
 ./run-tests.sh --scenario electrs container
+
+# Run a command in a container
+./run-tests.sh --scenario '{
+  services.clightning.enable = true;
+  nix-bitcoin.nodeinfo.enable = true;
+}' container --run c nodeinfo
 ```
 See [`run-tests.sh`](../test/run-tests.sh) for a complete documentation.

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -28,6 +28,10 @@
   # LND and electrs are not compatible with pruning.
   # services.bitcoind.prune = 100000;
   #
+  # Set this to accounce the onion service address to peers.
+  # The onion service allows accepting incoming connections via Tor.
+  # nix-bitcoin.onionServices.bitcoind.public = true;
+  #
   # You can add options that are not defined in modules/bitcoind.nix as follows
   # services.bitcoind.extraConfig = ''
   #   maxorphantx=110

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -22,7 +22,7 @@ let
     ${optionalString (cfg.assumevalid != null) "assumevalid=${cfg.assumevalid}"}
 
     # Connection options
-    ${optionalString cfg.listen "bind=${cfg.address}"}
+    ${optionalString cfg.listen "bind=${cfg.address}${optionalString cfg.enforceTor "=onion"}"}
     port=${toString cfg.port}
     ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
     listen=${if cfg.listen then "1" else "0"}

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -67,6 +67,14 @@ in {
         default = 8333;
         description = "Port to listen for peer connections.";
       };
+      getPublicAddressCmd = mkOption {
+        type = types.str;
+        default = "";
+        description = ''
+          Bash expression which outputs the public service address to announce to peers.
+          If left empty, no address is announced.
+        '';
+      };
       package = mkOption {
         type = types.package;
         default = config.nix-bitcoin.pkgs.bitcoind;
@@ -328,6 +336,10 @@ in {
           ${extraRpcauth}
           ${/* Enable bitcoin-cli for group 'bitcoin' */ ""}
           printf "rpcuser=${cfg.rpc.users.privileged.name}\nrpcpassword="; cat "${secretsDir}/bitcoin-rpcpassword-privileged";
+          echo
+          ${optionalString (cfg.getPublicAddressCmd != "") ''
+            echo "externalip=$(${cfg.getPublicAddressCmd})"
+          ''}
         )
         confFile='${cfg.dataDir}/bitcoin.conf'
         if [[ ! -e $confFile || $cfg != $(cat $confFile) ]]; then

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -71,12 +71,12 @@ in {
         );
       };
 
-      # Enable public services to access their own onion addresses
-      nix-bitcoin.onionAddresses.access = (
-        genAttrs publicServices singleton
-      ) // {
+      nix-bitcoin.onionAddresses = {
+        # Enable public services to access their own onion addresses
+        services = publicServices;
+
         # Allow the operator user to access onion addresses for all active services
-        ${config.nix-bitcoin.operator.name} = mkIf config.nix-bitcoin.operator.enable activeServices;
+        access.${config.nix-bitcoin.operator.name} = mkIf config.nix-bitcoin.operator.enable activeServices;
       };
       systemd.services = let
         onionAddresses = [ "onion-addresses.service" ];
@@ -96,7 +96,7 @@ in {
           in srv.public && srv.enable
         ) services;
       in genAttrs publicServices' (service: {
-        getPublicAddressCmd = "cat ${config.nix-bitcoin.onionAddresses.dataDir}/${service}/${service}";
+        getPublicAddressCmd = "cat ${config.nix-bitcoin.onionAddresses.dataDir}/${service}";
       });
     }
 

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -12,7 +12,7 @@ in
     sha256 = "1vjh0np1rlirbhhj9b2d0zhrqdmiji5svxh9baqq7r3680af1iif";
   };
   nixpkgs-unstable = fetch {
-    rev = "296793637b22bdb4d23b479879eba0a71c132a66";
-    sha256 = "0j09yih9693w5vjx64ikfxyja1ha7pisygrwrpg3wfz3sssglg69";
+    rev = "891f607d5301d6730cb1f9dcf3618bcb1ab7f10e";
+    sha256 = "1cr39f0sbr0h5d83dv1q34mcpwnkwwbdk5fqlyqp2mnxghzwssng";
   };
 }

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -13,9 +13,6 @@ in
     lnd
     nbxplorer
     btcpayserver;
-  inherit (nixBitcoinPkgsUnstable)
-    electrs
-    lightning-loop;
 
   stable = nixBitcoinPkgsStable;
   unstable = nixBitcoinPkgsUnstable;

--- a/test/pkgs-unstable.nix
+++ b/test/pkgs-unstable.nix
@@ -4,10 +4,15 @@ let
   nbPkgs = import ../pkgs { inherit pkgs; };
   pkgsUnstable = with nbPkgs; [
     electrs
-    elementsd
     hwi
     joinmarket
     lightning-loop
+
+    ## elementsd fails with error
+    # test/key_properties.cpp:16:10: fatal error: rapidcheck/boost_test.h: No such file or directory
+    # 16 | #include <rapidcheck/boost_test.h>
+    #    |          ^~~~~~~~~~~~~~~~~~~~~~~~~
+    # elementsd
   ];
 in
 pkgs.writeText "pkgs-unstable" (pkgs.lib.concatMapStringsSep "\n" toString pkgsUnstable)

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -187,6 +187,7 @@ let testEnv = rec {
       services.bitcoind.regtest = true;
       systemd.services.bitcoind.postStart = mkAfter ''
         cli=${config.services.bitcoind.cli}/bin/bitcoin-cli
+        $cli createwallet "test"
         address=$($cli getnewaddress)
         $cli generatetoaddress 10 $address
       '';

--- a/test/tests.py
+++ b/test/tests.py
@@ -296,12 +296,18 @@ def _():
         "0 differences found",
     )
     # Backup should include important files
-    files = succeed(f"{run_duplicity} list-current-files file:///var/lib/localBackups")
-    assert "var/lib/clightning/bitcoin/hsm_secret" in files
-    assert "secrets/lnd-seed-mnemonic" in files
-    assert "secrets/jm-wallet-seed" in files
-    assert "var/lib/bitcoind/wallet.dat" in files
-    assert "var/backup/postgresql/btcpaydb.sql.gz" in files
+    files = {
+        "bitcoind": "var/lib/bitcoind/wallet.dat",
+        "clightning": "var/lib/clightning/bitcoin/hsm_secret",
+        "lnd": "secrets/lnd-seed-mnemonic",
+        "joinmarket": "secrets/jm-wallet-seed",
+        "btcpayserver": "var/backup/postgresql/btcpaydb.sql.gz",
+    }
+    actual_files = succeed(f"{run_duplicity} list-current-files file:///var/lib/localBackups")
+
+    for test, file in files.items():
+        if test in enabled_tests and file not in actual_files:
+            raise Exception(f"Backup file '{file}' is missing.")
 
 
 # Impure: restarts services

--- a/test/tests.py
+++ b/test/tests.py
@@ -286,6 +286,9 @@ def _():
 # Impure: stops bitcoind (and dependent services)
 @test("backups")
 def _():
+    # For testing that bitcoind wallets are backed up
+    succeed("bitcoin-cli -named createwallet wallet_name=test blank=true >/dev/null")
+
     succeed("systemctl stop bitcoind")
     succeed("systemctl start duplicity")
     machine.wait_until_succeeds(log_has_string("duplicity", "duplicity.service: Succeeded."))
@@ -297,7 +300,7 @@ def _():
     )
     # Backup should include important files
     files = {
-        "bitcoind": "var/lib/bitcoind/wallet.dat",
+        "bitcoind": "var/lib/bitcoind/test/wallet.dat",
         "clightning": "var/lib/clightning/bitcoin/hsm_secret",
         "lnd": "secrets/lnd-seed-mnemonic",
         "joinmarket": "secrets/jm-wallet-seed",


### PR DESCRIPTION
I couldn't reproduce #303, neither within our test framework nor on my production server.

Use the following for a live test of the new v3 onion service:
```
test/run-tests.sh -s '{
  imports = [ <nix-bitcoin/modules/presets/secure-node.nix> ];
  nix-bitcoin.onionServices.bitcoind.public = true;
  test.container.enableWAN = true;
}' container

### Run these commands in the container shell

## check that onion service is reachable
onionAddr=$(c nodeinfo | jq -r .bitcoind.onion_address | tr ':' ' ')
echo $onionAddr
# Requires torsocks
torsocks nc -zv $onionAddr

# check config
c cat /var/lib/bitcoind/bitcoin.conf

# check network
c bitcoin-cli getnetworkinfo
```

Commit `improve backup test` fixes the cryptic `AssertionError` that probably happened to @nixbitcoin after updating nixpkgs-unstable.