### PR TITLE
lnd: point out SCB functionality more clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ NixOS modules ([src](modules/modules.nix))
     * [rebalance](https://github.com/lightningd/plugins/tree/master/rebalance): keeps your channels balanced
     * [summary](https://github.com/lightningd/plugins/tree/master/summary): print a nice summary of the node status
     * [zmq](https://github.com/lightningd/plugins/tree/master/zmq): publishes notifications via ZeroMQ to configured endpoints
-  * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service
+  * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service and [static channel backups](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)
     * [Lightning Loop](https://github.com/lightninglabs/loop)
     * [Lightning Pool](https://github.com/lightninglabs/pool)
     * [charge-lnd](https://github.com/accumulator/charge-lnd): policy-based channel fee manager

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -83,6 +83,8 @@
   # You should also backup your channel state after opening new channels.
   # This will allow you to recover off-chain funds, by force-closing channels.
   #   scp bitcoin-node:/var/lib/lnd/chain/bitcoin/mainnet/channel.backup ./backups/lnd/
+  #
+  # Alternatively, you can have these files backed up by services.backups below.
 
   ### RIDE THE LIGHTNING
   # Set this to enable RTL, a web interface for lnd and clightning.


### PR DESCRIPTION
I think it is not clearly apparent to new users that we support LND Static Channel Backups out of the box. Especially in conjunction with our `backups` module, this provides a fairly basic recovery strategy for LND.

At least a partial answer to https://github.com/fort-nix/nix-bitcoin/issues/409