### PR TITLE
missing sys import for error path set_onion_address

### DIFF
--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -42,6 +42,7 @@ let
 
     import json
     import subprocess
+    import sys
     from collections import OrderedDict
 
     def success(*args):


### PR DESCRIPTION
- fix missing import utilized here: https://github.com/fort-nix/nix-bitcoin/blob/master/modules/nodeinfo.nix#L71