### PR TITLE
fix build-to-cachix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,4 +39,4 @@ task:
   build_script:
     - echo "sandbox = true" >> /etc/nix/nix.conf
     - export NIX_PATH="nixpkgs=$(nix eval --raw -f pkgs/nixpkgs-pinned.nix $nixpkgs)"
-    - nix run -f '<nixpkgs>' bash cachix -c ./ci/build.sh
+    - nix run -f '<nixpkgs>' bash coreutils cachix -c ./ci/build.sh

--- a/ci/build-to-cachix.sh
+++ b/ci/build-to-cachix.sh
@@ -13,10 +13,16 @@ trap 'echo Error at line $LINENO' ERR
 
 atExit() {
     rm -rf $tmpDir
-    if [[ -v cachixPid ]]; then kill $cachixPid; fi
+    if [[ -v cachixPid ]]; then stopCachix; fi
 }
 tmpDir=$(mktemp -d -p /tmp)
 trap atExit EXIT
+
+stopCachix() {
+    kill $cachixPid 2>/dev/null || true
+    # Wait for process to finish
+    tail --pid=$cachixPid -f /dev/null
+}
 
 ## Instantiate
 
@@ -44,6 +50,7 @@ fi
 nix-build --out-link $tmpDir/result $tmpDir/drv >/dev/null
 
 if [[ $CACHIX_SIGNING_KEY ]]; then
+    stopCachix
     cachix push $cachixCache $outPath
 fi
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -317,7 +317,7 @@ def _():
     succeed("systemctl restart bitcoind clightning lnd lightning-loop spark-wallet liquidd")
 
     # Now that the bitcoind restart triggered a banlist import restart, check that
-    # re-importing already banned addresses works
+    # re-importing already banned addresses works tests
     machine.wait_until_succeeds(
         log_has_string(f"bitcoind-import-banlist --since=@{pre_restart}", "Importing node banlist")
     )

--- a/test/tests.py
+++ b/test/tests.py
@@ -317,7 +317,7 @@ def _():
     succeed("systemctl restart bitcoind clightning lnd lightning-loop spark-wallet liquidd")
 
     # Now that the bitcoind restart triggered a banlist import restart, check that
-    # re-importing already banned addresses works tests
+    # re-importing already banned addresses works tests2
     machine.wait_until_succeeds(
         log_has_string(f"bitcoind-import-banlist --since=@{pre_restart}", "Importing node banlist")
     )


### PR DESCRIPTION
Edit: I've included this PR in #308.

This fixes the cause of the CI build failure in #307.

## Copy of commit message
- Don't fail on `kill $cachixPid` when cachix has already exited.
  This fixes some failing CI builds.

- Stop the cachix background worker before the final `cachix push`.
  This can avoid unneeded reuploads.