### PR TITLE
joinmarket: bump secp256k1 to version used upstream

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -12,6 +12,7 @@ let self = {
   joinmarket = pkgs.callPackage ./joinmarket { inherit (self) nbPython3Packages; };
   liquid-swap = pkgs.python3Packages.callPackage ./liquid-swap { };
   rtl = pkgs.callPackage ./rtl { };
+  # The secp256k1 version used by joinmarket
   secp256k1 = pkgs.callPackage ./secp256k1 { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
 

--- a/pkgs/secp256k1/default.nix
+++ b/pkgs/secp256k1/default.nix
@@ -1,26 +1,46 @@
-{ lib, stdenv, fetchFromGitHub, autoreconfHook }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoreconfHook
+}:
 
 stdenv.mkDerivation {
   pname = "secp256k1";
 
-  version = "2019-10-11";
+  version = "2021-12-03";
 
   src = fetchFromGitHub {
     owner = "bitcoin-core";
     repo = "secp256k1";
-    rev = "0d9540b13ffcd7cd44cc361b8744b93d88aa76ba";
-    sha256 = "05zwhv8ffzrfdzqbsb4zm4kjdbjxqy5jh9r83fic0qpk2mkvc2i2";
+    rev = "490022745164b56439688b0fc04f9bd43578e5c3";
+    hash = "sha256-6CmGWiecthaGWSKX7VHWj5zvDAwVE9U5YOo9JRJWYwI=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = ["--enable-module-recovery" "--disable-jni" "--enable-experimental" "--enable-module-ecdh" "--enable-benchmark=no" ];
+  configureFlags = [
+    "--enable-benchmark=no"
+    "--enable-exhaustive-tests=no"
+    "--enable-experimental"
+    "--enable-module-ecdh"
+    "--enable-module-recovery"
+    "--enable-module-schnorrsig"
+  ];
+
+  doCheck = true;
+
+  checkPhase = "./tests";
 
   meta = with lib; {
     description = "Optimized C library for EC operations on curve secp256k1";
+    longDescription = ''
+      Optimized C library for EC operations on curve secp256k1. Part of
+      Bitcoin Core. This library is a work in progress and is being used
+      to research best practices. Use at your own risk.
+    '';
     homepage = "https://github.com/bitcoin-core/secp256k1";
-    license = licenses.mit;
+    license = with licenses; [ mit ];
     maintainers = with maintainers; [ nixbitcoin ];
-    platforms = platforms.unix;
+    platforms = with platforms; unix;
   };
 }


### PR DESCRIPTION
Also incorporate improvements from upstream nixpkgs expression.

GPG verified upstream commit and repo checksum.