### PR TITLE
secrets: fix sorting in `setup-secrets`

### DIFF
--- a/modules/secrets/secrets.nix
+++ b/modules/secrets/secrets.nix
@@ -173,6 +173,10 @@ in {
          RemainAfterExit = true;
       };
       script = ''
+        # Use the same sort order for globbing and sorting as in Nix attrsets.
+        # Required for `comm` below.
+        export LC_COLLATE=C
+
         ${optionalString cfg.generateSecrets ''
           mkdir -p "${cfg.secretsDir}"
           cd "${cfg.secretsDir}"


### PR DESCRIPTION
#### Copy of commit msg
Now the bash globbing sort order equals the nix sort order (order of `processedFiles`)
Previously, `comm` could fail with error `unsorted` on specific secrets names.