### PR TITLE
bitcoind: enable cookie-based authentication

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -327,8 +327,6 @@ in {
         cfg=$(
           cat ${configFile}
           ${extraRpcauth}
-          ${/* Enable bitcoin-cli for group 'bitcoin' */ ""}
-          printf "rpcuser=${cfg.rpc.users.privileged.name}\nrpcpassword="; cat "${secretsDir}/bitcoin-rpcpassword-privileged"
           echo
           ${optionalString (cfg.getPublicAddressCmd != "") ''
             echo "externalip=$(${cfg.getPublicAddressCmd})"
@@ -338,6 +336,10 @@ in {
         if [[ ! -e $confFile || $cfg != $(cat $confFile) ]]; then
           install -o '${cfg.user}' -g '${cfg.group}' -m 640 <(echo "$cfg") $confFile
         fi
+      '';
+      # Enable RPC access for group
+      postStart = ''
+        chmod g=r '${cfg.dataDir}/${optionalString cfg.regtest "regtest/"}.cookie'
       '';
       serviceConfig = nbLib.defaultHardening // {
         Type = "notify";

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -384,13 +384,13 @@ in {
 
     users.users.${cfg.user}.group = cfg.group;
     users.groups.${cfg.group} = {};
-    users.groups.bitcoinrpc = {};
+    users.groups.bitcoinrpc-public = {};
     nix-bitcoin.operator.groups = [ cfg.group ];
 
     nix-bitcoin.secrets.bitcoin-rpcpassword-privileged.user = cfg.user;
     nix-bitcoin.secrets.bitcoin-rpcpassword-public = {
       user = cfg.user;
-      group = "bitcoinrpc";
+      group = "bitcoinrpc-public";
     };
 
     nix-bitcoin.secrets.bitcoin-HMAC-privileged.user = cfg.user;

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -212,7 +212,7 @@ in {
 
     users.users.${cfg.nbxplorer.user} = {
       group = cfg.nbxplorer.group;
-      extraGroups = [ "bitcoinrpc" ];
+      extraGroups = [ "bitcoinrpc-public" ];
       home = cfg.nbxplorer.dataDir;
     };
     users.groups.${cfg.nbxplorer.group} = {};

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -144,7 +144,7 @@ in {
 
     users.users.${cfg.user} = {
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc" ];
+      extraGroups = [ "bitcoinrpc-public" ];
     };
     users.groups.${cfg.group} = {};
     nix-bitcoin.operator.groups = [ cfg.group ];

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -110,7 +110,7 @@ in {
 
     users.users.${cfg.user} = {
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc" ] ++ optionals cfg.high-memory [ bitcoind.user ];
+      extraGroups = [ "bitcoinrpc-public" ] ++ optionals cfg.high-memory [ bitcoind.user ];
     };
     users.groups.${cfg.group} = {};
   };

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -247,7 +247,7 @@ in {
 
     users.users.${cfg.user} = {
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc" ];
+      extraGroups = [ "bitcoinrpc-public" ];
     };
     users.groups.${cfg.group} = {};
     nix-bitcoin.operator.groups = [ cfg.group ];

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -275,7 +275,7 @@ in {
 
     users.users.${cfg.user} = {
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc" ];
+      extraGroups = [ "bitcoinrpc-public" ];
       home = cfg.dataDir; # lnd creates .lnd dir in HOME
     };
     users.groups.${cfg.group} = {};

--- a/test/tests.py
+++ b/test/tests.py
@@ -103,6 +103,10 @@ def _():
     assert_running("bitcoind")
     machine.wait_until_succeeds("bitcoin-cli getnetworkinfo")
     assert_matches("runuser -u operator -- bitcoin-cli getnetworkinfo | jq", '"version"')
+
+    regtest = "regtest/" if "regtest" in enabled_tests else ""
+    assert_full_match(f"stat  -c '%a' /var/lib/bitcoind/{regtest}.cookie", "640\n")
+
     # RPC access for user 'public' should be restricted
     machine.fail(
         "bitcoin-cli -rpcuser=public -rpcpassword=$(cat /secrets/bitcoin-rpcpassword-public) stop"


### PR DESCRIPTION
This PR adds an option to enable bitcoind cookie-file based RPC authenticaiton. Programs like [revaultd](https://github.com/re-vault/revaultd/blob/25bb6922986709c642caec2f3ebb6cd750224c6f/src/common/config.rs#L13) only allow bitcoind cookie-file based RPC authentication. Users of these programs should be able to run them under the `bitcoin` user with cookie-file based RPC authentication.

Sadly this only allows `bitcoin` and `root` users to make `bitcoin-cli` calls without manually adding the `privileged` or `public` password.

EDIT: Feature requested by @danielabrozzoni 