### PR TITLE
Fix lnd onion

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -385,13 +385,13 @@ in {
     users.groups.bitcoinrpc = {};
     nix-bitcoin.operator.groups = [ cfg.group ];
 
-    nix-bitcoin.secrets.bitcoin-rpcpassword-privileged.user = "bitcoin";
+    nix-bitcoin.secrets.bitcoin-rpcpassword-privileged.user = cfg.user;
     nix-bitcoin.secrets.bitcoin-rpcpassword-public = {
-      user = "bitcoin";
+      user = cfg.user;
       group = "bitcoinrpc";
     };
 
-    nix-bitcoin.secrets.bitcoin-HMAC-privileged.user = "bitcoin";
-    nix-bitcoin.secrets.bitcoin-HMAC-public.user = "bitcoin";
+    nix-bitcoin.secrets.bitcoin-HMAC-privileged.user = cfg.user;
+    nix-bitcoin.secrets.bitcoin-HMAC-public.user = cfg.user;
   };
 }

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -218,7 +218,7 @@ in {
     users.groups.${cfg.nbxplorer.group} = {};
     users.users.${cfg.btcpayserver.user} = {
       group = cfg.btcpayserver.group;
-      extraGroups = [ "nbxplorer" ]
+      extraGroups = [ cfg.nbxplorer.group ]
                     ++ optional (cfg.btcpayserver.lightningBackend == "clightning") cfg.clightning.user;
       home = cfg.btcpayserver.dataDir;
     };
@@ -226,10 +226,10 @@ in {
 
     nix-bitcoin.secrets = {
       bitcoin-rpcpassword-btcpayserver = {
-        user = "bitcoin";
-        group = "nbxplorer";
+        user = cfg.bitcoind.user;
+        group = cfg.nbxplorer.group;
       };
-      bitcoin-HMAC-btcpayserver.user = "bitcoin";
+      bitcoin-HMAC-btcpayserver.user = cfg.bitcoind.user;
     };
   };
 }

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -110,7 +110,7 @@ in {
 
     users.users.${cfg.user} = {
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc" ] ++ optionals cfg.high-memory [ "bitcoin" ];
+      extraGroups = [ "bitcoinrpc" ] ++ optionals cfg.high-memory [ bitcoind.user ];
     };
     users.groups.${cfg.group} = {};
   };

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -89,7 +89,7 @@ in {
     environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
 
     systemd.tmpfiles.rules = [
-      "d '${cfg.dataDir}' 0770 lnd lnd - -"
+      "d '${cfg.dataDir}' 0770 ${config.services.lnd.user} ${config.services.lnd.group} - -"
     ];
 
     systemd.services.lightning-loop = {
@@ -98,7 +98,7 @@ in {
       after = [ "lnd.service" ];
       serviceConfig = nbLib.defaultHardening // {
         ExecStart = "${cfg.package}/bin/loopd --configfile=${configFile}";
-        User = "lnd";
+        User = config.services.lnd.user;
         Restart = "on-failure";
         RestartSec = "10s";
         ReadWritePaths = cfg.dataDir;
@@ -108,8 +108,8 @@ in {
     };
 
      nix-bitcoin.secrets = {
-       loop-key.user = "lnd";
-       loop-cert.user = "lnd";
+       loop-key.user = config.services.lnd.user;
+       loop-cert.user = config.services.lnd.user;
      };
   };
 }

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -252,6 +252,6 @@ in {
     users.groups.${cfg.group} = {};
     nix-bitcoin.operator.groups = [ cfg.group ];
 
-    nix-bitcoin.secrets.liquid-rpcpassword.user = "liquid";
+    nix-bitcoin.secrets.liquid-rpcpassword.user = cfg.user;
   };
 }

--- a/modules/lnd-rest-onion-service.nix
+++ b/modules/lnd-rest-onion-service.nix
@@ -11,7 +11,7 @@ let
   lnd = config.services.lnd;
 
   bin = pkgs.writeScriptBin "lndconnect-rest-onion" ''
-    #!/usr/bin/env -S ${runAsUser} lnd ${pkgs.bash}/bin/bash
+    #!/usr/bin/env -S ${runAsUser} ${lnd.user} ${pkgs.bash}/bin/bash
 
     exec ${cfg.package}/bin/lndconnect \
      --host=$(cat ${config.nix-bitcoin.onionAddresses.dataDir}/lnd/lnd-rest) \

--- a/modules/onion-addresses.nix
+++ b/modules/onion-addresses.nix
@@ -84,7 +84,7 @@ in {
         ${concatMapStrings (service: ''
           onionFile=/var/lib/tor/onion/${service}/hostname
           if [[ -e $onionFile ]]; then
-            install -o ${config.systemd.services.${service}.serviceConfig.User} -m 400 $onionFile ${service}
+            install -D -o ${config.systemd.services.${service}.serviceConfig.User} -m 400 $onionFile services/${service}
           fi
         '') cfg.services}
       '';

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -94,7 +94,7 @@ in {
           in srv.public && srv.enable
         ) services;
       in genAttrs publicServices' (service: {
-        getPublicAddressCmd = "cat ${config.nix-bitcoin.onionAddresses.dataDir}/${service}";
+        getPublicAddressCmd = "cat ${config.nix-bitcoin.onionAddresses.dataDir}/services/${service}";
       });
     }
 

--- a/modules/recurring-donations.nix
+++ b/modules/recurring-donations.nix
@@ -100,7 +100,7 @@ in {
 
     users.users.recurring-donations = {
       group = "recurring-donations";
-      extraGroups = [ "clightning" ];
+      extraGroups = [ config.services.clightning.group ];
     };
     users.groups.recurring-donations = {};
   };


### PR DESCRIPTION
This PR fixes an issue with LND reported by @mmilata in the Freenode `#nix-bitcoin` channel.

If both `nix-bitcoin.onionServices.lnd.public` & `services.lnd.restOnionService.enable` were enabled, one would try to create a file named `lnd` and the other would try to create a directory named `lnd` with a file named `lnd-rest` inside it. This would obiously cause an error and fail the LND service. 

A bit of a yak shave, but I had to use `${config.services.${service}.user}` in order to avoid the infinite recursion of `${config.systemd.services.${service}.serviceConfig.User}`.

I've tried my best to locate all uses of hardcoded usernames, but its not guaranteed that all have been found/fixed. Please double-check.