### PR TITLE
krops: don't reimport pkgs

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -27,7 +27,7 @@ let self = {
 
   # Internal pkgs
   netns-exec = pkgs.callPackage ./netns-exec { };
-  krops = import ./krops { };
+  krops = import ./krops { inherit pkgs; };
 
   # Deprecated pkgs
   generate-secrets = import ./generate-secrets-deprecated.nix;

--- a/pkgs/krops/default.nix
+++ b/pkgs/krops/default.nix
@@ -8,5 +8,8 @@ let
   };
 in {
   lib = import "${src}/lib";
-  pkgs = import "${src}/pkgs" {};
+  pkgs = rec {
+    krops = pkgs.callPackage "${src}/pkgs/krops" { inherit populate; };
+    populate = pkgs.callPackage "${src}/pkgs/populate" {};
+  };
 }


### PR DESCRIPTION
#### Copy of commit msg
Previously, the krops pkg was accessed by evaluating nixpkgs with the krops overlay.
Now directly call krops with an existing pkgs instance.