### PR TITLE
bitcoind: add ping rpc to whitelist

### DIFF
--- a/modules/bitcoind-rpc-public-whitelist.nix
+++ b/modules/bitcoind-rpc-public-whitelist.nix
@@ -1,5 +1,6 @@
 # RPC calls that are safe for public use
 [
+  "ping"
   "echo"
   "getinfo"
   "uptime"


### PR DESCRIPTION
This PR adds the [ping](https://developer.bitcoin.org/reference/rpc/ping.html) command to the bitcoin-rpc-whitelist.

It is used by a bitcoinrpc library to check the connection to bitcoind.