### PR TITLE
onion-services: don't propagate restart of `onion-addresses` to depending services

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -376,6 +376,9 @@ in {
       # are not restarted when the secrets target restarts.
       # The secrets target always restarts when deploying with one of the methods
       # in ./deployment.
+      #
+      # TODO-EXTERNAL: Instead of `wants`, use a future systemd dependency type
+      # that propagates initial start failures but no restarts
       wants = [ "nix-bitcoin-secrets.target" ];
       after = [ "network.target" "nix-bitcoin-secrets.target" ];
       wantedBy = [ "multi-user.target" ];

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -80,7 +80,9 @@ in {
       systemd.services = let
         onionAddresses = [ "onion-addresses.service" ];
       in genAttrs publicServices (service: {
-        requires = onionAddresses;
+        # TODO-EXTERNAL: Instead of `wants`, use a future systemd dependency type
+        # that propagates initial start failures but no restarts
+        wants = onionAddresses;
         after = onionAddresses;
       });
     })


### PR DESCRIPTION
#### Copy of commit msg
Currently, public services that publish their onion addresses have a `requires` dependeny on service `onion-addresses`, so they are restarted when `onion-addresses` restarts.

This has the downside that most of nix-bitcoin's services are restarted when a new onion service is added and the system config has the following common settings:
- nix-bitcoin.onionServices.bitcoind.public = true
- nix-bitcoin.operator.enable = true

Sequence of events:
1. onion service is added
2. `onion-addresses` restarts, because the new onion service is made available to `operator`
3. bitcoind restarts
4. all depending services restart

Fix this by using a `wants` dependency.