### PR TITLE
examples/deploy-krops: fix missing secrets

### DIFF
--- a/examples/deploy-krops.sh
+++ b/examples/deploy-krops.sh
@@ -101,6 +101,10 @@ vmWaitForSSH
 c "nix-store --load-db < $(realpath $tmpDir/store-paths)/registration"
 
 echo
+echo "Generate secrets"
+nix-shell --run generate-secrets
+
+echo
 echo "Deploy with krops"
 $tmpDir/krops-deploy
 


### PR DESCRIPTION
#### Copy of commit msg
Previously, `deploy-krops.sh` failed when run in a freshly cloned repo due to missing secrets.