### PR TITLE
Update to NixOS 21.05

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -240,7 +240,7 @@
   # compatible, in order to avoid breaking some software such as database
   # servers. You should change this only after NixOS release notes say you
   # should.
-  system.stateVersion = "18.09"; # Did you read the comment?
+  system.stateVersion = "21.05"; # Did you read the comment?
 
   # The nix-bitcoin release version that your config is compatible with.
   # When upgrading to a backwards-incompatible release, nix-bitcoin will display an

--- a/examples/qemu-vm/vm-config.nix
+++ b/examples/qemu-vm/vm-config.nix
@@ -4,7 +4,7 @@
 
   config = {
     virtualisation.graphics = false;
-    services.mingetty.autologinUser = "root";
+    services.getty.autologinUser = "root";
     users.users.root = {
       openssh.authorizedKeys.keyFiles = [ ./id-vm.pub ];
     };

--- a/modules/backups.nix
+++ b/modules/backups.nix
@@ -82,7 +82,6 @@ in {
       services.postgresqlBackup = {
         enable = true;
         databases = [ "btcpaydb" ];
-        startAt = [];
       };
       systemd.services.duplicity = rec {
         wants = [ "postgresqlBackup-btcpaydb.service" ];

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -193,7 +193,7 @@ in {
       };
       proxy = mkOption {
         type = types.nullOr types.str;
-        default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+        default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
         description = "Connect through SOCKS5 proxy";
       };
       listen = mkOption {

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -388,7 +388,10 @@ in {
       } // nbLib.allowLocalIPAddresses;
     };
 
-    users.users.${cfg.user}.group = cfg.group;
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+    };
     users.groups.${cfg.group} = {};
     users.groups.bitcoinrpc-public = {};
     nix-bitcoin.operator.groups = [ cfg.group ];

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -184,7 +184,7 @@ in {
         network=${config.services.bitcoind.network}
         bind=${cfg.btcpayserver.address}
         port=${toString cfg.btcpayserver.port}
-        socksendpoint=${cfg.tor.client.socksListenAddress}
+        socksendpoint=${config.nix-bitcoin.torClientAddressWithPort}
         btcexplorerurl=${nbExplorerUrl}
         btcexplorercookiefile=${nbExplorerCookie}
         postgres=User ID=${cfg.btcpayserver.user};Host=/run/postgresql;Database=btcpaydb

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -230,6 +230,7 @@ in {
     }; in self;
 
     users.users.${cfg.nbxplorer.user} = {
+      isSystemUser = true;
       group = cfg.nbxplorer.group;
       extraGroups = [ "bitcoinrpc-public" ]
                     ++ optional cfg.btcpayserver.lbtc cfg.liquidd.group;
@@ -237,6 +238,7 @@ in {
     };
     users.groups.${cfg.nbxplorer.group} = {};
     users.users.${cfg.btcpayserver.user} = {
+      isSystemUser = true;
       group = cfg.btcpayserver.group;
       extraGroups = [ cfg.nbxplorer.group ]
                     ++ optional (cfg.btcpayserver.lightningBackend == "clightning") cfg.clightning.user;

--- a/modules/charge-lnd.nix
+++ b/modules/charge-lnd.nix
@@ -133,8 +133,8 @@ in
     };
 
     users.users.${user} = {
-      group = group;
       isSystemUser = true;
+      group = group;
     };
     users.groups.${group} = {};
   };

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -140,6 +140,7 @@ in {
     };
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       extraGroups = [ "bitcoinrpc-public" ];
     };

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -34,7 +34,7 @@ in {
     };
     proxy = mkOption {
       type = types.nullOr types.str;
-      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+      default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
       description = ''
         Socks proxy for connecting to Tor nodes (or for all connections if option always-use-proxy is set).
       '';

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -106,6 +106,7 @@ in {
     };
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       extraGroups = [ "bitcoinrpc-public" ] ++ optionals cfg.high-memory [ bitcoind.user ];
     };

--- a/modules/joinmarket-ob-watcher.nix
+++ b/modules/joinmarket-ob-watcher.nix
@@ -5,7 +5,13 @@ let
   cfg = config.services.joinmarket-ob-watcher;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
-  torAddress = builtins.head (builtins.split ":" config.services.tor.client.socksListenAddress);
+
+  socks5Settings = with config.services.tor.client.socksListenAddress; ''
+    socks5 = true
+    socks5_host = ${addr}
+    socks5_port = ${toString port}
+  '';
+
   configFile = builtins.toFile "config" ''
     [BLOCKCHAIN]
     blockchain_source = no-blockchain
@@ -15,18 +21,14 @@ let
     channel = joinmarket-pit
     port = 6697
     usessl = true
-    socks5 = true
-    socks5_host = ${torAddress}
-    socks5_port = 9050
+    ${socks5Settings}
 
     [MESSAGING:server2]
     host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
     channel = joinmarket-pit
     port = 6667
     usessl = false
-    socks5 = true
-    socks5_host = ${torAddress}
-    socks5_port = 9050
+    ${socks5Settings}
   '';
 in {
   options.services.joinmarket-ob-watcher = {

--- a/modules/joinmarket-ob-watcher.nix
+++ b/modules/joinmarket-ob-watcher.nix
@@ -80,6 +80,7 @@ in {
           ${nbPkgs.joinmarket}/bin/ob-watcher --datadir=${cfg.dataDir} \
             --host=${cfg.address} --port=${toString cfg.port}
         '';
+        SystemCallFilter = nbLib.defaultHardening.SystemCallFilter ++ [ "mbind" ] ;
         Restart = "on-failure";
         RestartSec = "10s";
       } // nbLib.allowTor;

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -10,7 +10,14 @@ let
   runAsUser = config.nix-bitcoin.runAsUserCmd;
 
   inherit (config.services) bitcoind;
-  torAddress = builtins.head (builtins.split ":" config.services.tor.client.socksListenAddress);
+
+  torAddress = config.services.tor.client.socksListenAddress;
+  socks5Settings = ''
+    socks5 = true
+    socks5_host = ${torAddress.addr}
+    socks5_port = ${toString torAddress.port}
+  '';
+
   # Based on https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/jmclient/jmclient/configure.py
   yg = cfg.yieldgenerator;
   configFile = builtins.toFile "config" ''
@@ -34,18 +41,14 @@ let
     channel = joinmarket-pit
     port = 6697
     usessl = true
-    socks5 = true
-    socks5_host = ${torAddress}
-    socks5_port = 9050
+    ${socks5Settings}
 
     [MESSAGING:server2]
     host = ncwkrwxpq2ikcngxq3dy2xctuheniggtqeibvgofixpzvrwpa77tozqd.onion
     channel = joinmarket-pit
     port = 6667
     usessl = false
-    socks5 = true
-    socks5_host = ${torAddress}
-    socks5_port = 9050
+    ${socks5Settings}
 
     [LOGGING]
     console_log_level = INFO
@@ -72,8 +75,8 @@ let
     disable_output_substitution = 0
     max_additional_fee_contribution = default
     min_fee_rate = 1.1
-    onion_socks5_host = ${torAddress}
-    onion_socks5_port = 9050
+    onion_socks5_host = ${torAddress.addr}
+    onion_socks5_port = ${toString torAddress.port}
     tor_control_host = unix:/run/tor/control
     hidden_service_ssl = false
 

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -270,6 +270,7 @@ in {
     };
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       home = cfg.dataDir;
       # Allow access to the tor control socket, needed for payjoin onion service creation

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -60,7 +60,7 @@ in {
     };
     proxy = mkOption {
       type = types.nullOr types.str;
-      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+      default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
       description = "host:port of SOCKS5 proxy for connnecting to the loop server.";
     };
     extraConfig = mkOption {

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -54,7 +54,7 @@ in {
     };
     proxy = mkOption {
       type = types.nullOr types.str;
-      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+      default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
       description = "host:port of SOCKS5 proxy for connnecting to the pool auction server.";
     };
     extraConfig = mkOption {

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -240,6 +240,7 @@ in {
     };
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       extraGroups = [ "bitcoinrpc-public" ];
     };

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -144,7 +144,7 @@ in {
       };
       proxy = mkOption {
         type = types.nullOr types.str;
-        default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+        default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
         description = "Connect through SOCKS5 proxy";
       };
       listen = mkOption {

--- a/modules/lnd-rest-onion-service.nix
+++ b/modules/lnd-rest-onion-service.nix
@@ -40,8 +40,9 @@ in {
   config = mkIf cfg.enable {
     services.tor = {
       enable = true;
-      hiddenServices.lnd-rest = nbLib.mkHiddenService {
-        toHost = lnd.restAddress;
+      relay.onionServices.lnd-rest = nbLib.mkOnionService {
+        target.addr = lnd.restAddress;
+        target.port = lnd.restPort;
         port = lnd.restPort;
       };
     };

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -83,7 +83,7 @@ in {
     };
     tor-socks = mkOption {
       type = types.nullOr types.str;
-      default = if cfg.enforceTor then config.services.tor.client.socksListenAddress else null;
+      default = if cfg.enforceTor then config.nix-bitcoin.torClientAddressWithPort else null;
       description = "Socks proxy for connecting to Tor nodes";
     };
     macaroons = mkOption {

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -263,6 +263,7 @@ in {
     };
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       extraGroups = [ "bitcoinrpc-public" ];
       home = cfg.dataDir; # lnd creates .lnd dir in HOME

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -49,13 +49,19 @@ with lib;
         default = import ../pkgs/lib.nix lib pkgs;
       };
 
+      torClientAddressWithPort = mkOption {
+        readOnly = true;
+        default =  with config.services.tor.client.socksListenAddress;
+          "${addr}:${toString port}";
+      };
+
       # Torify binary that works with custom Tor SOCKS addresses
       # Related issue: https://github.com/NixOS/nixpkgs/issues/94236
       torify = mkOption {
         readOnly = true;
         default = pkgs.writeScriptBin "torify" ''
           ${pkgs.tor}/bin/torify \
-            --address ${head (splitString ":" config.services.tor.client.socksListenAddress)} \
+            --address ${config.services.tor.client.socksListenAddress.addr} \
             "$@"
         '';
       };

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -70,7 +70,8 @@ with lib;
       runAsUserCmd = mkOption {
         readOnly = true;
         default = if config.security.doas.enable
-                  then "doas -u"
+                  # TODO: Use absolute path until https://github.com/NixOS/nixpkgs/pull/133622 is available.
+                  then "/run/wrappers/bin/doas -u"
                   else "sudo -u";
       };
     };

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -97,8 +97,13 @@ in {
   # Base infrastructure
   {
     networking.dhcpcd.denyInterfaces = [ "nb-br" "nb-veth*" ];
-    services.tor.client.socksListenAddress = "${bridgeIp}:9050";
-    networking.firewall.interfaces.nb-br.allowedTCPPorts = [ 9050 ];
+    services.tor.client.socksListenAddress = {
+      addr = bridgeIp;
+      # Default NixOS values. These must be repeated when redefining this option.
+      port = 9050;
+      IsolateDestAddr = true;
+    };
+    networking.firewall.interfaces.nb-br.allowedTCPPorts = [ config.services.tor.client.socksListenAddress.port ];
     boot.kernel.sysctl."net.ipv4.ip_forward" = true;
 
     security.wrappers.netns-exec = {

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -95,12 +95,12 @@ let
     '';
 
    mkIfOnionPort = name: fn:
-     if hiddenServices ? ${name} then
-       fn (toString (builtins.elemAt hiddenServices.${name}.map 0).port)
+     if onionServices ? ${name} then
+       fn (toString (builtins.elemAt onionServices.${name}.map 0).port)
      else
        "";
 
-  inherit (config.services.tor) hiddenServices;
+   inherit (config.services.tor.relay) onionServices;
 in {
   options = {
     nix-bitcoin.nodeinfo = {

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -57,14 +57,14 @@ in {
       # Define hidden services
       services.tor = {
         enable = true;
-        hiddenServices = genAttrs activeServices (name:
+        relay.onionServices = genAttrs activeServices (name:
           let
             service = config.services.${name};
             inherit (cfg.${name}) externalPort;
-          in nbLib.mkHiddenService {
+          in nbLib.mkOnionService {
             port = if externalPort != null then externalPort else service.port;
-            toPort = service.port;
-            toHost = if service.address == "0.0.0.0" then "127.0.0.1" else service.address;
+            target.port = service.port;
+            target.addr = if service.address == "0.0.0.0" then "127.0.0.1" else service.address;
           }
         );
       };

--- a/modules/presets/hardened.nix
+++ b/modules/presets/hardened.nix
@@ -9,6 +9,6 @@
   # Needed for sandboxed builds and services
   security.allowUserNamespaces = true;
 
-  # The "scudo" allocator is broken on NixOS 20.09
+  # The "scudo" allocator is broken on NixOS >= 20.09
   environment.memoryAllocator.provider = "libc";
 }

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -29,7 +29,7 @@ in {
     ];
 
     # sshd
-    services.tor.hiddenServices.sshd = nbLib.mkHiddenService { port = 22; };
+    services.tor.relay.onionServices.sshd = nbLib.mkOnionService { port = 22; };
     nix-bitcoin.onionAddresses.access.${operatorName} = [ "sshd" ];
 
     services.bitcoind = {

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -18,7 +18,7 @@ in {
 
     networking.firewall.enable = true;
 
-    nix-bitcoin.security.hideProcessInformation = true;
+    nix-bitcoin.security.dbusHideProcessInformation = true;
 
     # Use doas instead of sudo
     security.doas.enable = true;

--- a/modules/recurring-donations.nix
+++ b/modules/recurring-donations.nix
@@ -97,6 +97,7 @@ in {
     };
 
     users.users.recurring-donations = {
+      isSystemUser = true;
       group = "recurring-donations";
       extraGroups = [ config.services.clightning.group ];
     };

--- a/modules/recurring-donations.nix
+++ b/modules/recurring-donations.nix
@@ -11,7 +11,7 @@ let
       NAME=$1
       AMOUNT=$2
       echo Attempting to pay $AMOUNT sat to $NAME
-      INVOICE=$(curl --socks5-hostname ${config.services.tor.client.socksListenAddress} -d "satoshi_amount=$AMOUNT&payment_method=ln&id=$NAME&type=profile" -X POST https://api.tallyco.in/v1/payment/request/ | jq -r '.lightning_pay_request') 2> /dev/null
+      INVOICE=$(curl --socks5-hostname ${config.nix-bitcoin.torClientAddressWithPort} -d "satoshi_amount=$AMOUNT&payment_method=ln&id=$NAME&type=profile" -X POST https://api.tallyco.in/v1/payment/request/ | jq -r '.lightning_pay_request') 2> /dev/null
       if [ -z "$INVOICE" ] || [ "$INVOICE" = "null" ]; then
         echo "ERROR: did not get invoice from tallycoin"
         return

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -65,6 +65,7 @@ in {
     services.clightning.enable = true;
 
     users.users.${cfg.user} = {
+      isSystemUser = true;
       group = cfg.group;
       extraGroups = [ config.services.clightning.group ];
     };

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -8,7 +8,7 @@ let
 
   # Use wasabi rate provider because the default (bitstamp) doesn't accept
   # connections through Tor
-  torRateProvider = "--rate-provider wasabi --proxy socks5h://${config.services.tor.client.socksListenAddress}";
+  torRateProvider = "--rate-provider wasabi --proxy socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
   startScript = ''
     ${optionalString (cfg.getPublicAddressCmd != "") ''
       publicURL="--public-url http://$(${cfg.getPublicAddressCmd})"

--- a/pkgs/clightning-plugins/default.nix
+++ b/pkgs/clightning-plugins/default.nix
@@ -17,7 +17,7 @@ let
     monitor = {};
     prometheus = {
       extraPkgs = [ prometheus_client ];
-      patchRequirements = "--replace prometheus-client==0.6.0 prometheus-client==0.8.0";
+      patchRequirements = "--replace prometheus-client==0.6.0 prometheus-client==0.9.0";
     };
     rebalance = {};
     summary = {

--- a/pkgs/extra-container/default.nix
+++ b/pkgs/extra-container/default.nix
@@ -4,11 +4,11 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
-  version = "0.6";
+  version = "0.7";
 
   src = builtins.fetchTarball {
     url = "https://github.com/erikarvstedt/extra-container/archive/${version}.tar.gz";
-    sha256 = "0hm4xfjbqjrrq7n1pkbs33lpw9k5q3ms3psprqhfsxkkwzy78zlm";
+    sha256 = "1hcbi611vm0kn8rl7q974wcjkihpddan6m3p7hx8l8jnv18ydng8";
   };
 
   buildCommand = ''

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -80,7 +80,7 @@ let self = {
     default = "exec";
   };
 
-  mkHiddenService = map: {
+  mkOnionService = map: {
     map = [ map ];
     version = 3;
   };

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -17,9 +17,8 @@ let self = {
       ProtectKernelModules = "true";
       ProtectKernelLogs = "true";
       ProtectClock = "true";
-      # Test and enable these when systemd v247 is available
-      # ProtectProc = "invisible";
-      # ProcSubset = "pid";
+      ProtectProc = "invisible";
+      ProcSubset = "pid";
       ProtectControlGroups = "true";
       RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";
       RestrictNamespaces = "true";

--- a/pkgs/nixpkgs-pinned.nix
+++ b/pkgs/nixpkgs-pinned.nix
@@ -8,8 +8,9 @@ in
 {
   # To update, run ../helper/fetch-channel REV
   nixpkgs = fetch {
-    rev = "359e6542e1d41eb18df55c82bdb08bf738fae2cf";
-    sha256 = "05v28njaas9l26ibc6vy6imvy7grbkli32bmv0n32x6x9cf68gf9";
+    # nixos-21.05 (2021-08-03)
+    rev = "d4590d21006387dcb190c516724cb1e41c0f8fdf";
+    sha256 = "17q39hlx1x87xf2rdygyimj8whdbx33nzszf4rxkc6b85wz0l38n";
   };
   nixpkgs-unstable = fetch {
     rev = "16105403bdd843540cbef9c63fc0f16c1c6eaa70";

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -21,6 +21,8 @@ in
     lightning-loop
     lightning-pool;
 
+  inherit nixpkgsStable nixpkgsUnstable;
+
   stable = nixBitcoinPkgsStable;
   unstable = nixBitcoinPkgsUnstable;
 }

--- a/pkgs/spark-wallet/composition.nix
+++ b/pkgs/spark-wallet/composition.nix
@@ -6,7 +6,8 @@
 
 let
   nodeEnv = import "${toString pkgs.path}/pkgs/development/node-packages/node-env.nix" {
-    inherit (pkgs) stdenv python2 utillinux runCommand writeTextFile;
+    inherit pkgs;
+    inherit (pkgs) lib stdenv python2 runCommand writeTextFile;
     inherit nodejs;
     libtool = if pkgs.stdenv.isDarwin then pkgs.darwin.cctools else null;
   };

--- a/test/lib/make-test-vm.nix
+++ b/test/lib/make-test-vm.nix
@@ -10,36 +10,16 @@ args:
 let
   test = pythonTesting.makeTest args;
 
-  fixedDriver = test.driver.overrideAttrs (old: let
-    # Allow the test script to have longer lines by fixing the call to the 'black'
-    # code formatter.
-    # The default width of 88 chars is too restrictive for our script.
-    parts = builtins.split ''/nix/store/[^ ]+/black '' old.buildCommand;
-    preMatch = builtins.elemAt parts 0;
-    postMatch = builtins.elemAt parts 2;
-  in {
-    # See `mkDriver` in nixpkgs/nixos/lib/testing-python.nix for the original definition of `buildCommand`
-    buildCommand = ''
-      ${preMatch}${pkgs.python3Packages.black}/bin/black --line-length 100 ${postMatch}
-    '';
-    # Keep reference to the `testDriver` derivation, required by `buildCommand`
-    testDriverReference = old.buildCommand;
-  });
-
-  # 1. Use fixed driver
-  # 2. Save test logging output
-  # 3. Add link to driver so that a gcroot to a test prevents the driver from
+  # 1. Save test logging output
+  # 2. Add link to driver so that a gcroot to a test prevents the driver from
   #    being garbage-collected
   fixedTest = test.overrideAttrs (_: {
     # See `runTests` in nixpkgs/nixos/lib/testing-python.nix for the original definition of `buildCommand`
     buildCommand = ''
       mkdir $out
-      LOGFILE=$out/output.xml tests='exec(os.environ["testScript"])' ${fixedDriver}/bin/nixos-test-driver
-      ln -s ${fixedDriver} $out/driver
+      LOGFILE=$out/output.xml tests='exec(os.environ["testScript"])' ${test.driver}/bin/nixos-test-driver
+      ln -s ${test.driver} $out/driver
     '';
-  }) // {
-    driver = fixedDriver;
-    inherit (test) nodes;
-  };
+  });
 in
   fixedTest

--- a/test/lib/make-test.nix
+++ b/test/lib/make-test.nix
@@ -69,7 +69,7 @@ name: testConfig:
       "${toString pkgs.path}/nixos/modules/virtualisation/qemu-vm.nix"
     ];
     virtualisation.graphics = false;
-    services.mingetty.autologinUser = "root";
+    services.getty.autologinUser = "root";
 
     # Provide a shortcut for instant poweroff from within the machine
     environment.systemPackages = with pkgs; [

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -106,6 +106,9 @@ let
       systemd.services.setup-secrets.preStart = mkIfTest "security" ''
         install -D -o nobody -g nogroup -m777 <(:) /secrets/dummy
       '';
+
+      # Avoid timeout failures on slow CI nodes
+      systemd.services.postgresql.serviceConfig.TimeoutStartSec = "3min";
     }
     (mkIf config.test.features.clightningPlugins {
       services.clightning.plugins = {

--- a/test/tests.py
+++ b/test/tests.py
@@ -239,7 +239,7 @@ def _():
 @test("joinmarket-yieldgenerator")
 def _():
     machine.wait_until_succeeds(
-        log_has_string("joinmarket-yieldgenerator", "Critical error updating blockheight.",)
+        log_has_string("joinmarket-yieldgenerator", "Critical error updating blockheight.")
     )
 
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 import json
 
+logger = machine.logger
 
 def succeed(*cmds):
     """Returns the concatenated output of all cmds"""
@@ -39,7 +40,7 @@ def wait_for_open_port(address, port):
         status, _ = machine.execute(f"nc -z {address} {port}")
         return status == 0
 
-    with log.nested(f"Waiting for TCP port {address}:{port}"):
+    with logger.nested(f"Waiting for TCP port {address}:{port}"):
         retry(is_port_open)
 
 
@@ -66,7 +67,7 @@ def run_tests():
         raise RuntimeError(f"The following tests are enabled but not defined: {enabled}")
     machine.connect()  # Visually separate boot output from the test output
     for test in to_run:
-        with log.nested(f"test: {test}"):
+        with logger.nested(f"test: {test}"):
             tests[test]()
 
 
@@ -150,9 +151,9 @@ def _():
                 f"Output of 'lightning-cli plugin list':\n{plugin_list}"
             )
         else:
-            log.log("Active clightning plugins:")
+            logger.log("Active clightning plugins:")
             for p in test_data["clightning-plugins"]:
-                log.log(os.path.basename(p))
+                logger.log(os.path.basename(p))
 
 
 @test("lnd")

--- a/test/tests.py
+++ b/test/tests.py
@@ -271,9 +271,9 @@ def _():
 
     if "joinmarket" in enabled_tests:
         # netns-exec should drop capabilities
-        assert_full_match(
+        assert_matches(
             "runuser -u operator -- netns-exec nb-joinmarket capsh --print | grep Current",
-            "Current: =\n",
+            re.compile("^Current: =$", re.MULTILINE),
         )
 
     if "clightning" in enabled_tests:

--- a/test/tests.py
+++ b/test/tests.py
@@ -85,9 +85,6 @@ def _():
     succeed('[[ $(stat -c "%U:%G %a" /secrets/dummy) = "root:root 440" ]]')
 
     if "secure-node" in enabled_tests:
-        # Access to '/proc' should be restricted
-        machine.succeed("grep -Fq hidepid=2 /proc/mounts")
-
         machine.wait_for_unit("bitcoind")
         # `systemctl status` run by unprivileged users shouldn't leak cgroup info
         assert_matches(
@@ -96,7 +93,6 @@ def _():
         )
         # The 'operator' with group 'proc' has full access
         assert_full_match("runuser -u operator -- systemctl status bitcoind 2>&1 >/dev/null", "")
-
 
 @test("bitcoind")
 def _():


### PR DESCRIPTION
### Commit `security: update /proc restriction mechanism`

@nixbitcoin, you might want to update https://github.com/systemd/systemd/issues/16825:
`systemctl status` still leaks process infos to services running with `ProtectProc`.

### Commit `joinmarket-ob-watcher: allow required 'mbind' system call`

We're disabling `mbind` as suggested by the [docker seccomp blacklist](https://docs.docker.com/engine/security/seccomp/).
But [`mbind`](https://man7.org/linux/man-pages/man2/mbind.2.html) seems to be safe for use in unprivileged processes.
Shouldn't we just allow it in general?

### extra-container

You can use the following to audit the `extra-container` update:

```
tmp=$(mktemp -d -p /tmp)
mkdir -p $tmp/{old,new}
fetchAndCheck() {
    local url=https://github.com/erikarvstedt/extra-container/archive/$1.tar.gz
    curl -sSL $url | tar xz --strip-components=1 -C $2;
    echo "sha256 for $1 is $(nix hash-path --base32 "$2")"
}
fetchAndCheck 0.6 $tmp/old
fetchAndCheck 0.7 $tmp/new
git diff --no-index $tmp/{old,new}
rm -rf $tmp
```