### PR TITLE
lnd: Add TimoutSec

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -209,6 +209,7 @@ in {
         RuntimeDirectoryMode = "711";
         ExecStart = "${cfg.package}/bin/lnd --configfile=${cfg.dataDir}/lnd.conf";
         User = cfg.user;
+        TimeoutSec = "15min";
         Restart = "on-failure";
         RestartSec = "10s";
         ReadWritePaths = cfg.dataDir;


### PR DESCRIPTION
Starting my large / old lnd node (6gb channel.db) usually takes around 10 mins.

This PR fixes the service terminating while starting up.