### PR TITLE
operator: fix syntax error in description

### DIFF
--- a/modules/operator.nix
+++ b/modules/operator.nix
@@ -12,7 +12,7 @@ let
 
         When using nix-bitcoin as part of a larger system config, it makes sense
         to set your main system user as the operator, by setting option
-        `nix-bitcoin.operator.name = "<main user name>";`.
+        `nix-bitcoin.operator.name = "MAIN_USER_NAME";`.
       '';
     };
     name = mkOption {

--- a/test/nixos-search/ci-test.sh
+++ b/test/nixos-search/ci-test.sh
@@ -17,7 +17,5 @@ if [[ ${CACHIX_SIGNING_KEY:-} ]]; then
     cachix push $cachixCache $(type -P flake-info);
 fi
 
-# flake-info requires '<nixpkgs>'
-export NIX_PATH=nixpkgs=$(nix eval --raw .#nixpkgsPath)
 echo "Running flake-info (nixos-search)"
-flake-info flake ./.
+flake-info flake ../..


### PR DESCRIPTION
Fix error `Invalid XML` when running flake-info (nixos-search).