### PR TITLE
BTCPayServer L-BTC Support

### DIFF
--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -61,7 +61,10 @@ in {
       };
       package = mkOption {
         type = types.package;
-        default = nbPkgs.btcpayserver;
+        default = if cfg.btcpayserver.lbtc then
+                    nbPkgs.btcpayserver.override { altcoinSupport = true; }
+                  else
+                    nbPkgs.btcpayserver;
         description = "The package providing btcpayserver binaries.";
       };
       dataDir = mkOption {
@@ -84,6 +87,11 @@ in {
         default = null;
         description = "The lightning node implementation to use.";
       };
+      lbtc = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Enable liquid support in btcpayserver.";
+      };
       rootpath = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -98,6 +106,7 @@ in {
     services.bitcoind.enable = true;
     services.clightning.enable = mkIf (cfg.btcpayserver.lightningBackend == "clightning") true;
     services.lnd.enable = mkIf (cfg.btcpayserver.lightningBackend == "lnd") true;
+    services.liquidd.enable = mkIf cfg.btcpayserver.lbtc true;
 
     services.bitcoind.rpc.users.btcpayserver = {
       passwordHMACFromFile = true;
@@ -135,6 +144,12 @@ in {
         btcnodeendpoint=${config.services.bitcoind.address}:${toString config.services.bitcoind.port}
         bind=${cfg.nbxplorer.address}
         port=${toString cfg.nbxplorer.port}
+        ${optionalString cfg.btcpayserver.lbtc ''
+          chains=btc,lbtc
+          lbtcrpcuser=${cfg.liquidd.rpcuser}
+          lbtcrpcurl=http://${cfg.liquidd.rpc.address}:${toString cfg.liquidd.rpc.port}
+          lbtcnodeendpoint=${cfg.liquidd.address}:${toString cfg.liquidd.port}
+        ''}
       '';
     in {
       wantedBy = [ "multi-user.target" ];
@@ -142,8 +157,12 @@ in {
       after = [ "bitcoind.service" ];
       preStart = ''
         install -m 600 ${configFile} '${cfg.nbxplorer.dataDir}/settings.config'
-        echo "btcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-btcpayserver)" \
-          >> '${cfg.nbxplorer.dataDir}/settings.config'
+        {
+          echo "btcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-btcpayserver)"
+          ${optionalString cfg.btcpayserver.lbtc ''
+            echo "lbtcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/liquid-rpcpassword)"
+          ''}
+        } >> '${cfg.nbxplorer.dataDir}/settings.config'
       '';
       serviceConfig = nbLib.defaultHardening // {
         ExecStart = ''
@@ -159,17 +178,23 @@ in {
     };
 
     systemd.services.btcpayserver = let
+      nbExplorerUrl = "http://${cfg.nbxplorer.address}:${toString cfg.nbxplorer.port}/";
+      nbExplorerCookie = "${cfg.nbxplorer.dataDir}/${config.services.bitcoind.makeNetworkName "Main" "RegTest"}/.cookie";
       configFile = builtins.toFile "config" (''
         network=${config.services.bitcoind.network}
         bind=${cfg.btcpayserver.address}
         port=${toString cfg.btcpayserver.port}
         socksendpoint=${cfg.tor.client.socksListenAddress}
-        btcexplorerurl=http://${cfg.nbxplorer.address}:${toString cfg.nbxplorer.port}/
-        btcexplorercookiefile=${cfg.nbxplorer.dataDir}/${config.services.bitcoind.makeNetworkName "Main" "RegTest"}/.cookie
+        btcexplorerurl=${nbExplorerUrl}
+        btcexplorercookiefile=${nbExplorerCookie}
         postgres=User ID=${cfg.btcpayserver.user};Host=/run/postgresql;Database=btcpaydb
         ${optionalString (cfg.btcpayserver.rootpath != null) "rootpath=${cfg.btcpayserver.rootpath}"}
       '' + optionalString (cfg.btcpayserver.lightningBackend == "clightning") ''
         btclightning=type=clightning;server=unix:///${cfg.clightning.dataDir}/bitcoin/lightning-rpc
+      '' + optionalString cfg.btcpayserver.lbtc ''
+        chains=btc,lbtc
+        lbtcexplorerurl=${nbExplorerUrl}
+        lbtcexplorercookiefile=${nbExplorerCookie}
       '');
       lndConfig =
         "btclightning=type=lnd-rest;" +
@@ -206,7 +231,8 @@ in {
 
     users.users.${cfg.nbxplorer.user} = {
       group = cfg.nbxplorer.group;
-      extraGroups = [ "bitcoinrpc-public" ];
+      extraGroups = [ "bitcoinrpc-public" ]
+                    ++ optional cfg.btcpayserver.lbtc cfg.liquidd.group;
       home = cfg.nbxplorer.dataDir;
     };
     users.groups.${cfg.nbxplorer.group} = {};

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -9,8 +9,10 @@ let
   secretsDir = config.nix-bitcoin.secretsDir;
   pidFile = "${cfg.dataDir}/liquidd.pid";
   configFile = pkgs.writeText "elements.conf" ''
-    chain=liquidv1
-    ${optionalString cfg.testnet "testnet=1"}
+    chain=${config.services.bitcoind.makeNetworkName "liquidv1" ''
+      regtest
+      [regtest]'' # Add [regtest] config section
+    }
     ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
     ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
     ${optionalString (cfg.validatepegin != null) "validatepegin=${if cfg.validatepegin then "1" else "0"}"}
@@ -139,11 +141,6 @@ in {
           type = types.str;
           default = "liquidrpc";
           description = "Username for JSON-RPC connections";
-      };
-      testnet = mkOption {
-        type = types.bool;
-        default = false;
-        description = "Whether to use the test chain.";
       };
       proxy = mkOption {
         type = types.nullOr types.str;

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -230,12 +230,14 @@ in {
       };
       nbxplorer = {
         id = 23;
-        connections = [ "bitcoind" ];
+        connections = [ "bitcoind" ]
+                      ++ optional config.services.btcpayserver.lbtc "liquidd";
       };
       btcpayserver = {
         id = 24;
         connections = [ "nbxplorer" ]
-                      ++ optional (config.services.btcpayserver.lightningBackend == "lnd") "lnd";
+                      ++ optional (config.services.btcpayserver.lightningBackend == "lnd") "lnd"
+                      ++ optional config.services.btcpayserver.lbtc "liquidd";
         # communicates with clightning over rpc socket
       };
       joinmarket = {

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -12,7 +12,7 @@ in
     sha256 = "05v28njaas9l26ibc6vy6imvy7grbkli32bmv0n32x6x9cf68gf9";
   };
   nixpkgs-unstable = fetch {
-    rev = "88e010dcb29ecf70a973c8d57ed175eadf7f42cf";
-    sha256 = "0v6g32yw3cx2qg76idkccayap6lvnhkgnw70isy4vbjd88injmpv";
+    rev = "16105403bdd843540cbef9c63fc0f16c1c6eaa70";
+    sha256 = "0sl6hsxlh14kcs38jcra908nvi5hd8p8hlim3lbra55lz0kd9rcl";
   };
 }

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -183,6 +183,7 @@ let
       imports = [ scenarios.regtestBase ];
       services.clightning.enable = true;
       test.features.clightningPlugins = true;
+      services.liquidd.enable = true;
       services.spark-wallet.enable = true;
       services.lnd.enable = true;
       services.lightning-loop.enable = true;

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -79,7 +79,10 @@ let
       services.liquidd.extraConfig = mkIf config.test.noConnections "connect=0";
 
       tests.btcpayserver = cfg.btcpayserver.enable;
-      services.btcpayserver.lightningBackend = "lnd";
+      services.btcpayserver = {
+        lightningBackend = "lnd";
+        lbtc = true;
+      };
       # Needed to test macaroon creation
       environment.systemPackages = mkIfTest "btcpayserver" (with pkgs; [ openssl xxd ]);
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -210,6 +210,7 @@ def _():
 def _():
     assert_running("nbxplorer")
     machine.wait_until_succeeds(log_has_string("nbxplorer", "BTC: RPC connection successful"))
+    machine.wait_until_succeeds(log_has_string("nbxplorer", "LBTC: RPC connection successful"))
     wait_for_open_port(ip("nbxplorer"), 24444)
     assert_running("btcpayserver")
     machine.wait_until_succeeds(log_has_string("btcpayserver", "Listening on"))
@@ -291,7 +292,7 @@ def _():
     # These reachability tests are non-exhaustive
     assert_reachable("bitcoind", ["clightning", "lnd", "liquidd"])
     assert_unreachable("bitcoind", ["btcpayserver", "spark-wallet", "lightning-loop"])
-    assert_unreachable("btcpayserver", ["bitcoind", "lightning-loop", "liquidd"])
+    assert_unreachable("btcpayserver", ["bitcoind", "lightning-loop"])
 
     # netns addresses can not be bound to in the main netns.
     # This prevents processes in the main netns from impersonating nix-bitcoin services.


### PR DESCRIPTION
Excuse the hackyness of pulling in a custom `nixpkgs-unstable` for the BTCPayServer Altcoin support. I'm working on patching it elegantly upstream.