### PR TITLE
secure-node: stop pruning liquidd

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -259,5 +259,5 @@
   # The nix-bitcoin release version that your config is compatible with.
   # When upgrading to a backwards-incompatible release, nix-bitcoin will display an
   # an error and provide hints for migrating your config to the new release.
-  nix-bitcoin.configVersion = "0.0.53";
+  nix-bitcoin.configVersion = "0.0.57";
 }

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -12,6 +12,11 @@ in {
     ./enable-tor.nix
   ];
 
+  options = {
+    # Used by ../versioning.nix
+    nix-bitcoin.secure-node-preset-enabled = {};
+  };
+
   config =  {
     # For backwards compatibility only
     nix-bitcoin.secretsDir = mkDefault "/secrets";

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -44,7 +44,9 @@ in {
     };
 
     services.liquidd = {
-      prune = 1000;
+      # Enable `validatepegin` to verify that a transaction sending BTC into
+      # Liquid exists on Bitcoin. Without it, a malicious liquid federation can
+      # make the node accept a sidechain that is not fully backed.
       validatepegin = true;
       listen = true;
     };

--- a/modules/versioning.nix
+++ b/modules/versioning.nix
@@ -169,6 +169,20 @@ let
             This includes the final database size (0.4) plus some extra storage (0.2).
       '';
     }
+    {
+      version = "0.0.57";
+      condition = config.nix-bitcoin ? secure-node-preset-enabled && config.services.liquidd.enable;
+      message = ''
+        The `secure-node.nix` preset does _not_ set `liquidd.prune = 1000` anymore.
+
+          - If you want to keep the same behavior as before, manually set
+            `services.liquidd.prune = 1000;` in your configuration.nix.
+          - Otherwise, if you want to turn off pruning, you must instruct liquidd
+            to reindex by setting `services.liquidd.extraConfig = "reindex=1";`.
+            This can be removed after having started liquidd with that option
+            once.
+      '';
+    }
   ];
 
   mkOnionServiceChange = service: {


### PR DESCRIPTION
There is no security reason why pruning should be enabled and therefore it
surprises users. Turning on pruning in the first place was simply a mistake.

Fixes #413 