### PR TITLE
run-tests: Fix interrupt handling for --copy-src

### DIFF
--- a/test/lib/copy-src.sh
+++ b/test/lib/copy-src.sh
@@ -3,16 +3,16 @@
 
 tmp=$(mktemp -d '/tmp/nix-bitcoin-src.XXXXX')
 
-# Ignore errors from now on
-set +e
-
 # Move source cache if it exists (atomic)
-mv /tmp/nix-bitcoin-src $tmp/src 2>/dev/null
+mv /tmp/nix-bitcoin-src $tmp/src 2>/dev/null || true
 
-rsync -a --delete --exclude='.git*' "$scriptDir/../" $tmp/src && \
-  echo "Copied src" && \
-  _nixBitcoinInCopySrc=1 $tmp/src/test/run-tests.sh "${args[@]}"
+atExit() {
+    # Set the current src as the source cache (atomic)
+    mv -T $tmp/src /tmp/nix-bitcoin-src 2>/dev/null || true
+    rm -rf $tmp
+}
+trap "atExit" EXIT
 
-# Set the current src as the source cache (atomic)
-mv -T $tmp/src /tmp/nix-bitcoin-src 2>/dev/null
-rm -rf $tmp
+rsync -a --delete --exclude='.git*' "$scriptDir/../" $tmp/src
+echo "Copied src"
+_nixBitcoinInCopySrc=1 $tmp/src/test/run-tests.sh "${args[@]}"


### PR DESCRIPTION
##### Copy of commit msg
Previously, `run-tests.sh --copy-src ...` exited with status 0 (success) when interrupted (SIGINT).
It now exits with an error status.

##### Details
For `ACK`ing PRs I'm using a shell command similar to this:
```
test/run-tests.sh --copy-src all && gh pr review $pr --approve --body "ACK $rev"
```
This was broken because `run-tests.sh` always succeeded on interrupts.