### PR TITLE
bitcoind: add uptime to the public API whitelist

### DIFF
--- a/modules/bitcoind-rpc-public-whitelist.nix
+++ b/modules/bitcoind-rpc-public-whitelist.nix
@@ -2,6 +2,7 @@
 [
   "echo"
   "getinfo"
+  "uptime"
   # Blockchain
   "getbestblockhash"
   "getblock"


### PR DESCRIPTION
It is needed by lnd to check bitcoind health status since version 0.12.0: https://github.com/lightningnetwork/lnd/pull/4755

If the api method is blocked lnd shuts down soon after starting.

```
# journalctl -b
...
Feb 02 22:13:30 nix-bitcoin bitcoind[8416]: 2021-02-02T21:13:30Z RPC User public not allowed to call method uptime
...
Feb 02 22:13:30 nix-bitcoin lnd[9845]: 2021-02-02 22:13:30.708 [CRT] SRVR: Health check: chain backend failed after 3 calls
Feb 02 22:13:30 nix-bitcoin lnd[9845]: 2021-02-02 22:13:30.708 [INF] SRVR: Sending request for shutdown
Feb 02 22:13:30 nix-bitcoin lnd[9845]: 2021-02-02 22:13:30.708 [INF] LTND: Received shutdown request.
Feb 02 22:13:30 nix-bitcoin lnd[9845]: 2021-02-02 22:13:30.708 [INF] LTND: Shutting down...
```