### PR TITLE
Update CLBOSS, add test, add option for custom pkg

### DIFF
--- a/modules/clightning-plugins/clboss.nix
+++ b/modules/clightning-plugins/clboss.nix
@@ -12,11 +12,16 @@ let cfg = config.services.clightning.plugins.clboss; in
         Specify target amount (in satoshi) that CLBOSS will leave onchain.
       '';
     };
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.clboss;
+      description = "The package providing clboss binaries.";
+    };
   };
 
   config = mkIf cfg.enable {
     services.clightning.extraConfig = ''
-      plugin=${config.nix-bitcoin.pkgs.clboss}/bin/clboss
+      plugin=${cfg.package}/bin/clboss
       clboss-min-onchain=${toString cfg.min-onchain}
     '';
     systemd.services.clightning.path = [

--- a/pkgs/clboss/default.nix
+++ b/pkgs/clboss/default.nix
@@ -5,11 +5,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "clboss";
-  version = "0.10";
+  version = "0.11A";
 
   src = fetchurl {
-    url = "https://github.com/ZmnSCPxj/clboss/releases/download/v${version}/clboss-${version}.tar.gz";
-    sha256 = "1bmlpfhsjs046qx2ikln15rj4kal32752zs1s5yjklsq9xwnbciz";
+    url = "https://github.com/ZmnSCPxj/clboss/releases/download/${version}/clboss-${version}.tar.gz";
+    sha256 = "1vxa1f3jwlybdca2da73a1fnqy55c4ipwwysvkhy74sw5b4q905g";
   };
 
   nativeBuildInputs = [ pkgconfig libev curlWithGnuTLS sqlite ];

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -47,7 +47,10 @@ let
       test.data.clightning-plugins = let
         plugins = config.services.clightning.plugins;
         enabled = builtins.filter (plugin: plugins.${plugin}.enable) (builtins.attrNames plugins);
-        pluginPkgs = config.nix-bitcoin.pkgs.clightning-plugins;
+        nbPkgs = config.nix-bitcoin.pkgs;
+        pluginPkgs = nbPkgs.clightning-plugins // {
+          clboss.path = "${nbPkgs.clboss}/bin/clboss";
+        };
       in map (plugin: pluginPkgs.${plugin}.path) enabled;
 
       tests.spark-wallet = cfg.spark-wallet.enable;
@@ -95,7 +98,7 @@ let
     }
     (mkIf config.test.features.clightningPlugins {
       services.clightning.plugins = {
-        # TODO: add clboss when https://github.com/ZmnSCPxj/clboss/issues/49 is closed
+        clboss.enable = true;
         helpme.enable = true;
         monitor.enable = true;
         prometheus.enable = true;


### PR DESCRIPTION
CLBOSS 0.10 pays an enormous amount in rebalancing fees, which appears to be fixed in CLBOSS 0.11A. It is only a pre-release and apparently has a bug [that prevents rebalancing](https://github.com/ZmnSCPxj/clboss/blob/master/ChangeLog). Hopefully we don't have to wait very long for a new release soon (ping @zmnscpxj :]). The new module option allowing custom packages will help users to run CLBOSS master or test specific PRs.
