### PR TITLE
bitcoind, liquidd: increase `TimeoutStartSec`

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -418,7 +418,7 @@ in {
         NotifyAccess = "all";
         User = cfg.user;
         Group = cfg.group;
-        TimeoutStartSec = "5min";
+        TimeoutStartSec = "10min";
         TimeoutStopSec = "10min";
         ExecStart = "${cfg.package}/bin/bitcoind -datadir='${cfg.dataDir}'";
         Restart = "on-failure";

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -270,7 +270,7 @@ in {
         NotifyAccess = "all";
         User = cfg.user;
         Group = cfg.group;
-        TimeoutStartSec = "5min";
+        TimeoutStartSec = "10min";
         TimeoutStopSec = "10min";
         ExecStart = "${nbPkgs.elementsd}/bin/elementsd -datadir='${cfg.dataDir}'";
         Restart = "on-failure";


### PR DESCRIPTION
### Copy of commit msg
I've just seen `liquidd` hit the timeout on nixbitcoin.org while `Loading block index`.
This was probably due to HDD contention while starting services during
boot.