### PR TITLE
pkgs-unstable: inherit system from stable pkgs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -3,7 +3,11 @@ let
 in
 # Set default values for use without flakes
 { pkgs ? import <nixpkgs> { config = {}; overlays = []; }
-, pkgsUnstable ? import nixpkgsPinned.nixpkgs-unstable { config = {}; overlays = []; }
+, pkgsUnstable ? import nixpkgsPinned.nixpkgs-unstable {
+    inherit (pkgs) system;
+    config = {};
+    overlays = [];
+  }
 }:
 let self = {
   clightning-rest = pkgs.callPackage ./clightning-rest { };


### PR DESCRIPTION
Previously, `builtins.defaultSystem` was implicitly used.
This fixes NixOS system builds for systems other than `defaultSystem`. 
(Flake-based systems are unaffected.)

Fixes #482