### PR TITLE
tests: disable `nixosSearch`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,7 +35,6 @@ task:
     - name: flake
       build_script:
         - nix flake check
-        - ./test/nixos-search/ci-test.sh
 
     - name: shellcheck
       build_script:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Hint: To show a table of contents, click the button (![Github TOC button](docs/i
 top left corner of the documents.
 
 <!-- TODO-EXTERNAL: -->
-<!-- Change query to `nix-bitcoin` when upstream search has been fixed -->
-* [NixOS options search](https://search.nixos.org/flakes?channel=unstable&sort=relevance&type=options&query=bitcoin)
 * [Hardware requirements](docs/hardware.md)
 * [Installation](docs/install.md)
 * [Configuration and maintenance](docs/configuration.md)

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -275,6 +275,11 @@ flake() {
 
 # Test generating module documentation for search.nixos.org
 nixosSearch() {
+    # TODO-EXTERNAL:
+    # Remove this when nixos-search has been fixed
+    echo "Skipping test nixosSearch"
+    return
+
     if ! checkFlakeSupport "nixosSearch"; then return; fi
 
     if [[ $_nixBitcoinInCopiedSrc ]]; then


### PR DESCRIPTION
The nixos-search binary currently fails with:
```
Error: Getting flake info caused an error: Failed to analyze flake ../..

Caused by:
    0: [22]: data did not match any variant of untagged enum FlakeEntry at line 1 column 11194
    1: data did not match any variant of untagged enum FlakeEntry at line 1 column 11194
```
This happens locally and in [CI](https://github.com/erikarvstedt/nix-bitcoin/runs/8193778511).

The [NixOS option search](https://search.nixos.org/flakes?channel=unstable&from=0&size=30&sort=relevance&type=options&query=mail) also has stopped showing results (for all queries).

The error doesn't happen when run in a firejail container with `--net=none`. I currently don't have time for further debugging.