### PR TITLE
lnd: fix missing RPC permissions when bitcoind is pruned

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -312,6 +312,7 @@ buildable() {
     scenario=regtest buildTest "$@"
     scenario=hardened buildTest "$@"
     scenario=clightningReplication buildTest "$@"
+    scenario=lndPruned buildTest "$@"
 }
 
 examples() {

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -318,6 +318,12 @@ let
       services.btcpayserver.lbtc = mkForce false;
     };
 
+    # Test the special bitcoin RPC setup that lnd uses when bitcoin is pruned
+    lndPruned = {
+      services.lnd.enable = true;
+      services.bitcoind.prune = 1000;
+    };
+
     ## Examples / debug helper
 
     # Run a selection of tests in scenario 'netns'


### PR DESCRIPTION
This branch includes some required commits from #559.

I've confirmed that lnd requires extra bitcoin RPC commands (via [pruned_block_dispatcher.go](https://github.com/btcsuite/btcwallet/blob/master/chain/pruned_block_dispatcher.go)) when bitcoind is pruned. This PR fixes the missing RPC permissions.

@ekimber, does this PR fix #562 for you?