### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1656265786,
-        "narHash": "sha256-A9RkoGrxzsmMm0vily18p92Rasb+MbdDMaSnzmywXKw=",
+        "lastModified": 1656679828,
+        "narHash": "sha256-akGA97pR1BAQew1FrVTCME3p8qvYxJXB2X3a13aBphs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd90e773eae83ba7733d2377b6cdf84d45558780",
+        "rev": "915f5a5b3cc4f8ba206afd0b70e52ba4c6a2796b",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1656250965,
-        "narHash": "sha256-2IlNf6jxEJiuCrGymqLOLjxk2SIj4HhVIwEb0kvcs24=",
+        "lastModified": 1656755932,
+        "narHash": "sha256-TGThfOxr+HjFK464+UoUE6rClp2cwxjiKvHcBVdIGSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a17f325397d137ac4d219ecbd5c7f15154422f4",
+        "rev": "660ac43ff9ab1f12e28bfb31d4719795777fe152",
         "type": "github"
       },
       "original": {

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -5,18 +5,18 @@ pkgs: pkgsUnstable:
     bitcoin
     bitcoind
     charge-lnd
-    clightning
     electrs
     elementsd
     extra-container
     lightning-pool
-    lnd
     lndconnect;
 
   inherit (pkgsUnstable)
     btcpayserver
+    clightning
     hwi
     lightning-loop
+    lnd
     nbxplorer;
 
   inherit pkgs pkgsUnstable;

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     "nixos-org-configurations": {
       "flake": false,
       "locked": {
-        "lastModified": 1654268653,
-        "narHash": "sha256-oTW2IFRAE1juNLE1tJ/mqVeSG1P+XPrm9o2E0irBVKg=",
+        "lastModified": 1656005614,
+        "narHash": "sha256-82JwxcIkNj+tGt1zIhMna6LfcshPiuP/qsq/EuQ4UPA=",
         "owner": "NixOS",
         "repo": "nixos-org-configurations",
-        "rev": "8e8668be80e6d3b6f5f602770dca42e6c6f33d50",
+        "rev": "a5e623b9729601da2b51368287bb623afd7b9ffc",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1654646126,
-        "narHash": "sha256-GjfJq6tK2IB8aQcXA3UkFa2/hsPYvT/H+KE9Ghse4j4=",
+        "lastModified": 1656581004,
+        "narHash": "sha256-CHNw9tuckso6+5JZmeHAX1ApL121XWYcrEPf7bo2Sdk=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "74ed61a9152400465f590a1ad2575c2526ee375b",
+        "rev": "398253d3ebc67cb1ee7c65e80dcb2fd7894927d0",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654230545,
-        "narHash": "sha256-8Vlwf0x8ow6pPOK2a04bT+pxIeRnM1+O0Xv9/CuDzRs=",
+        "lastModified": 1655983783,
+        "narHash": "sha256-0h1FzkYWei24IdKNpCX93onkF/FMiXQG8SdEbTc0r8A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "236cc2971ac72acd90f0ae3a797f9f83098b17ec",
+        "rev": "6141b8932a5cf376fe18fcd368cecd9ad946cb68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
clightning: 0.11.1 -> 0.11.2
lnd: 0.14.3-beta -> 0.15.0-beta

The nixpkgs-unstable update includes commit https://github.com/NixOS/nixpkgs/commit/aae0476728516c6a2ce78638fbc13436c4f4fa19 which fixes [a bug](https://github.com/NixOS/nixpkgs/issues/179272) that prevented the previous revision of nixpkgs-unstable to be used on macOS.

Fixes #500