### PR TITLE
secrets: fix secrets setup warning

### DIFF
--- a/modules/secrets/secrets.nix
+++ b/modules/secrets/secrets.nix
@@ -66,7 +66,7 @@ let
     };
 
     secretsSetupMethod = mkOption {
-      type = types.str;
+      type = with types; nullOr str;
       default = null;
     };
 


### PR DESCRIPTION
#### Commit msg
With newer nixpkgs versions, a type error was shown instead of the warning message when `secretsSetupMethod` was unset.

Reproduce with:
```bash
nix eval --impure --expr '
(import <nixpkgs/nixos> {
  configuration = {
    imports = [
      <nix-bitcoin/modules/modules.nix>
    ];
  };
}).system
'
```