### PR TITLE
joinmarket: 0.9.4 -> 0.9.5

### DIFF
--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -150,16 +150,8 @@ let
     usessl = false
     ${socks5Settings}
 
-    # agora.anarplex.net
-    [MESSAGING:server3]
-    host = vxecvd6lc4giwtasjhgbrr3eop6pzq6i5rveracktioneunalgqlwfad.onion
-    channel = joinmarket-pit
-    port = 6667
-    usessl = false
-    ${socks5Settings}
-
     # ilita
-    [MESSAGING:server4]
+    [MESSAGING:server3]
     host = ilitafrzzgxymv6umx2ux7kbz3imyeko6cnqkvy4nisjjj4qpqkrptid.onion
     channel = joinmarket-pit
     port = 6667

--- a/pkgs/joinmarket/default.nix
+++ b/pkgs/joinmarket/default.nix
@@ -1,10 +1,20 @@
-{ stdenv, lib, fetchurl, python3, nbPython3Packages, pkgs }:
+{ stdenv, lib, fetchurl, applyPatches, fetchpatch, python3, nbPython3Packages, pkgs }:
 
 let
-  version = "0.9.4";
-  src = fetchurl {
-    url = "https://github.com/JoinMarket-Org/joinmarket-clientserver/archive/v${version}.tar.gz";
-    sha256 = "1xkz274g9lv5yif77h0mci1fsgam56sdc8m281q3a8hij9nmzmq1";
+  version = "0.9.5";
+  src = applyPatches {
+    src = fetchurl {
+      url = "https://github.com/JoinMarket-Org/joinmarket-clientserver/archive/v${version}.tar.gz";
+      sha256 = "0q8hfq4y7az5ly97brq1khhhvhnq6irzw0ginmz20fwn7w3yc5sn";
+    };
+    patches = [
+      (fetchpatch {
+        # https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1206
+        name = "ob-export-fix";
+        url = "https://patch-diff.githubusercontent.com/raw/JoinMarket-Org/joinmarket-clientserver/pull/1206.patch";
+        sha256 = "0532gixjyc8r11sfmlf32v5iwy0rhkpa8rbvm4b7h509hnyycvhx";
+      })
+    ];
   };
 
   runtimePackages = with nbPython3Packages; [

--- a/pkgs/python-packages/python-bitcointx/default.nix
+++ b/pkgs/python-packages/python-bitcointx/default.nix
@@ -2,11 +2,11 @@
 
 buildPythonPackage rec {
   pname = "python-bitcointx";
-  version = "1.1.1.post0";
+  version = "1.1.3";
 
   src = fetchurl {
     url = "https://github.com/Simplexum/${pname}/archive/${pname}-v${version}.tar.gz";
-    sha256 = "d12593b09785a7a4ce08cb1928815c2366e9f6e4fab317267462857bf83904b0";
+    sha256 = "f0f487c29619df0e94a04f6deb3dc950ff9954c072017bd3eda90f73c24f0953";
   };
 
   patchPhase = ''

--- a/pkgs/python-packages/python-bitcointx/get-sha256.sh
+++ b/pkgs/python-packages/python-bitcointx/get-sha256.sh
@@ -9,7 +9,7 @@ cd $TMPDIR
 echo "Fetching latest release"
 git clone https://github.com/simplexum/python-bitcointx 2> /dev/null
 cd python-bitcointx
-latest=python-bitcointx-v1.1.1.post0
+latest=python-bitcointx-v1.1.3
 echo "Latest release is ${latest}"
 
 # GPG verification

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -108,10 +108,6 @@ let
         txfee = 200;
       };
 
-      # Disable restarting joinmarket-ob-watcher because it always fails
-      # on non-synced mainnet nodes
-      systemd.services.joinmarket-ob-watcher.serviceConfig.Restart = mkForce "no";
-
       tests.nodeinfo = config.nix-bitcoin.nodeinfo.enable;
 
       tests.backups = cfg.backups.enable;

--- a/test/tests.py
+++ b/test/tests.py
@@ -241,9 +241,8 @@ def _():
 
 @test("joinmarket-ob-watcher")
 def _():
-    # joinmarket-ob-watcher fails on non-synced mainnet nodes.
-    # Also, it doesn't support any of the test networks.
-    machine.wait_until_succeeds(log_has_string("joinmarket-ob-watcher", "unknown error in JSON-RPC"))
+    assert_running("joinmarket-ob-watcher")
+    machine.wait_until_succeeds(log_has_string("joinmarket-ob-watcher", "Starting ob-watcher"))
 
 @test("nodeinfo")
 def _():


### PR DESCRIPTION
Notes
- We can no longer test for `unknown error in JSON-RPC`. `jm-ob-watcher`
  now simply outputs `Starting ob-watcher`. Tested working on
  https://nixbitcoin.org/orderbook.
- Removed Agora IRC server since it is offline semi-permanently. Should
  probably also be removed upstream.
- Includes patch for
  https://github.com/JoinMarket-Org/joinmarket-clientserver/issues/1193