### PR TITLE
krops: Enable evaluating nodes with non-native systems

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -238,6 +238,24 @@ You can also build Nix from source by following the instructions at https://nixo
     cp -r ../nix-bitcoin/examples/{nix-bitcoin-release.nix,configuration.nix,shell.nix,krops,.gitignore} .
     ```
 
+#### Optional: Specify the system of your node
+   This enables evaluating your node config on a machine that has a different system platform
+   than your node.\
+   Examples: Deploying from macOS or deploying from a x86 desktop PC to a Raspberry Pi.
+
+    ```
+    # Run this when your node has a 64-Bit x86 CPU (e.g., an Intel or AMD CPU)
+    echo "x86_64-linux" > krops/system
+
+    # Run this when your node has a 64-Bit ARM CPU (e.g., Raspberry Pi 4 B, Pine64)
+    echo "aarch64-linux" > krops/system
+    ```
+    Other available systems:
+    - `i686-linux` (`x86`)
+    - `armv7l-linux` (`ARMv7`)\
+      This platform is untested and has no binary caches.
+      [See here](https://nixos.wiki/wiki/NixOS_on_ARM) for details.
+
 ## 4. Deploy with krops
 
 1. Edit your ssh config

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,12 @@
 
   outputs = { self, nixpkgs, nixpkgsUnstable, flake-utils }:
     let
-      supportedSystems = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+      supportedSystems = [
+        "x86_64-linux"
+        "i686-linux"
+        "aarch64-linux"
+        "armv7l-linux"
+      ];
     in {
       lib = {
         mkNbPkgs = {

--- a/helper/makeShell.nix
+++ b/helper/makeShell.nix
@@ -29,6 +29,9 @@ pkgs.stdenv.mkDerivation {
     eval-config
       Evaluate your node system configuration
 
+    build-config
+       Build your node system on your local machine
+
     generate-secrets
       Create secrets required by your node configuration.
       Secrets are written to ./secrets/
@@ -115,6 +118,13 @@ pkgs.stdenv.mkDerivation {
       NIXOS_CONFIG="${cfgDir}/krops/krops-configuration.nix" \
         nix-instantiate --eval ${nixpkgs}/nixos $system -A system.outPath | tr -d '"'
       echo
+    )}
+
+    build-config() {(
+      set -euo pipefail
+      system=$(getNodeSystem)
+      NIXOS_CONFIG="${cfgDir}/krops/krops-configuration.nix" \
+        nix-build --no-out-link ${nixpkgs}/nixos $system -A system
     )}
 
     getNodeSystem() {

--- a/helper/makeShell.nix
+++ b/helper/makeShell.nix
@@ -109,11 +109,25 @@ pkgs.stdenv.mkDerivation {
       $(nix-build --no-out-link "${cfgDir}/krops/deploy.nix")
     )}
 
-    eval-config() {
+    eval-config() {(
+      set -euo pipefail
+      system=$(getNodeSystem)
       NIXOS_CONFIG="${cfgDir}/krops/krops-configuration.nix" \
-        nix-instantiate --eval ${nixpkgs}/nixos -A system.outPath | tr -d '"'
+        nix-instantiate --eval ${nixpkgs}/nixos $system -A system.outPath | tr -d '"'
       echo
-    }
+    )}
+
+    getNodeSystem() {
+      if [[ -e '${cfgDir}/krops/system' ]]; then
+        echo -n "--argstr system "; cat '${cfgDir}/krops/system'
+      elif [[ $OSTYPE == darwin* ]]; then
+        # On macOS, `builtins.currentSystem` (`*-darwin`) can never equal
+        # the node system (`*-linux`), so we can always provide a helpful error message:
+        >&2 echo "Error, node system not set. See here how to fix this:"
+        >&2 echo "https://github.com/fort-nix/nix-bitcoin/blob/master/docs/install.md#optional-specify-the-system-of-your-node"
+        return 1
+      fi
+    };
 
     pidClosure() {
       echo "$1"


### PR DESCRIPTION
Most importantly, this unlocks `deploy` on macOS.

Use the following for testing:
```bash
cd /path/to/nix-bitcoin

cd examples
# Set hardware config to allow eval'ing the node config
sed -i -r 's|#(./hardware-configuration.nix)|\1|' configuration.nix
echo '
{
  boot.isContainer = true;
  documentation.enable = false;
}
' > hardware-configuration.nix
rm -f krops/system

# This runs normally
nix-shell --run eval-config
# Failure on macOS
OSTYPE=darwin19 nix-shell --run eval-config
# Set system
echo "aarch64-linux" > krops/system
# Eval'ing succeeds
OSTYPE=darwin19 nix-shell --run eval-config

# Test building
echo "x86_64-linux" > krops/system
nix-shell --run build-config
```

This PR requires a special mention in the release notes.
I'll post the text here when this is merged.