### PR TITLE
bitcoind: fix rare startup error

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -380,7 +380,7 @@ in {
       # TODO-EXTERNAL: Instead of `wants`, use a future systemd dependency type
       # that propagates initial start failures but no restarts
       wants = [ "nix-bitcoin-secrets.target" ];
-      after = [ "network.target" "nix-bitcoin-secrets.target" ];
+      after = [ "network-online.target" "nix-bitcoin-secrets.target" ];
       wantedBy = [ "multi-user.target" ];
 
       preStart = let


### PR DESCRIPTION
#### Copy of commit msg
Previously, dhcpcd and bitcoind starting up in parallel could lead to the following error in bitcoind:
```
bitcoind: libevent: getaddrinfo: address family for nodename not supported
bitcoind: Binding RPC on address 127.0.0.1 port 8332 failed.
bitcoind: Unable to bind any endpoint for
```
After the initial failure, the bitcoind service would always restart successfully.

This race condition, where both applications were simultaneously manipulating network resources, was only triggered under specific hardware conditions.

Fix it by running bitcoind after dhcp has started (by running after `network-online.target`).
This bug and the fix only affect the default NixOS scripted networking backend.

#### Appendix

Upstream fix in nixpkgs: https://github.com/NixOS/nixpkgs/pull/199147