### PR TITLE
makeShell: use final system configuration in generate-secrets

### DIFF
--- a/helper/makeShell.nix
+++ b/helper/makeShell.nix
@@ -77,7 +77,11 @@ pkgs.stdenv.mkDerivation {
 
     generate-secrets() {(
       set -euo pipefail
-      genSecrets=$(nix-build --no-out-link -I nixos-config="${cfgDir}/configuration.nix" \
+      config="${cfgDir}/krops/krops-configuration.nix"
+      if [[ ! -e $config ]]; then
+        config="${cfgDir}/configuration.nix"
+      fi
+      genSecrets=$(nix-build --no-out-link -I nixos-config="$config" \
                    '<nixpkgs/nixos>' -A config.nix-bitcoin.generateSecretsScript)
       mkdir -p "${cfgDir}/secrets"
       (cd "${cfgDir}/secrets"; $genSecrets)


### PR DESCRIPTION
#### Copy of commit msg
This fixes a bug where the version update message for v0.0.65 is erroneously triggered because the krops config is not included when evaluating secrets.