### PR TITLE
clightning: add currencyrate plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ NixOS modules ([src](modules/modules.nix))
     Available plugins:
     * [clboss](https://github.com/ZmnSCPxj/clboss): automated C-Lightning Node Manager
     * [commando](https://github.com/lightningd/plugins/tree/master/commando): control your node over lightning
+    * [currencyrate](https://github.com/lightningd/plugins/tree/master/currencyrate): currency converter
     * [helpme](https://github.com/lightningd/plugins/tree/master/helpme): walks you through setting up a fresh c-lightning node
     * [monitor](https://github.com/lightningd/plugins/tree/master/monitor): helps you analyze the health of your peers and channels
     * [prometheus](https://github.com/lightningd/plugins/tree/master/prometheus): lightning node exporter for the prometheus timeseries server

--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -3,6 +3,7 @@
 with lib;
 let
   options.services.clightning.plugins = {
+    currencyrate.enable = mkEnableOption "Currencyrate (clightning plugin)";
     helpme.enable = mkEnableOption "Help me (clightning plugin)";
     monitor.enable = mkEnableOption "Monitor (clightning plugin)";
     rebalance.enable = mkEnableOption "Rebalance (clightning plugin)";
@@ -24,6 +25,7 @@ in {
 
   config = {
     services.clightning.extraConfig = mkMerge [
+      (mkIf cfg.currencyrate.enable "plugin=${pluginPkgs.currencyrate.path}")
       (mkIf cfg.helpme.enable "plugin=${pluginPkgs.helpme.path}")
       (mkIf cfg.monitor.enable "plugin=${pluginPkgs.monitor.path}")
       (mkIf cfg.rebalance.enable "plugin=${pluginPkgs.rebalance.path}")

--- a/pkgs/clightning-plugins/default.nix
+++ b/pkgs/clightning-plugins/default.nix
@@ -6,8 +6,8 @@ let
   src = pkgs.fetchFromGitHub {
     owner = "lightningd";
     repo = "plugins";
-    rev = "7ef9e6c172c0bd0dd09168e19b29e44f7ec6ec4d";
-    sha256 = "12llf4dnyria0s1x4bmm360d6bxk47z0wyxwwlmq3762mdfl36js";
+    rev = "59bad754cb338872c622ad716e8ed0063edf4052";
+    sha256 = "19nnmv2jvb0xmcha79dij399avasn2x521n9qg11lqj8xnzadm6a";
   };
 
   version = builtins.substring 0 7 src.rev;

--- a/pkgs/clightning-plugins/default.nix
+++ b/pkgs/clightning-plugins/default.nix
@@ -17,6 +17,10 @@ let
       description = "Enable RPC over lightning";
       extraPkgs = [ nbPython3Packages.runes ];
     };
+    currencyrate = {
+      description = "Currency rate fetcher and converter";
+      extraPkgs = [ requests cachetools ];
+    };
     feeadjuster = {
       description = "Dynamically changes channel fees to keep your channels more balanced";
     };


### PR DESCRIPTION
    clightning: add currencyrate plugin
    
    Add the currencyrate plugin. This is used by other plugins to fetch
    currency rates. This can be used for setting fiat amounts in bolt12
    invoices.
    