### PR TITLE
services: set systemd list options as list values

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -423,7 +423,7 @@ in {
         ExecStart = "${cfg.package}/bin/bitcoind -datadir='${cfg.dataDir}'";
         Restart = "on-failure";
         UMask = mkIf cfg.dataDirReadableByGroup "0027";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce
         // optionalAttrs zmqServerEnabled nbLib.allowNetlink;
     };
@@ -449,7 +449,7 @@ in {
       serviceConfig = nbLib.defaultHardening // {
         User = cfg.user;
         Group = cfg.group;
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowLocalIPAddresses;
     };
 

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -192,7 +192,7 @@ in {
         User = cfg.nbxplorer.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.nbxplorer.dataDir;
+        ReadWritePaths = [ cfg.nbxplorer.dataDir ];
         MemoryDenyWriteExecute = "false";
       } // nbLib.allowedIPAddresses cfg.nbxplorer.tor.enforce;
     };
@@ -245,7 +245,7 @@ in {
         User = cfg.btcpayserver.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.btcpayserver.dataDir;
+        ReadWritePaths = [ cfg.btcpayserver.dataDir ];
         MemoryDenyWriteExecute = "false";
       } // nbLib.allowedIPAddresses cfg.btcpayserver.tor.enforce;
     }; in self;

--- a/modules/clightning-rest.nix
+++ b/modules/clightning-rest.nix
@@ -96,7 +96,7 @@ in {
         User = clightning.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce
         // nbLib.nodejs;
     };

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -148,7 +148,7 @@ in {
         User = cfg.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
       # Wait until the rpc socket appears
       postStart = ''

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -92,7 +92,7 @@ in {
         Group = cfg.group;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -328,7 +328,7 @@ in {
         User = cfg.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 
@@ -368,7 +368,7 @@ in {
         # because it provides the wallet password via stdin to the main process
         SyslogIdentifier = "joinmarket-yieldgenerator";
         User = cfg.user;
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowTor;
     };
   })

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -106,7 +106,7 @@ in {
         User = lnd.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -103,7 +103,7 @@ in {
         User = "lnd";
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // (nbLib.allowedIPAddresses cfg.tor.enforce)
         // nbLib.allowNetlink; # required by gRPC-Go
     };

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -274,7 +274,7 @@ in {
         TimeoutStopSec = "10min";
         ExecStart = "${nbPkgs.elementsd}/bin/elementsd -datadir='${cfg.dataDir}'";
         Restart = "on-failure";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -232,7 +232,7 @@ in {
         TimeoutSec = "15min";
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
         ExecStartPost = let
           curl = "${pkgs.curl}/bin/curl -s --show-error --cacert ${cfg.certPath}";
           restUrl = "https://${nbLib.addressWithPort cfg.restAddress cfg.restPort}/v1";

--- a/modules/rtl.nix
+++ b/modules/rtl.nix
@@ -185,7 +185,7 @@ in {
         User = cfg.user;
         Restart = "on-failure";
         RestartSec = "10s";
-        ReadWritePaths = cfg.dataDir;
+        ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce
         // nbLib.nodejs;
     };

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -46,7 +46,11 @@ let self = {
 
   # Allow takes precedence over Deny.
   allowLocalIPAddresses = {
-    IPAddressAllow = "127.0.0.1/32 ::1/128 169.254.0.0/16";
+    IPAddressAllow = [
+      "127.0.0.1/32"
+      "::1/128"
+      "169.254.0.0/16"
+    ];
   };
   allowAllIPAddresses = { IPAddressAllow = "any"; };
   allowTor = self.allowLocalIPAddresses;


### PR DESCRIPTION
#### Copy of commit msg
This makes our list definitions mergeable with custom list values set by users.
Previously, a module error ("value is a string while a list was expected") was thrown instead.

This commit was partly auto-generated with this script:

```ruby
#!/usr/bin/env ruby
Dir["**/*.nix"].each do |file|
  src = File.read(file)
  fixed = src.gsub(/ReadWritePaths *= *(.*?);/) do
    "ReadWritePaths = [ #{$1} ];"
  end
  File.write(file, fixed) if fixed != src
end
```