### PR TITLE
Add feeadjust core lightning plugin

### DIFF
--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -14,6 +14,7 @@ in {
   imports = [
     ./clboss.nix
     ./commando.nix
+    ./feeadjuster.nix
     ./prometheus.nix
     ./summary.nix
     ./zmq.nix

--- a/modules/clightning-plugins/feeadjuster.nix
+++ b/modules/clightning-plugins/feeadjuster.nix
@@ -1,0 +1,34 @@
+{ config, lib, ... }:
+
+with lib;
+let cfg = config.services.clightning.plugins.feeadjuster; in
+let maybeFlag = enable: flag: if enable then flag + "\n" else ""; in
+{
+  options.services.clightning.plugins.feeadjuster = {
+    enable = mkEnableOption "Feeaduster (clightning plugin)";
+    fuzz = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Enable update threshold randomization and hysterisis";
+    };
+    adjustOnForward = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Automatically update fees on forward events";
+    };
+    method = mkOption {
+      type = types.enum [ "soft" "default" "hard" ];
+      default = "default";
+      description = "Adjustment method to calculate channel fee (soft=less difference, hard=high difference)";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.clightning.extraConfig = ''
+      plugin=${config.nix-bitcoin.pkgs.clightning-plugins.feeadjuster.path}
+      feeadjuster-adjustment-method="${cfg.method}"
+    '' +
+    (maybeFlag (!cfg.fuzz) "feeadjuster-deactivate-fuzz") +
+    (maybeFlag (!cfg.adjustOnForward) "feeadjuster-deactivate-fee-update");
+  };
+}

--- a/pkgs/clightning-plugins/default.nix
+++ b/pkgs/clightning-plugins/default.nix
@@ -39,6 +39,9 @@ let
       scriptName = "cl-zmq";
       extraPkgs = [ twisted txzmq ];
     };
+    feeadjuster = {
+      description = "Dynamically changes channel fees to keep your channels more balanced";
+    };
   };
 
   basePkgs = [ nbPython3Packages.pyln-client ];


### PR DESCRIPTION
The `feeadjuster` plugin sets channel fees based on their how balanced they are. This PR implements a subset of its config options with some opinionated defaults and allows running the fee adjustment once a day via a systemd timer.

I don't really know what I'm doing in nix, so any feedback and ways to do things better are much appreciated.