### PR TITLE
Add PeerSwap

### DIFF
--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -17,6 +17,7 @@ in {
     ./prometheus.nix
     ./summary.nix
     ./zmq.nix
+    ./peerswap-cln.nix
   ];
 
   inherit options;

--- a/modules/clightning-plugins/peerswap-cln.nix
+++ b/modules/clightning-plugins/peerswap-cln.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let 
+nbPkgs = config.nix-bitcoin.pkgs;
+cfg = config.services.clightning.plugins.peerswap; 
+configFile = builtins.toFile "policy.conf" ''
+${optionalString (cfg.acceptallpeers != null) "accept_all_peers=${toString cfg.acceptallpeers}"}
+${lib.concatMapStrings (nodeid: "allowlisted_peers=${nodeid}\n") cfg.allowlist}
+'';
+in
+{
+  options.services.clightning.plugins.peerswap = {
+    enable = mkEnableOption "peerswap (clightning plugin)";
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.peerswap-cln;
+      description = "The package providing peerswap binaries.";
+    };
+    allowlist = mkOption {
+      type = types.listOf types.str;
+      default = [""];
+      description = ''
+        Only node ids in the allowlist can send a peerswap request to your node.
+      '';
+    };
+    acceptallpeers = mkOption {
+      type = types.nullOr types.bool;
+        default = null;
+        description = "UNSAFE Allow all peers to swap with your node";
+    };
+    enableLiquid = mkOption {
+      type = types.bool;
+        default = config.services.liquidd.enable;
+        description = "enables l-btc swaps";
+    };
+    enableBitcoin = mkOption {
+      type = types.bool;
+        default = true;
+        description = "enables bitcoin swaps";
+    };
+    liquidRpcWallet = mkOption {
+      type = types.str;
+      default = "peerswap";
+      description = "The liquid rpc wallet to use peerswap with";
+    };
+  };
+  
+  config = mkIf cfg.enable {
+    services.clightning.extraConfig = ''
+      plugin=${cfg.package}/bin/peerswap
+      peerswap-db-path=${config.services.clightning.dataDir}/peerswap/swaps
+      peerswap-policy-path=${configFile}
+      ${optionalString cfg.enableLiquid ''
+        peerswap-liquid-rpchost=http://${config.services.liquidd.rpc.address}
+        peerswap-liquid-rpcport=${toString config.services.liquidd.rpc.port}
+        peerswap-liquid-rpcuser=${config.services.liquidd.rpcuser}
+        peerswap-liquid-rpcpasswordfile=${config.nix-bitcoin.secretsDir}/liquid-rpcpassword
+        peerswap-liquid-network=liquidv1
+        peerswap-liquid-rpcwallet=${cfg.liquidRpcWallet}
+      ''}
+    '';
+         
+    users.users.${config.services.clightning.user}.extraGroups = optional cfg.enableLiquid config.services.liquidd.group;
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -25,6 +25,7 @@
     ./joinmarket.nix
     ./joinmarket-ob-watcher.nix
     ./hardware-wallets.nix
+    ./peerswap-lnd.nix
 
     # Support features
     ./versioning.nix

--- a/modules/peerswap-lnd.nix
+++ b/modules/peerswap-lnd.nix
@@ -1,0 +1,145 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let 
+  nbPkgs = config.nix-bitcoin.pkgs;
+  cfg = config.services.peerswap-lnd;
+  nbLib = config.nix-bitcoin.lib;
+
+  options.services.peerswap-lnd = {
+    enable = mkEnableOption "peerswap lnd";
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.peerswap-lnd;
+      description = "The package providing peerswap binaries.";
+    };
+    allowlist = mkOption {
+      type = types.listOf types.str;
+      default = [""];
+      description = ''
+        Only node ids in the allowlist can send a peerswap request to your node.
+      '';
+    };
+    acceptallpeers = mkOption {
+      type = types.nullOr types.bool;
+        default = null;
+        description = "UNSAFE Allow all peers to swap with your node";
+    };
+    rpcAddress = mkOption {
+      type = types.str;
+      default = "localhost";
+      description = "Address to listen for gRPC connections.";
+    };
+    rpcPort = mkOption {
+      type = types.port;
+      default = 42069;
+      description = "Port to listen for gRPC connections.";
+    };
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/peerswap-lnd";
+      description = "The data directory for peerswap.";
+    };
+    enableLiquid = mkOption {
+      type = types.bool;
+        default = config.services.liquidd.enable;
+        description = "enables l-btc swaps";
+    };
+    enableBitcoin = mkOption {
+      type = types.bool;
+        default = true;
+        description = "enables bitcoin swaps";
+    };
+    liquidRpcWallet = mkOption {
+      type = types.str;
+      default = "peerswap";
+      description = "The liquid rpc wallet to use peerswap with";
+    };
+    user = mkOption {
+      type = types.str;
+      default = "peerswap";
+      description = "The user as which to run PeerSwap.";
+    };
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      description = "The group as which to run PeerSwap.";
+    };
+    cli = mkOption {
+      default = pkgs.writeScriptBin "pscli" ''
+        ${cfg.package}/bin/pscli --rpchost=${nbLib.addressWithPort cfg.rpcAddress cfg.rpcPort} "$@"
+      '';
+      defaultText = "(See source)";
+      description = "Binary to connect with the peerswap instance.";
+    };
+  };
+
+  configFile = builtins.toFile "peerswap.conf" ''
+    ${optionalString (cfg.acceptallpeers != null) "accept_all_peers=${toString cfg.acceptallpeers}"}
+    host=${nbLib.addressWithPort cfg.rpcAddress cfg.rpcPort}
+    lnd.macaroonpath=${cfg.dataDir}/peerswap.macaroon
+    lnd.tlscertpath=${lnd.certPath}
+    lnd.host=${nbLib.addressWithPort lnd.rpcAddress lnd.rpcPort}
+    bitcoinswaps=${toString cfg.enableBitcoin}
+    datadir=${cfg.dataDir}
+    ${optionalString cfg.enableLiquid ''
+    liquid.rpchost=http://${config.services.liquidd.rpc.address}
+    liquid.rpcport=${toString config.services.liquidd.rpc.port}
+    liquid.rpcuser=${config.services.liquidd.rpcuser}
+    liquid.rpcpasswordfile=${config.nix-bitcoin.secretsDir}/liquid-rpcpassword
+    liquid.network=liquidv1
+    liquid.rpcwallet=${cfg.liquidRpcWallet}
+    ''}
+    ${lib.concatMapStrings (nodeid: "allowlisted_peers=${nodeid}\n") cfg.allowlist}
+  '';
+
+  inherit (config.services)
+    liquidd
+    lnd;
+in
+{
+  inherit options;
+  config = mkIf cfg.enable {
+      
+    services.lnd.enable = true;
+    services.lnd.macaroons.peerswap = {
+      user = cfg.user;
+      permissions = ''{"entity": "info","action": "read"},{"entity": "onchain","action": "write"},{"entity": "onchain","action": "read"},{"entity": "invoices","action": "write"},{"entity": "invoices","action": "read"},{"entity": "offchain","action": "write"},{"entity": "offchain","action": "read"},{"entity": "peers","action": "read"}'';
+    };
+
+    environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0770 ${lnd.user} ${lnd.group} - -"
+    ];
+    
+
+    systemd.services.peerswap-lnd = {
+      description = "peerswap initialize script";
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "lnd.service" ];
+      after = [ "lnd.service" ];
+      preStart = ''
+      macaroonDir=${cfg.dataDir}
+      ln -sf /run/lnd/peerswap.macaroon $macaroonDir
+      '';
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/peerswapd --configfile=${configFile}";
+        User = cfg.user;
+        Restart = "on-failure";
+        RestartSec = "10s";
+        ReadWritePaths = cfg.dataDir;
+      };
+    };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      extraGroups =
+        [ lnd.group ]
+        ++ optional cfg.enableLiquid liquidd.group;
+    };
+    users.groups.${cfg.group} = {};
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15,7 +15,8 @@ let self = {
   # The secp256k1 version used by joinmarket
   secp256k1 = pkgs.callPackage ./secp256k1 { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
-
+  peerswap-lnd = pkgs.callPackage ./peerswap { goSubPackages = ["cmd/peerswaplnd/peerswapd" "cmd/peerswaplnd/pscli" ]; };
+  peerswap-cln = pkgs.callPackage ./peerswap { goSubPackages = ["cmd/peerswap" ]; };
   nbPython3Packages = (pkgs.python3.override {
     packageOverrides = import ./python-packages self;
   }).pkgs;

--- a/pkgs/peerswap/default.nix
+++ b/pkgs/peerswap/default.nix
@@ -1,0 +1,26 @@
+{ pkgs, lib, fetchFromGitHub, buildGoModule, goSubPackages}:
+
+buildGoModule rec {
+  pname = "peerswap-lnd";
+  version = "0.2.0-beta";
+
+  src = fetchFromGitHub {
+      repo = "peerswap";
+      owner = "sputn1ck";
+      rev = "d37d4be0be7899e48694068f03c1b02fde1734a0";
+      sha256 = "sha256:1axmxrk3svrzpg18sp2c21x7bqakhk3hszz1smpy6pc1x3s7hfsh";
+  };
+
+  subPackages = goSubPackages;
+  vendorSha256 = "sha256:13jgk2r8ac2vxrs10xjhilp0x1qvjjgs6knkhf67bmsbx3n9abnl";
+  proxyVendor = true;
+
+  meta = with lib; {
+    description = "P2P lightning channel rebalancing using lightning<->on-chain atomic swaps";
+    homepage = "peerswap.dev";
+    maintainers = with maintainers; [ sputn1ck ];
+    license = licenses.mit;
+    platforms = platforms.linux;
+
+  };
+}

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -116,6 +116,8 @@ let
 
       tests.backups = cfg.backups.enable;
 
+      tests.peerswap-lnd = cfg.peerswap-lnd.enable;
+
       # To test that unused secrets are made inaccessible by 'setup-secrets'
       systemd.services.setup-secrets.preStart = mkIfTest "security" ''
         install -D -o nobody -g nogroup -m777 <(:) /secrets/dummy
@@ -177,6 +179,7 @@ let
       services.joinmarket.enable = true;
       services.joinmarket-ob-watcher.enable = true;
       services.backups.enable = true;
+      services.peerswap-lnd.enable = true;
 
       nix-bitcoin.nodeinfo.enable = true;
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -184,6 +184,14 @@ def _():
     succeed("systemctl start charge-lnd")
     assert_no_failure("charge-lnd")
 
+@test("peerswap-lnd")
+def _():
+    assert_running("peerswap-lnd")
+    machine.wait_until_succeeds(
+        log_has_string("peerswap-lnd", "peerswapd listening on")
+    )
+    assert_matches("pscli reloadpolicy", "policy")
+
 @test("btcpayserver")
 def _():
     assert_running("nbxplorer")


### PR DESCRIPTION
This PR adds [peerswap](https://github.com/sputn1ck/peerswap). Peerswap allows you to rebalance channels with your direct peers using submarine swaps on bitcoin and on liquid. It is alpha software so should be used with caution.

I added modules for lnd as well as the clightning plugin.

Let me know if the testcase makes sense. I don't know how to run clightning plugin tests, however running
`./run-tests.sh -s "{ services.clightning.enable = true;services.clightning.plugins.peerswap.enable = true;}" container --run c "lightning-cli peerswap-listswaps"` went fine