### PR TITLE
Update nixpkgs

### DIFF
--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,8 +8,8 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "93c2261684ea8c65606d7167b5d52b8da7d7778a";
-    sha256 = "1vjh0np1rlirbhhj9b2d0zhrqdmiji5svxh9baqq7r3680af1iif";
+    rev = "6fbc72a353a1b0ae4f5b48cae111bfb1a4d3a529";
+    sha256 = "0aj4xfkwk8gf96ypjp0rcap3hxrqg5qdwgwgx55zk0mlvq9z3h68";
   };
   nixpkgs-unstable = fetch {
     rev = "5ff6700bb824a6d824fa021550a5596f6c3f64e7";


### PR DESCRIPTION
Includes [CVE-2019-25016](http://cve.circl.lu/cve/CVE-2019-25016) patch

> In OpenDoas from 6.6 to 6.8 the users PATH variable was incorrectly inherited by authenticated executions if the authenticating rule allowed the user to execute any command. Rules that only allowed to authenticated user to execute specific commands were not affected by this issue.

AFAICT this vulnerability wasn't very serious for us because it allowed the `operator` user to execute any command in the `PATH` as the `joinmarket` or `lnd` user, which is the intended behavior. It used to be the default behavior for the software.