### PR TITLE
liquidd: add service timeouts like in bitcoind

### DIFF
--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -270,6 +270,8 @@ in {
         NotifyAccess = "all";
         User = cfg.user;
         Group = cfg.group;
+        TimeoutStartSec = "5min";
+        TimeoutStopSec = "10min";
         ExecStart = "${nbPkgs.elementsd}/bin/elementsd -datadir='${cfg.dataDir}'";
         Restart = "on-failure";
         ReadWritePaths = cfg.dataDir;

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -6,22 +6,26 @@ in
 , pkgsUnstable ? import nixpkgsPinned.nixpkgs-unstable { config = {}; overlays = []; }
 }:
 let self = {
-  rtl = pkgs.callPackage ./rtl { };
   cl-rest = pkgs.callPackage ./cl-rest { };
-  spark-wallet = pkgs.callPackage ./spark-wallet { };
-  liquid-swap = pkgs.python3Packages.callPackage ./liquid-swap { };
-  joinmarket = pkgs.callPackage ./joinmarket { inherit (self) nbPython3Packages; };
-  generate-secrets = import ./generate-secrets-deprecated.nix;
-  nixops19_09 = pkgs.callPackage ./nixops { };
-  krops = import ./krops { };
-  netns-exec = pkgs.callPackage ./netns-exec { };
-  clightning-plugins = pkgs.recurseIntoAttrs (import ./clightning-plugins pkgs self.nbPython3Packages);
   clboss = pkgs.callPackage ./clboss { };
+  clightning-plugins = pkgs.recurseIntoAttrs (import ./clightning-plugins pkgs self.nbPython3Packages);
+  joinmarket = pkgs.callPackage ./joinmarket { inherit (self) nbPython3Packages; };
+  liquid-swap = pkgs.python3Packages.callPackage ./liquid-swap { };
+  rtl = pkgs.callPackage ./rtl { };
   secp256k1 = pkgs.callPackage ./secp256k1 { };
+  spark-wallet = pkgs.callPackage ./spark-wallet { };
 
   nbPython3Packages = (pkgs.python3.override {
     packageOverrides = import ./python-packages self;
   }).pkgs;
+
+  # Internal pkgs
+  netns-exec = pkgs.callPackage ./netns-exec { };
+  krops = import ./krops { };
+
+  # Deprecated pkgs
+  generate-secrets = import ./generate-secrets-deprecated.nix;
+  nixops19_09 = pkgs.callPackage ./nixops { };
 
   pinned = import ./pinned.nix pkgs pkgsUnstable;
 


### PR DESCRIPTION
#### Copy of main commit msg:
Previously, liquidd could fail with error:
`liquidd.service: start operation timed out. Terminating.`