### PR TITLE
run-tests: Fix 'eval' command for newer versions of nix

### DIFF
--- a/pkgs/extra-container/default.nix
+++ b/pkgs/extra-container/default.nix
@@ -4,6 +4,7 @@
 
 stdenv.mkDerivation rec {
   pname = "extra-container";
+  # Update this file when changing the version: ../../test/lib/make-container.sh
   version = "0.7";
 
   src = builtins.fetchTarball {

--- a/test/lib/make-container.sh
+++ b/test/lib/make-container.sh
@@ -77,8 +77,8 @@ while [[ $# > 0 ]]; do
 done
 
 containerBin=$(type -P extra-container) || true
-if [[ ! ($containerBin && $(realpath $containerBin) == *extra-container-0.6*) ]]; then
-    echo "Building extra-container. Skip this step by adding extra-container 0.6 to PATH."
+if [[ ! ($containerBin && $(realpath $containerBin) == *extra-container-0.7*) ]]; then
+    echo "Building extra-container. Skip this step by adding extra-container 0.7 to PATH."
     nix-build --out-link /tmp/extra-container "$scriptDir"/../pkgs -A extra-container >/dev/null
     export PATH="/tmp/extra-container/bin${PATH:+:}$PATH"
 fi

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -165,8 +165,7 @@ debug() {
 }
 
 evalTest() {
-    nix eval --raw "($(vmTestNixExpr)).outPath"
-    echo # nix eval doesn't print a newline
+    nix-instantiate --eval -E "($(vmTestNixExpr)).outPath"
 }
 
 instantiate() {


### PR DESCRIPTION
#### Copy of main commit  msg
There's no common `nix` command argument syntax for eval'ing a nix expression that supports both older and newer (flake support) versions of nix.
So fall back to nix-instantiate.