### PR TITLE
Modules formatting

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -43,16 +43,6 @@ let
         default = "/var/lib/bitcoind";
         description = "The data directory for bitcoind.";
       };
-      user = mkOption {
-        type = types.str;
-        default = "bitcoin";
-        description = "The user as which to run bitcoind.";
-      };
-      group = mkOption {
-        type = types.str;
-        default = cfg.user;
-        description = "The group as which to run bitcoind.";
-      };
       rpc = {
         address = mkOption {
           type = types.str;
@@ -220,6 +210,16 @@ let
         default = null;
         example = "bech32";
         description = "The type of addresses to use";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "bitcoin";
+        description = "The user as which to run bitcoind.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.user;
+        description = "The group as which to run bitcoind.";
       };
       cli = mkOption {
         readOnly = true;

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -1,12 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services;
-  nbLib = config.nix-bitcoin.lib;
-  nbPkgs = config.nix-bitcoin.pkgs;
-in {
   options.services = {
     nbxplorer = {
       package = mkOption {
@@ -101,6 +96,12 @@ in {
       enforceTor = nbLib.enforceTor;
     };
   };
+
+  cfg = config.services;
+  nbLib = config.nix-bitcoin.lib;
+  nbPkgs = config.nix-bitcoin.pkgs;
+in {
+  inherit options;
 
   config = mkIf cfg.btcpayserver.enable {
     services.bitcoind.enable = true;

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -67,16 +67,6 @@ let
         default = "/var/lib/btcpayserver";
         description = "The data directory for btcpayserver.";
       };
-      user = mkOption {
-        type = types.str;
-        default = "btcpayserver";
-        description = "The user as which to run btcpayserver.";
-      };
-      group = mkOption {
-        type = types.str;
-        default = cfg.btcpayserver.user;
-        description = "The group as which to run btcpayserver.";
-      };
       lightningBackend = mkOption {
         type = types.nullOr (types.enum [ "clightning" "lnd" ]);
         default = null;
@@ -92,6 +82,16 @@ let
         default = null;
         example = "btcpayserver";
         description = "The prefix for root-relative btcpayserver URLs.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "btcpayserver";
+        description = "The user as which to run btcpayserver.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.btcpayserver.user;
+        description = "The group as which to run btcpayserver.";
       };
       enforceTor = nbLib.enforceTor;
     };

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -100,6 +100,8 @@ let
   cfg = config.services;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
+
+  bitcoind = config.services.bitcoind;
 in {
   inherit options;
 
@@ -139,10 +141,10 @@ in {
 
     systemd.services.nbxplorer = let
       configFile = builtins.toFile "config" ''
-        network=${config.services.bitcoind.network}
+        network=${bitcoind.network}
         btcrpcuser=${cfg.bitcoind.rpc.users.btcpayserver.name}
-        btcrpcurl=http://${config.services.bitcoind.rpc.address}:${toString cfg.bitcoind.rpc.port}
-        btcnodeendpoint=${config.services.bitcoind.address}:${toString config.services.bitcoind.port}
+        btcrpcurl=http://${bitcoind.rpc.address}:${toString cfg.bitcoind.rpc.port}
+        btcnodeendpoint=${bitcoind.address}:${toString bitcoind.port}
         bind=${cfg.nbxplorer.address}
         port=${toString cfg.nbxplorer.port}
         ${optionalString cfg.btcpayserver.lbtc ''
@@ -180,9 +182,9 @@ in {
 
     systemd.services.btcpayserver = let
       nbExplorerUrl = "http://${cfg.nbxplorer.address}:${toString cfg.nbxplorer.port}/";
-      nbExplorerCookie = "${cfg.nbxplorer.dataDir}/${config.services.bitcoind.makeNetworkName "Main" "RegTest"}/.cookie";
+      nbExplorerCookie = "${cfg.nbxplorer.dataDir}/${bitcoind.makeNetworkName "Main" "RegTest"}/.cookie";
       configFile = builtins.toFile "config" (''
-        network=${config.services.bitcoind.network}
+        network=${bitcoind.network}
         bind=${cfg.btcpayserver.address}
         port=${toString cfg.btcpayserver.port}
         socksendpoint=${config.nix-bitcoin.torClientAddressWithPort}

--- a/modules/charge-lnd.nix
+++ b/modules/charge-lnd.nix
@@ -69,6 +69,7 @@ let
 
   cfg = config.services.charge-lnd;
   nbLib = config.nix-bitcoin.lib;
+
   lnd = config.services.lnd;
   electrs = if (config.services ? electrs) && config.services.electrs.enable
             then config.services.electrs
@@ -77,7 +78,6 @@ let
   user = "charge-lnd";
   group = user;
   dataDir = "/var/lib/charge-lnd";
-
   configFile = builtins.toFile "charge-lnd.config" cfg.policies;
   checkedConfig = pkgs.runCommandNoCC "charge-lnd-checked.config" { } ''
     ${config.nix-bitcoin.pkgs.charge-lnd}/bin/charge-lnd --check --config ${configFile}

--- a/modules/charge-lnd.nix
+++ b/modules/charge-lnd.nix
@@ -1,26 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.charge-lnd;
-  nbLib = config.nix-bitcoin.lib;
-  lnd = config.services.lnd;
-  electrs = if (config.services ? electrs) && config.services.electrs.enable
-            then config.services.electrs
-            else null;
-
-  user = "charge-lnd";
-  group = user;
-  dataDir = "/var/lib/charge-lnd";
-
-  configFile = builtins.toFile "charge-lnd.config" cfg.policies;
-  checkedConfig = pkgs.runCommandNoCC "charge-lnd-checked.config" { } ''
-    ${config.nix-bitcoin.pkgs.charge-lnd}/bin/charge-lnd --check --config ${configFile}
-    cp ${configFile} $out
-  '';
-in
-{
   options.services.charge-lnd = with types; {
     enable = mkEnableOption "charge-lnd, policy-based fee manager";
 
@@ -85,6 +66,26 @@ in
       '';
     };
   };
+
+  cfg = config.services.charge-lnd;
+  nbLib = config.nix-bitcoin.lib;
+  lnd = config.services.lnd;
+  electrs = if (config.services ? electrs) && config.services.electrs.enable
+            then config.services.electrs
+            else null;
+
+  user = "charge-lnd";
+  group = user;
+  dataDir = "/var/lib/charge-lnd";
+
+  configFile = builtins.toFile "charge-lnd.config" cfg.policies;
+  checkedConfig = pkgs.runCommandNoCC "charge-lnd-checked.config" { } ''
+    ${config.nix-bitcoin.pkgs.charge-lnd}/bin/charge-lnd --check --config ${configFile}
+    cp ${configFile} $out
+  '';
+in
+{
+  inherit options;
 
   config = mkIf cfg.enable {
     services.lnd = {

--- a/modules/charge-lnd.nix
+++ b/modules/charge-lnd.nix
@@ -1,4 +1,4 @@
-{ config, options, lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -6,7 +6,7 @@ let
   cfg = config.services.charge-lnd;
   nbLib = config.nix-bitcoin.lib;
   lnd = config.services.lnd;
-  electrs = if (options ? services.electrs) && config.services.electrs.enable
+  electrs = if (config.services ? electrs) && config.services.electrs.enable
             then config.services.electrs
             else null;
 

--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -2,6 +2,12 @@
 
 with lib;
 let
+  options.services.clightning.plugins = {
+    helpme.enable = mkEnableOption "Help me (clightning plugin)";
+    monitor.enable = mkEnableOption "Monitor (clightning plugin)";
+    rebalance.enable = mkEnableOption "Rebalance (clightning plugin)";
+  };
+
   cfg = config.services.clightning.plugins;
   pluginPkgs = config.nix-bitcoin.pkgs.clightning-plugins;
 in {
@@ -12,11 +18,7 @@ in {
     ./zmq.nix
   ];
 
-  options.services.clightning.plugins = {
-    helpme.enable = mkEnableOption "Help me (clightning plugin)";
-    monitor.enable = mkEnableOption "Monitor (clightning plugin)";
-    rebalance.enable = mkEnableOption "Rebalance (clightning plugin)";
-  };
+  inherit options;
 
   config = {
     services.clightning.extraConfig = mkMerge [

--- a/modules/clightning-plugins/zmq.nix
+++ b/modules/clightning-plugins/zmq.nix
@@ -2,6 +2,10 @@
 
 with lib;
 let
+  options.services.clightning.plugins.zmq = {
+    enable = mkEnableOption "ZMQ (clightning plugin)";
+  } // lib.genAttrs endpoints mkEndpointOption;
+
   cfg = config.services.clightning.plugins.zmq;
 
   nbLib = config.nix-bitcoin.lib;
@@ -31,9 +35,7 @@ let
     '';
 in
 {
-  options.services.clightning.plugins.zmq = {
-    enable = mkEnableOption "ZMQ (clightning plugin)";
-  } // lib.genAttrs endpoints mkEndpointOption;
+  inherit options;
 
   config = mkIf cfg.enable {
     services.clightning.extraConfig = ''

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -76,6 +76,7 @@ let
   cfg = config.services.clightning;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
+
   network = config.services.bitcoind.makeNetworkName "bitcoin" "regtest";
   configFile = pkgs.writeText "config" ''
     network=${network}

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -1,25 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.clightning;
-  nbLib = config.nix-bitcoin.lib;
-  nbPkgs = config.nix-bitcoin.pkgs;
-  network = config.services.bitcoind.makeNetworkName "bitcoin" "regtest";
-  configFile = pkgs.writeText "config" ''
-    network=${network}
-    bitcoin-datadir=${config.services.bitcoind.dataDir}
-    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
-    always-use-proxy=${boolToString cfg.always-use-proxy}
-    bind-addr=${cfg.address}:${toString cfg.port}
-    bitcoin-rpcconnect=${config.services.bitcoind.rpc.address}
-    bitcoin-rpcport=${toString config.services.bitcoind.rpc.port}
-    bitcoin-rpcuser=${config.services.bitcoind.rpc.users.public.name}
-    rpc-file-mode=0660
-    ${cfg.extraConfig}
-  '';
-in {
   options.services.clightning = {
     enable = mkEnableOption "clightning";
     address = mkOption {
@@ -90,6 +72,25 @@ in {
     };
     inherit (nbLib) enforceTor;
   };
+
+  cfg = config.services.clightning;
+  nbLib = config.nix-bitcoin.lib;
+  nbPkgs = config.nix-bitcoin.pkgs;
+  network = config.services.bitcoind.makeNetworkName "bitcoin" "regtest";
+  configFile = pkgs.writeText "config" ''
+    network=${network}
+    bitcoin-datadir=${config.services.bitcoind.dataDir}
+    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
+    always-use-proxy=${boolToString cfg.always-use-proxy}
+    bind-addr=${cfg.address}:${toString cfg.port}
+    bitcoin-rpcconnect=${config.services.bitcoind.rpc.address}
+    bitcoin-rpcport=${toString config.services.bitcoind.rpc.port}
+    bitcoin-rpcuser=${config.services.bitcoind.rpc.users.public.name}
+    rpc-file-mode=0660
+    ${cfg.extraConfig}
+  '';
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     services.bitcoind = {

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -19,16 +19,6 @@ let
       default = "/var/lib/electrs";
       description = "The data directory for electrs.";
     };
-    user = mkOption {
-      type = types.str;
-      default = "electrs";
-      description = "The user as which to run electrs.";
-    };
-    group = mkOption {
-      type = types.str;
-      default = cfg.user;
-      description = "The group as which to run electrs.";
-    };
     high-memory = mkOption {
       type = types.bool;
       default = false;
@@ -45,6 +35,16 @@ let
       type = types.separatedString " ";
       default = "";
       description = "Extra command line arguments passed to electrs.";
+    };
+    user = mkOption {
+      type = types.str;
+      default = "electrs";
+      description = "The user as which to run electrs.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      description = "The group as which to run electrs.";
     };
     enforceTor = nbLib.enforceTor;
   };

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -2,11 +2,6 @@
 
 with lib;
 let
-  cfg = config.services.electrs;
-  nbLib = config.nix-bitcoin.lib;
-  secretsDir = config.nix-bitcoin.secretsDir;
-  bitcoind = config.services.bitcoind;
-in {
   options.services.electrs = {
     enable = mkEnableOption "electrs";
     address = mkOption {
@@ -53,6 +48,13 @@ in {
     };
     enforceTor = nbLib.enforceTor;
   };
+
+  cfg = config.services.electrs;
+  nbLib = config.nix-bitcoin.lib;
+  secretsDir = config.nix-bitcoin.secretsDir;
+  bitcoind = config.services.bitcoind;
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     assertions = [

--- a/modules/hardware-wallets.nix
+++ b/modules/hardware-wallets.nix
@@ -1,12 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.hardware-wallets;
-  dataDir = "/var/lib/hardware-wallets/";
-  enabled = cfg.ledger || cfg.trezor;
-in {
   options.services.hardware-wallets = {
     ledger = mkOption {
       type = types.bool;
@@ -30,6 +25,12 @@ in {
       '';
     };
   };
+
+  cfg = config.services.hardware-wallets;
+  dataDir = "/var/lib/hardware-wallets/";
+  enabled = cfg.ledger || cfg.trezor;
+in {
+  inherit options;
 
   config = mkMerge [
     (mkIf (cfg.ledger || cfg.trezor) {

--- a/modules/joinmarket-ob-watcher.nix
+++ b/modules/joinmarket-ob-watcher.nix
@@ -2,6 +2,40 @@
 
 with lib;
 let
+  options.services.joinmarket-ob-watcher = {
+    enable = mkEnableOption "JoinMarket orderbook watcher";
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "HTTP server address.";
+    };
+    port = mkOption {
+      type = types.port;
+      default = 62601;
+      description = "HTTP server port.";
+    };
+    dataDir = mkOption {
+      readOnly = true;
+      default = "/var/lib/joinmarket-ob-watcher";
+      description = "The data directory for JoinMarket orderbook watcher.";
+    };
+    user = mkOption {
+      type = types.str;
+      default = "joinmarket-ob-watcher";
+      description = "The user as which to run JoinMarket.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      description = "The group as which to run JoinMarket.";
+    };
+    # This option is only used by netns-isolation
+    enforceTor = mkOption {
+      readOnly = true;
+      default = true;
+    };
+  };
+
   cfg = config.services.joinmarket-ob-watcher;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
@@ -39,39 +73,7 @@ let
     ${socks5Settings}
   '';
 in {
-  options.services.joinmarket-ob-watcher = {
-    enable = mkEnableOption "JoinMarket orderbook watcher";
-    address = mkOption {
-      type = types.str;
-      default = "127.0.0.1";
-      description = "HTTP server address.";
-    };
-    port = mkOption {
-      type = types.port;
-      default = 62601;
-      description = "HTTP server port.";
-    };
-    dataDir = mkOption {
-      readOnly = true;
-      default = "/var/lib/joinmarket-ob-watcher";
-      description = "The data directory for JoinMarket orderbook watcher.";
-    };
-    user = mkOption {
-      type = types.str;
-      default = "joinmarket-ob-watcher";
-      description = "The user as which to run JoinMarket.";
-    };
-    group = mkOption {
-      type = types.str;
-      default = cfg.user;
-      description = "The group as which to run JoinMarket.";
-    };
-    # This option is only used by netns-isolation
-    enforceTor = mkOption {
-      readOnly = true;
-      default = true;
-    };
-  };
+  inherit options;
 
   config = mkIf cfg.enable {
     services.bitcoind.rpc.users.joinmarket-ob-watcher = {

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -1,8 +1,102 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
+  options.services.joinmarket = {
+    enable = mkEnableOption "JoinMarket";
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/joinmarket";
+      description = "The data directory for JoinMarket.";
+    };
+    user = mkOption {
+      type = types.str;
+      default = "joinmarket";
+      description = "The user as which to run JoinMarket.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      description = "The group as which to run JoinMarket.";
+    };
+    rpcWalletFile = mkOption {
+      type = types.nullOr types.str;
+      default = "jm_wallet";
+      description = ''
+        Name of the watch-only bitcoind wallet the JoinMarket addresses are imported to.
+      '';
+    };
+    cli = mkOption {
+      default = cli;
+    };
+    # This option is only used by netns-isolation
+    enforceTor = mkOption {
+      readOnly = true;
+      default = true;
+    };
+    inherit (nbLib) cliExec;
+
+    yieldgenerator = {
+      enable = mkEnableOption "yield generator bot";
+      ordertype = mkOption {
+        type = types.enum [ "reloffer" "absoffer" ];
+        default = "reloffer";
+        description = ''
+          Which fee type to actually use
+        '';
+      };
+      cjfee_a = mkOption {
+        type = types.ints.unsigned;
+        default = 500;
+        description = ''
+          Absolute offer fee you wish to receive for coinjoins (cj) in Satoshis
+        '';
+      };
+      cjfee_r = mkOption {
+        type = types.float;
+        default = 0.00002;
+        description = ''
+          Relative offer fee you wish to receive based on a cj's amount
+        '';
+      };
+      cjfee_factor = mkOption {
+        type = types.float;
+        default = 0.1;
+        description = ''
+          Variance around the average cj fee
+        '';
+      };
+      txfee = mkOption {
+        type = types.ints.unsigned;
+        default = 100;
+        description = ''
+          The average transaction fee you're adding to coinjoin transactions
+        '';
+      };
+      txfee_factor = mkOption {
+        type = types.float;
+        default = 0.3;
+        description = ''
+          Variance around the average tx fee
+        '';
+      };
+      minsize = mkOption {
+        type = types.ints.unsigned;
+        default = 100000;
+        description = ''
+          Minimum size of your cj offer in Satoshis. Lower cj amounts will be disregarded.
+        '';
+      };
+      size_factor = mkOption {
+        type = types.float;
+        default = 0.1;
+        description = ''
+          Variance around all offer sizes
+        '';
+      };
+    };
+  };
+
   cfg = config.services.joinmarket;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
@@ -114,100 +208,7 @@ let
      chmod -R +x $out/bin
    '';
 in {
-  options.services.joinmarket = {
-    enable = mkEnableOption "JoinMarket";
-    dataDir = mkOption {
-      type = types.path;
-      default = "/var/lib/joinmarket";
-      description = "The data directory for JoinMarket.";
-    };
-    user = mkOption {
-      type = types.str;
-      default = "joinmarket";
-      description = "The user as which to run JoinMarket.";
-    };
-    group = mkOption {
-      type = types.str;
-      default = cfg.user;
-      description = "The group as which to run JoinMarket.";
-    };
-    rpcWalletFile = mkOption {
-      type = types.nullOr types.str;
-      default = "jm_wallet";
-      description = ''
-        Name of the watch-only bitcoind wallet the JoinMarket addresses are imported to.
-      '';
-    };
-    cli = mkOption {
-      default = cli;
-    };
-    # This option is only used by netns-isolation
-    enforceTor = mkOption {
-      readOnly = true;
-      default = true;
-    };
-    inherit (nbLib) cliExec;
-
-    yieldgenerator = {
-      enable = mkEnableOption "yield generator bot";
-      ordertype = mkOption {
-        type = types.enum [ "reloffer" "absoffer" ];
-        default = "reloffer";
-        description = ''
-          Which fee type to actually use
-        '';
-      };
-      cjfee_a = mkOption {
-        type = types.ints.unsigned;
-        default = 500;
-        description = ''
-          Absolute offer fee you wish to receive for coinjoins (cj) in Satoshis
-        '';
-      };
-      cjfee_r = mkOption {
-        type = types.float;
-        default = 0.00002;
-        description = ''
-          Relative offer fee you wish to receive based on a cj's amount
-        '';
-      };
-      cjfee_factor = mkOption {
-        type = types.float;
-        default = 0.1;
-        description = ''
-          Variance around the average cj fee
-        '';
-      };
-      txfee = mkOption {
-        type = types.ints.unsigned;
-        default = 100;
-        description = ''
-          The average transaction fee you're adding to coinjoin transactions
-        '';
-      };
-      txfee_factor = mkOption {
-        type = types.float;
-        default = 0.3;
-        description = ''
-          Variance around the average tx fee
-        '';
-      };
-      minsize = mkOption {
-        type = types.ints.unsigned;
-        default = 100000;
-        description = ''
-          Minimum size of your cj offer in Satoshis. Lower cj amounts will be disregarded.
-        '';
-      };
-      size_factor = mkOption {
-        type = types.float;
-        default = 0.1;
-        description = ''
-          Variance around all offer sizes
-        '';
-      };
-    };
-  };
+  inherit options;
 
   config = mkIf cfg.enable (mkMerge [{
     services.bitcoind = {

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -9,6 +9,13 @@ let
       default = "/var/lib/joinmarket";
       description = "The data directory for JoinMarket.";
     };
+    rpcWalletFile = mkOption {
+      type = types.nullOr types.str;
+      default = "jm_wallet";
+      description = ''
+        Name of the watch-only bitcoind wallet the JoinMarket addresses are imported to.
+      '';
+    };
     user = mkOption {
       type = types.str;
       default = "joinmarket";
@@ -18,13 +25,6 @@ let
       type = types.str;
       default = cfg.user;
       description = "The group as which to run JoinMarket.";
-    };
-    rpcWalletFile = mkOption {
-      type = types.nullOr types.str;
-      default = "jm_wallet";
-      description = ''
-        Name of the watch-only bitcoind wallet the JoinMarket addresses are imported to.
-      '';
     };
     cli = mkOption {
       default = cli;

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -1,34 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.lightning-loop;
-  nbLib = config.nix-bitcoin.lib;
-  secretsDir = config.nix-bitcoin.secretsDir;
-
-  lnd = config.services.lnd;
-
-  network = config.services.bitcoind.network;
-  rpclisten = "${cfg.rpcAddress}:${toString cfg.rpcPort}";
-  configFile = builtins.toFile "loop.conf" ''
-    datadir=${cfg.dataDir}
-    network=${network}
-    rpclisten=${rpclisten}
-    restlisten=${cfg.restAddress}:${toString cfg.restPort}
-    logdir=${cfg.dataDir}/logs
-    tlscertpath=${secretsDir}/loop-cert
-    tlskeypath=${secretsDir}/loop-key
-
-    lnd.host=${lnd.rpcAddress}:${toString lnd.rpcPort}
-    lnd.macaroonpath=${lnd.networkDir}/admin.macaroon
-    lnd.tlspath=${lnd.certPath}
-
-    ${optionalString (cfg.proxy != null) "server.proxy=${cfg.proxy}"}
-
-    ${cfg.extraConfig}
-  '';
-in {
   options.services.lightning-loop = {
     enable = mkEnableOption "lightning-loop";
     rpcAddress = mkOption {
@@ -85,6 +58,34 @@ in {
     };
     enforceTor = nbLib.enforceTor;
   };
+
+  cfg = config.services.lightning-loop;
+  nbLib = config.nix-bitcoin.lib;
+  secretsDir = config.nix-bitcoin.secretsDir;
+
+  lnd = config.services.lnd;
+
+  network = config.services.bitcoind.network;
+  rpclisten = "${cfg.rpcAddress}:${toString cfg.rpcPort}";
+  configFile = builtins.toFile "loop.conf" ''
+    datadir=${cfg.dataDir}
+    network=${network}
+    rpclisten=${rpclisten}
+    restlisten=${cfg.restAddress}:${toString cfg.restPort}
+    logdir=${cfg.dataDir}/logs
+    tlscertpath=${secretsDir}/loop-cert
+    tlskeypath=${secretsDir}/loop-key
+
+    lnd.host=${lnd.rpcAddress}:${toString lnd.rpcPort}
+    lnd.macaroonpath=${lnd.networkDir}/admin.macaroon
+    lnd.tlspath=${lnd.certPath}
+
+    ${optionalString (cfg.proxy != null) "server.proxy=${cfg.proxy}"}
+
+    ${cfg.extraConfig}
+  '';
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     services.lnd.enable = true;

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -1,27 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.lightning-pool;
-  nbLib = config.nix-bitcoin.lib;
-
-  lnd = config.services.lnd;
-
-  network = config.services.bitcoind.network;
-  rpclisten = "${cfg.rpcAddress}:${toString cfg.rpcPort}";
-  configFile = builtins.toFile "pool.conf" ''
-    rpclisten=${rpclisten}
-    restlisten=${cfg.restAddress}:${toString cfg.restPort}
-    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
-
-    lnd.host=${lnd.rpcAddress}:${toString lnd.rpcPort}
-    lnd.macaroondir=${lnd.networkDir}
-    lnd.tlspath=${lnd.certPath}
-
-    ${cfg.extraConfig}
-  '';
-in {
   options.services.lightning-pool = {
     enable = mkEnableOption "lightning-pool";
     rpcAddress = mkOption {
@@ -78,6 +58,27 @@ in {
     };
     enforceTor = nbLib.enforceTor;
   };
+
+  cfg = config.services.lightning-pool;
+  nbLib = config.nix-bitcoin.lib;
+
+  lnd = config.services.lnd;
+
+  network = config.services.bitcoind.network;
+  rpclisten = "${cfg.rpcAddress}:${toString cfg.rpcPort}";
+  configFile = builtins.toFile "pool.conf" ''
+    rpclisten=${rpclisten}
+    restlisten=${cfg.restAddress}:${toString cfg.restPort}
+    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
+
+    lnd.host=${lnd.rpcAddress}:${toString lnd.rpcPort}
+    lnd.macaroondir=${lnd.networkDir}
+    lnd.tlspath=${lnd.certPath}
+
+    ${cfg.extraConfig}
+  '';
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     services.lnd.enable = true;

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -3,7 +3,6 @@
 with lib;
 let
   options = {
-
     services.liquidd = {
       enable = mkEnableOption "Liquid sidechain";
       address = mkOption {
@@ -30,16 +29,6 @@ let
         type = types.path;
         default = "/var/lib/liquidd";
         description = "The data directory for liquidd.";
-      };
-      user = mkOption {
-        type = types.str;
-        default = "liquid";
-        description = "The user as which to run liquidd.";
-      };
-      group = mkOption {
-        type = types.str;
-        default = cfg.user;
-        description = "The group as which to run liquidd.";
       };
       rpc = {
         address = mkOption {
@@ -119,6 +108,16 @@ let
         description = ''
           Validate pegin claims. All functionaries must run this.
         '';
+      };
+      user = mkOption {
+        type = types.str;
+        default = "liquid";
+        description = "The user as which to run liquidd.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.user;
+        description = "The group as which to run liquidd.";
       };
       cli = mkOption {
         readOnly = true;

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -1,73 +1,7 @@
 { config, pkgs, lib, ... }:
 
 with lib;
-
 let
-  cfg = config.services.liquidd;
-  nbLib = config.nix-bitcoin.lib;
-  nbPkgs = config.nix-bitcoin.pkgs;
-  secretsDir = config.nix-bitcoin.secretsDir;
-  pidFile = "${cfg.dataDir}/liquidd.pid";
-  configFile = pkgs.writeText "elements.conf" ''
-    chain=${config.services.bitcoind.makeNetworkName "liquidv1" ''
-      regtest
-      [regtest]'' # Add [regtest] config section
-    }
-    ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
-    ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
-    ${optionalString (cfg.validatepegin != null) "validatepegin=${if cfg.validatepegin then "1" else "0"}"}
-
-    # Connection options
-    ${optionalString cfg.listen "bind=${cfg.address}"}
-    port=${toString cfg.port}
-    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
-    listen=${if cfg.listen then "1" else "0"}
-
-    # RPC server options
-    rpcport=${toString cfg.rpc.port}
-    ${concatMapStringsSep  "\n"
-      (rpcUser: "rpcauth=${rpcUser.name}:${rpcUser.passwordHMAC}")
-      (attrValues cfg.rpc.users)
-    }
-    rpcbind=${cfg.rpc.address}
-    rpcconnect=${cfg.rpc.address}
-    ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
-    rpcuser=${cfg.rpcuser}
-    mainchainrpchost=${config.services.bitcoind.rpc.address}
-    mainchainrpcport=${toString config.services.bitcoind.rpc.port}
-    mainchainrpcuser=${config.services.bitcoind.rpc.users.public.name}
-
-    # Extra config options (from liquidd nixos service)
-    ${cfg.extraConfig}
-  '';
-  cmdlineOptions = concatMapStringsSep " " (arg: "'${arg}'") [
-    "-datadir=${cfg.dataDir}"
-    "-pid=${pidFile}"
-  ];
-  hexStr = types.strMatching "[0-9a-f]+";
-  rpcUserOpts = { name, ... }: {
-    options = {
-      name = mkOption {
-        type = types.str;
-        example = "alice";
-        description = ''
-          Username for JSON-RPC connections.
-        '';
-      };
-      passwordHMAC = mkOption {
-        type = with types; uniq (strMatching "[0-9a-f]+\\$[0-9a-f]{64}");
-        example = "f7efda5c189b999524f151318c0c86$d5b51b3beffbc02b724e5d095828e0bc8b2456e9ac8757ae3211a5d9b16a22ae";
-        description = ''
-          Password HMAC-SHA-256 for JSON-RPC connections. Must be a string of the
-          format <SALT-HEX>$<HMAC-HEX>.
-        '';
-      };
-    };
-    config = {
-      name = mkDefault name;
-    };
-  };
-in {
   options = {
 
     services.liquidd = {
@@ -202,6 +136,73 @@ in {
       enforceTor = nbLib.enforceTor;
     };
   };
+
+  cfg = config.services.liquidd;
+  nbLib = config.nix-bitcoin.lib;
+  nbPkgs = config.nix-bitcoin.pkgs;
+  secretsDir = config.nix-bitcoin.secretsDir;
+  pidFile = "${cfg.dataDir}/liquidd.pid";
+  configFile = pkgs.writeText "elements.conf" ''
+    chain=${config.services.bitcoind.makeNetworkName "liquidv1" ''
+      regtest
+      [regtest]'' # Add [regtest] config section
+    }
+    ${optionalString (cfg.dbCache != null) "dbcache=${toString cfg.dbCache}"}
+    ${optionalString (cfg.prune != null) "prune=${toString cfg.prune}"}
+    ${optionalString (cfg.validatepegin != null) "validatepegin=${if cfg.validatepegin then "1" else "0"}"}
+
+    # Connection options
+    ${optionalString cfg.listen "bind=${cfg.address}"}
+    port=${toString cfg.port}
+    ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
+    listen=${if cfg.listen then "1" else "0"}
+
+    # RPC server options
+    rpcport=${toString cfg.rpc.port}
+    ${concatMapStringsSep  "\n"
+      (rpcUser: "rpcauth=${rpcUser.name}:${rpcUser.passwordHMAC}")
+      (attrValues cfg.rpc.users)
+    }
+    rpcbind=${cfg.rpc.address}
+    rpcconnect=${cfg.rpc.address}
+    ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
+    rpcuser=${cfg.rpcuser}
+    mainchainrpchost=${config.services.bitcoind.rpc.address}
+    mainchainrpcport=${toString config.services.bitcoind.rpc.port}
+    mainchainrpcuser=${config.services.bitcoind.rpc.users.public.name}
+
+    # Extra config options (from liquidd nixos service)
+    ${cfg.extraConfig}
+  '';
+  cmdlineOptions = concatMapStringsSep " " (arg: "'${arg}'") [
+    "-datadir=${cfg.dataDir}"
+    "-pid=${pidFile}"
+  ];
+  hexStr = types.strMatching "[0-9a-f]+";
+  rpcUserOpts = { name, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        example = "alice";
+        description = ''
+          Username for JSON-RPC connections.
+        '';
+      };
+      passwordHMAC = mkOption {
+        type = with types; uniq (strMatching "[0-9a-f]+\\$[0-9a-f]{64}");
+        example = "f7efda5c189b999524f151318c0c86$d5b51b3beffbc02b724e5d095828e0bc8b2456e9ac8757ae3211a5d9b16a22ae";
+        description = ''
+          Password HMAC-SHA-256 for JSON-RPC connections. Must be a string of the
+          format <SALT-HEX>$<HMAC-HEX>.
+        '';
+      };
+    };
+    config = {
+      name = mkDefault name;
+    };
+  };
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     services.bitcoind.enable = true;

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -140,9 +140,12 @@ let
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
   secretsDir = config.nix-bitcoin.secretsDir;
+
+  bitcoind = config.services.bitcoind;
+
   pidFile = "${cfg.dataDir}/liquidd.pid";
   configFile = pkgs.writeText "elements.conf" ''
-    chain=${config.services.bitcoind.makeNetworkName "liquidv1" ''
+    chain=${bitcoind.makeNetworkName "liquidv1" ''
       regtest
       [regtest]'' # Add [regtest] config section
     }
@@ -166,9 +169,9 @@ let
     rpcconnect=${cfg.rpc.address}
     ${lib.concatMapStrings (rpcallowip: "rpcallowip=${rpcallowip}\n") cfg.rpcallowip}
     rpcuser=${cfg.rpcuser}
-    mainchainrpchost=${config.services.bitcoind.rpc.address}
-    mainchainrpcport=${toString config.services.bitcoind.rpc.port}
-    mainchainrpcuser=${config.services.bitcoind.rpc.users.public.name}
+    mainchainrpchost=${bitcoind.rpc.address}
+    mainchainrpcport=${toString bitcoind.rpc.port}
+    mainchainrpcuser=${bitcoind.rpc.users.public.name}
 
     # Extra config options (from liquidd nixos service)
     ${cfg.extraConfig}

--- a/modules/lnd-rest-onion-service.nix
+++ b/modules/lnd-rest-onion-service.nix
@@ -1,24 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.lnd.restOnionService;
-  nbLib = config.nix-bitcoin.lib;
-  runAsUser = config.nix-bitcoin.runAsUserCmd;
-
-  lnd = config.services.lnd;
-
-  bin = pkgs.writeScriptBin "lndconnect-rest-onion" ''
-    #!/usr/bin/env -S ${runAsUser} ${lnd.user} ${pkgs.bash}/bin/bash
-
-    exec ${cfg.package}/bin/lndconnect \
-     --host=$(cat ${config.nix-bitcoin.onionAddresses.dataDir}/lnd/lnd-rest) \
-     --port=${toString lnd.restPort} \
-     --lnddir=${lnd.dataDir} \
-     --tlscertpath=${lnd.certPath} "$@"
-  '';
-in {
   options.services.lnd.restOnionService = {
     enable = mkOption {
       default = false;
@@ -35,6 +18,24 @@ in {
       description = "The package providing lndconnect binaries.";
     };
   };
+
+  cfg = config.services.lnd.restOnionService;
+  nbLib = config.nix-bitcoin.lib;
+  runAsUser = config.nix-bitcoin.runAsUserCmd;
+
+  lnd = config.services.lnd;
+
+  bin = pkgs.writeScriptBin "lndconnect-rest-onion" ''
+    #!/usr/bin/env -S ${runAsUser} ${lnd.user} ${pkgs.bash}/bin/bash
+
+    exec ${cfg.package}/bin/lndconnect \
+     --host=$(cat ${config.nix-bitcoin.onionAddresses.dataDir}/lnd/lnd-rest) \
+     --port=${toString lnd.restPort} \
+     --lnddir=${lnd.dataDir} \
+     --tlscertpath=${lnd.certPath} "$@"
+  '';
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     services.tor = {

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -128,6 +128,7 @@ let
   runAsUser = config.nix-bitcoin.runAsUserCmd;
 
   bitcoind = config.services.bitcoind;
+
   bitcoindRpcAddress = bitcoind.rpc.address;
   networkDir = "${cfg.dataDir}/chain/bitcoin/${bitcoind.network}";
   configFile = pkgs.writeText "lnd.conf" ''

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -1,42 +1,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.services.lnd;
-  nbLib = config.nix-bitcoin.lib;
-  secretsDir = config.nix-bitcoin.secretsDir;
-  runAsUser = config.nix-bitcoin.runAsUserCmd;
-
-  bitcoind = config.services.bitcoind;
-  bitcoindRpcAddress = bitcoind.rpc.address;
-  networkDir = "${cfg.dataDir}/chain/bitcoin/${bitcoind.network}";
-  configFile = pkgs.writeText "lnd.conf" ''
-    datadir=${cfg.dataDir}
-    logdir=${cfg.dataDir}/logs
-    tlscertpath=${cfg.certPath}
-    tlskeypath=${secretsDir}/lnd-key
-
-    listen=${toString cfg.address}:${toString cfg.port}
-    rpclisten=${cfg.rpcAddress}:${toString cfg.rpcPort}
-    restlisten=${cfg.restAddress}:${toString cfg.restPort}
-
-    bitcoin.${bitcoind.network}=1
-    bitcoin.active=1
-    bitcoin.node=bitcoind
-
-    ${optionalString (cfg.enforceTor) "tor.active=true"}
-    ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
-
-    bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}
-    bitcoind.rpcuser=${bitcoind.rpc.users.public.name}
-    bitcoind.zmqpubrawblock=${bitcoind.zmqpubrawblock}
-    bitcoind.zmqpubrawtx=${bitcoind.zmqpubrawtx}
-
-    ${cfg.extraConfig}
-  '';
-in {
-
   options.services.lnd = {
     enable = mkEnableOption "Lightning Network Daemon";
     dataDir = mkOption {
@@ -156,6 +121,42 @@ in {
     };
     inherit (nbLib) enforceTor;
   };
+
+  cfg = config.services.lnd;
+  nbLib = config.nix-bitcoin.lib;
+  secretsDir = config.nix-bitcoin.secretsDir;
+  runAsUser = config.nix-bitcoin.runAsUserCmd;
+
+  bitcoind = config.services.bitcoind;
+  bitcoindRpcAddress = bitcoind.rpc.address;
+  networkDir = "${cfg.dataDir}/chain/bitcoin/${bitcoind.network}";
+  configFile = pkgs.writeText "lnd.conf" ''
+    datadir=${cfg.dataDir}
+    logdir=${cfg.dataDir}/logs
+    tlscertpath=${cfg.certPath}
+    tlskeypath=${secretsDir}/lnd-key
+
+    listen=${toString cfg.address}:${toString cfg.port}
+    rpclisten=${cfg.rpcAddress}:${toString cfg.rpcPort}
+    restlisten=${cfg.restAddress}:${toString cfg.restPort}
+
+    bitcoin.${bitcoind.network}=1
+    bitcoin.active=1
+    bitcoin.node=bitcoind
+
+    ${optionalString (cfg.enforceTor) "tor.active=true"}
+    ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
+
+    bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}
+    bitcoind.rpcuser=${bitcoind.rpc.users.public.name}
+    bitcoind.zmqpubrawblock=${bitcoind.zmqpubrawblock}
+    bitcoind.zmqpubrawtx=${bitcoind.zmqpubrawtx}
+
+    ${cfg.extraConfig}
+  '';
+in {
+
+  inherit options;
 
   config = mkIf cfg.enable {
     assertions = [

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -2,6 +2,16 @@
 
 with lib;
 let
+  options = {
+    nix-bitcoin.nodeinfo = {
+      enable = mkEnableOption "nodeinfo";
+      program = mkOption {
+        readOnly = true;
+        default = script;
+      };
+    };
+  };
+
   cfg = config.nix-bitcoin.nodeinfo;
 
   # Services included in the output
@@ -102,15 +112,7 @@ let
 
   inherit (config.services.tor.relay) onionServices;
 in {
-  options = {
-    nix-bitcoin.nodeinfo = {
-      enable = mkEnableOption "nodeinfo";
-      program = mkOption {
-        readOnly = true;
-        default = script;
-      };
-    };
-  };
+  inherit options;
 
   config = {
     environment.systemPackages = optional cfg.enable script;

--- a/modules/onion-addresses.nix
+++ b/modules/onion-addresses.nix
@@ -7,11 +7,7 @@
 { config, lib, ... }:
 
 with lib;
-
 let
-  cfg = config.nix-bitcoin.onionAddresses;
-  nbLib = config.nix-bitcoin.lib;
-in {
   options.nix-bitcoin.onionAddresses = {
     access = mkOption {
       type = with types; attrsOf (listOf str);
@@ -41,6 +37,11 @@ in {
       default = "/var/lib/onion-addresses";
     };
   };
+
+  cfg = config.nix-bitcoin.onionAddresses;
+  nbLib = config.nix-bitcoin.lib;
+in {
+  inherit options;
 
   config = mkIf (cfg.access != {} || cfg.services != []) {
     systemd.services.onion-addresses = {

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -7,19 +7,7 @@
 { config, lib, pkgs, ... }:
 
 with lib;
-
 let
-  cfg = config.nix-bitcoin.onionServices;
-  nbLib = config.nix-bitcoin.lib;
-
-  services = builtins.attrNames cfg;
-
-  activeServices = builtins.filter (service:
-    config.services.${service}.enable && cfg.${service}.enable
-  ) services;
-
-  publicServices = builtins.filter (service: cfg.${service}.public) activeServices;
-in {
   options.nix-bitcoin.onionServices = mkOption {
     default = {};
     type = with types; attrsOf (submodule (
@@ -51,6 +39,19 @@ in {
       }
     ));
   };
+
+  cfg = config.nix-bitcoin.onionServices;
+  nbLib = config.nix-bitcoin.lib;
+
+  services = builtins.attrNames cfg;
+
+  activeServices = builtins.filter (service:
+    config.services.${service}.enable && cfg.${service}.enable
+  ) services;
+
+  publicServices = builtins.filter (service: cfg.${service}.public) activeServices;
+in {
+  inherit options;
 
   config = mkMerge [
     (mkIf (cfg != {}) {

--- a/modules/operator.nix
+++ b/modules/operator.nix
@@ -8,8 +8,6 @@
 
 with lib;
 let
-  cfg = config.nix-bitcoin.operator;
-in {
   options.nix-bitcoin.operator = {
     enable = mkEnableOption "operator user";
     name = mkOption {
@@ -28,6 +26,10 @@ in {
       description = "Users as which the operator is allowed to run commands.";
     };
   };
+
+  cfg = config.nix-bitcoin.operator;
+in {
+  inherit options;
 
   config = mkIf cfg.enable {
     users.users.${cfg.name} = {

--- a/modules/operator.nix
+++ b/modules/operator.nix
@@ -4,7 +4,7 @@
 # When using nix-bitcoin as part of a larger system config, set
 # `nix-bitcoin.operator.name` to your main user name.
 
-{ config, lib, pkgs, options, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 let

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -65,13 +65,6 @@ in {
   config = mkIf cfg.enable {
     services.clightning.enable = true;
 
-    users.users.${cfg.user} = {
-      isSystemUser = true;
-      group = cfg.group;
-      extraGroups = [ config.services.clightning.group ];
-    };
-    users.groups.${cfg.group} = {};
-
     systemd.services.spark-wallet = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "clightning.service" ];
@@ -84,6 +77,13 @@ in {
       } // nbLib.allowedIPAddresses cfg.enforceTor
         // nbLib.nodejs;
     };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      extraGroups = [ config.services.clightning.group ];
+    };
+    users.groups.${cfg.group} = {};
 
     nix-bitcoin.secrets.spark-wallet-login.user = cfg.user;
     nix-bitcoin.generateSecretsCmds.spark-wallet = ''

--- a/modules/spark-wallet.nix
+++ b/modules/spark-wallet.nix
@@ -44,6 +44,8 @@ let
   cfg = config.services.spark-wallet;
   nbLib = config.nix-bitcoin.lib;
 
+  clightning = config.services.clightning;
+
   # Use wasabi rate provider because the default (bitstamp) doesn't accept
   # connections through Tor
   torRateProvider = "--rate-provider wasabi --proxy socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
@@ -52,7 +54,7 @@ let
       publicURL="--public-url http://$(${cfg.getPublicAddressCmd})"
     ''}
     exec ${config.nix-bitcoin.pkgs.spark-wallet}/bin/spark-wallet \
-      --ln-path '${config.services.clightning.networkDir}'  \
+      --ln-path '${clightning.networkDir}'  \
       --host ${cfg.address} --port ${toString cfg.port} \
       --config '${config.nix-bitcoin.secretsDir}/spark-wallet-login' \
       ${optionalString cfg.enforceTor torRateProvider} \
@@ -81,7 +83,7 @@ in {
     users.users.${cfg.user} = {
       isSystemUser = true;
       group = cfg.group;
-      extraGroups = [ config.services.clightning.group ];
+      extraGroups = [ clightning.group ];
     };
     users.groups.${cfg.group} = {};
 

--- a/modules/versioning.nix
+++ b/modules/versioning.nix
@@ -7,6 +7,21 @@
 
 with lib;
 let
+  options = {
+    nix-bitcoin.configVersion = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = ''
+        Set this option to the nix-bitcoin release version that your config is
+        compatible with.
+
+        When upgrading to a backwards-incompatible release, nix-bitcoin will throw an
+        error during evaluation and provide hints for migrating your config to the
+        new release.
+      '';
+    };
+  };
+
   version = config.nix-bitcoin.configVersion;
 
   # Sorted by increasing version numbers
@@ -161,20 +176,7 @@ in
     ./obsolete-options.nix
   ];
 
-  options = {
-    nix-bitcoin.configVersion = mkOption {
-      type = with types; nullOr str;
-      default = null;
-      description = ''
-        Set this option to the nix-bitcoin release version that your config is
-        compatible with.
-
-        When upgrading to a backwards-incompatible release, nix-bitcoin will throw an
-        error during evaluation and provide hints for migrating your config to the
-        new release.
-      '';
-    };
-  };
+  inherit options;
 
   config = {
     # Force evaluation. An actual option value is never assigned


### PR DESCRIPTION
All commits are non-functional and have no effect on system derivations.
You can test this by evaluating the default test VM: `test/run-tests.sh eval`

#### Commit `modules: move options to the top`
This commit was auto-generated by a script.
Use [this script](https://gist.github.com/293c3054e2df949a7258ecd40b824938) to verify this.

Check the following files to see the advantages of the new formatting:
`joinmarket.nix`: [old](https://github.com/fort-nix/nix-bitcoin/blob/cf70d05be0fe8f2b97380931125cac92e0373557/modules/joinmarket.nix), [new](https://github.com/erikarvstedt/nix-bitcoin/blob/f6b219de50c42a8891c2749238583469f0730d4c/modules/joinmarket.nix)
`bitcoind.nix`: [old](https://github.com/fort-nix/nix-bitcoin/blob/cf70d05be0fe8f2b97380931125cac92e0373557/modules/bitcoind.nix),  [new](https://github.com/erikarvstedt/nix-bitcoin/blob/f6b219de50c42a8891c2749238583469f0730d4c/modules/bitcoind.nix)

Or locally:
```
# Checkout old versions
git show master:modules/joinmarket.nix > modules/joinmarket.pre.nix
git show master:modules/bitcoind.nix > modules/bitcoind.pre.nix

# Now open these files
modules/joinmarket.nix
modules/joinmarket.pre.nix
modules/bitcoind.nix
modules/bitcoind.pre.nix
```
