### PR TITLE
CVE-2021-33909 patch

### DIFF
--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,8 +8,8 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "359e6542e1d41eb18df55c82bdb08bf738fae2cf";
-    sha256 = "05v28njaas9l26ibc6vy6imvy7grbkli32bmv0n32x6x9cf68gf9";
+    rev = "46f9b120e836b8af69782f8ad05c4b78292cd590";
+    sha256 = "1l2dqi6jpgpy3vgb6nakpx3azaryf9qg1470syn7jvpc0aq05l7z";
   };
   nixpkgs-unstable = fetch {
     rev = "88e010dcb29ecf70a973c8d57ed175eadf7f42cf";


### PR DESCRIPTION
Includes fix for [CVE-2021-33909](https://lwn.net/Articles/863586/), a local root vulnerability.