### PR TITLE
defaultHardening: allow `clone3` system call

### DIFF
--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -33,7 +33,7 @@ let self = {
       # @system-service whitelist and docker seccomp blacklist (except for "clone"
       # which is a core requirement for systemd services)
       # @system-service is defined in src/shared/seccomp-util.c (systemd source)
-      SystemCallFilter = [ "@system-service" "~add_key clone3  kcmp keyctl mbind move_pages name_to_handle_at personality process_vm_readv process_vm_writev request_key set_mempolicy setns unshare userfaultfd" ];
+      SystemCallFilter = [ "@system-service" "~add_key kcmp keyctl mbind move_pages name_to_handle_at personality process_vm_readv process_vm_writev request_key set_mempolicy setns unshare userfaultfd" ];
       SystemCallArchitectures = "native";
   };
 


### PR DESCRIPTION
#### Copy of commit msg
clone3 is the latest version of the clone system call, which is already allowed.
clone3 is required by nbxplorer 2.3.20.