### PR TITLE
Update nixpkgs, fix lnd module to work with 0.13.0

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -198,7 +198,7 @@ in {
         RestartSec = "10s";
         ReadWritePaths = cfg.dataDir;
         ExecStartPost = let
-          curl = "${pkgs.curl}/bin/curl -s --show-error";
+          curl = "${pkgs.curl}/bin/curl -s --show-error --retry 10";
           restUrl = "https://${cfg.restAddress}:${toString cfg.restPort}/v1";
         in [
           (nbLib.script "lnd-create-wallet" ''

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,11 +8,11 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "dc326c78a93862efb30a76216f527a56496e6284";
-    sha256 = "094zb1p5i5f2nlxny3dc814jvs90nimdj6wwd80495hgs9z76wgp";
+    rev = "69f3a9705014ce75b0489404210995fb6f29836e";
+    sha256 = "12rspv54fclh4lsry7jxhg6bidbpvzm14f88wbg7rn7ql1bb4rjc";
   };
   nixpkgs-unstable = fetch {
-    rev = "4518794ee53d109d551c210a6d195b79e9995a90";
-    sha256 = "1h86bqrkiydn5nwpndg8k5apdjxff5qigbrrwfam3893vgb7hws2";
+    rev = "33d42ad7cf2769ce6364ed4e52afa8e9d1439d58";
+    sha256 = "0l8vvfq0zk3wdrgr5wnfkk02yx389ikxjgvf7lka2c7rh7rbgvsz";
   };
 }


### PR DESCRIPTION
* btcpayserver 1.1.1
* nbxplorer 2.1.51
* lnd 0.13.0
* hwi 2.0.2

New lnd version has changed wallet unlocking API ([release notes#RPC](https://github.com/lightningnetwork/lnd/releases/tag/v0.13.0-beta)) so that it now starts sooner but returns `"waiting to start, RPC services not available"` until lnd boots up. There's also a new parameter/config option to [pass path to file with wallet password](https://github.com/lightningnetwork/lnd/blob/master/docs/wallet.md#auto-unlocking-a-wallet). Perhaps it could be used to simplify `lnd-create-wallet` script, for now retrying the RPC with exponential backoff seems to work though. Related: https://github.com/lightningnetwork/lnd/pull/5150