### PR TITLE
spark-wallet: fix util-linux evaluation error

### DIFF
--- a/pkgs/spark-wallet/composition.nix
+++ b/pkgs/spark-wallet/composition.nix
@@ -10,7 +10,7 @@ let
     inherit (pkgs) fetchurl fetchgit;
   });
   nodeEnv = import ./node-env.nix {
-    inherit (pkgs) stdenv python2 utillinux runCommand writeTextFile;
+    inherit (pkgs) stdenv python2 util-linux runCommand writeTextFile;
     inherit nodejs;
     libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
   };


### PR DESCRIPTION
I noticed node-env imports nixpkgs from the local env so `nix build -f . pinned.stable.spark-wallet` doesn't work here. I couldn't think of a fix for this so here's a quick fix for the evaluation issue.