### PR TITLE
clightning: add trustedcoin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ NixOS modules ([src](modules/modules.nix))
     * [prometheus](https://github.com/lightningd/plugins/tree/master/prometheus): lightning node exporter for the prometheus timeseries server
     * [rebalance](https://github.com/lightningd/plugins/tree/master/rebalance): keeps your channels balanced
     * [summary](https://github.com/lightningd/plugins/tree/master/summary): print a nice summary of the node status
+    * [trustedcoin](https://github.com/fiatjaf/trustedcoin): replaces bitcoind with trusted public explorers
     * [zmq](https://github.com/lightningd/plugins/tree/master/zmq): publishes notifications via ZeroMQ to configured endpoints
   * [clightning-rest](https://github.com/Ride-The-Lightning/c-lightning-REST): REST server for clightning
   * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service and [static channel backups](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)

--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -18,6 +18,7 @@ in {
     ./feeadjuster.nix
     ./prometheus.nix
     ./summary.nix
+    ./trustedcoin.nix
     ./zmq.nix
   ];
 

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.services.clightning.plugins.trustedcoin; in
+{
+  options.services.clightning.plugins.trustedcoin = {
+    enable = mkEnableOption "Trustedcoin (clightning plugin)";
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.trustedcoin;
+      defaultText = "config.nix-bitcoin.pkgs.trustedcoin";
+      description = "The package providing trustedcoin binaries.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.clightning.extraConfig = ''
+      plugin=${cfg.package}/bin/trustedcoin
+    '';
+  };
+}

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -30,6 +30,14 @@ let
         This also disables all DNS lookups, to avoid leaking address information.
       '';
     };
+    useBcli = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        If clightning should use the bcli plugin for getting on-chain block data.
+        Disable this to use other providers such as trustedcoin.
+      '';
+    };
     dataDir = mkOption {
       type = types.path;
       default = "/var/lib/clightning";
@@ -105,7 +113,8 @@ let
   network = config.services.bitcoind.makeNetworkName "bitcoin" "regtest";
   configFile = pkgs.writeText "config" ''
     network=${network}
-    bitcoin-datadir=${config.services.bitcoind.dataDir}
+    ${optionalString (!cfg.useBcli) "disable-plugin=bcli"}
+    ${optionalString (cfg.useBcli) "bitcoin-datadir=${config.services.bitcoind.dataDir}"}
     ${optionalString (cfg.proxy != null) "proxy=${cfg.proxy}"}
     always-use-proxy=${boolToString cfg.always-use-proxy}
     bind-addr=${cfg.address}:${toString cfg.port}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -20,6 +20,7 @@ let self = {
   # The secp256k1 version used by joinmarket
   secp256k1 = pkgs.callPackage ./secp256k1 { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
+  trustedcoin = pkgs.callPackage ./trustedcoin { };
 
   nbPython3Packages = (pkgs.python3.override {
     packageOverrides = import ./python-packages self;

--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "trustedcoin";
+  version = "0.5.2";
+  src = fetchFromGitHub {
+    owner = "fiatjaf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-s8zgY+TDABK96BehY+SVl86wCMd+e8BKdxw0kGV1jAI=";
+  };
+
+  vendorSha256 = "sha256-wpK5SW9nOMO/e4DoEk8LRxLykxYt06LoBBxjeEujOiU=";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Light bitcoin node implementation";
+    homepage = "https://github.com/fiatjaf/trustedcoin";
+    maintainers = with maintainers; [ nixbitcoin ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/trustedcoin/get-sha256.sh
+++ b/pkgs/trustedcoin/get-sha256.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p git gnupg curl jq
+set -euo pipefail
+
+TMPDIR="$(mktemp -d -p /tmp)"
+trap "rm -rf $TMPDIR" EXIT
+cd $TMPDIR
+
+echo "Fetching latest release"
+repo=fiatjaf/trustedcoin
+latest=$(curl -s --show-error https://api.github.com/repos/$repo/releases/latest | jq -r .tag_name)
+echo "Latest release is $latest"
+git clone --depth 1 --branch $latest https://github.com/fiatjaf/trustedcoin 2>/dev/null
+cd trustedcoin
+
+echo "tag: $latest"
+git checkout -q tags/$latest
+rm -rf .git
+nix --extra-experimental-features nix-command hash path .


### PR DESCRIPTION
Adds the [trustedcoin](https://github.com/fiatjaf/trustedcoin) plugin to allow using clightning without bitcoind, and an option to disable the bcli plugin in clightning, so trustedcoin can be used instead.

I didn't remove the clightning dependency on the bitcoind service though, but that could also be done.