### PR TITLE
test/lib/create-git-repo: fix variable quoting

### DIFF
--- a/test/lib/create-git-repo.sh
+++ b/test/lib/create-git-repo.sh
@@ -2,14 +2,14 @@
 (
   # shellcheck disable=SC2154,SC2164
   cd "$scriptDir/.."
-  amend=--amend
+  amend=(--amend)
 
   if [[ ! -e .git ]] || ! git rev-parse HEAD 2>/dev/null; then
     git init
-    amend=
+    amend=()
   fi
   git add .
   if ! git diff --quiet --cached; then
-    git commit -a "$amend" -m -
+    git commit -a "${amend[@]}" -m -
   fi
 ) >/dev/null


### PR DESCRIPTION
Remove quotes around var that may expand to nothing.