### PR TITLE
bitcoind-remote: fix quotation marks in preStart script

### DIFF
--- a/modules/presets/bitcoind-remote.nix
+++ b/modules/presets/bitcoind-remote.nix
@@ -13,7 +13,7 @@ in {
 
   systemd.services.bitcoind = {
     preStart = lib.mkAfter ''
-      echo "rpcpassword=$(cat ${secretsDir}/bitcoin-rpcpassword-privileged)" >> '${cfg.dataDir}'/bitcoin.conf
+      echo "rpcpassword=$(cat ${secretsDir}/bitcoin-rpcpassword-privileged)" >> '${cfg.dataDir}/bitcoin.conf'
     '';
     postStart = lib.mkForce "";
     serviceConfig = {


### PR DESCRIPTION
I think there is a small typo in quotation marks.