### PR TITLE
[LND] Remove pruning assertion

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -161,9 +161,6 @@ in {
 
   config = mkIf cfg.enable {
     assertions = [
-      { assertion = bitcoind.prune == 0;
-        message = "lnd does not support bitcoind pruning.";
-      }
       { assertion =
           !(config.services ? clightning)
           || !config.services.clightning.enable


### PR DESCRIPTION
As of `lnd v0.13.0-beta` lnd started to support pruned bitcoind nodes.

PR: https://github.com/lightningnetwork/lnd/pull/5154

This PR removes the assertion that checks for a pruned bitcoind node.

