### PR TITLE
treewide: set shebang for bash scripts

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -265,7 +265,7 @@ let
       cli = mkOption {
         readOnly = true;
         type = types.package;
-        default = pkgs.writeScriptBin "bitcoin-cli" ''
+        default = pkgs.writers.writeBashBin "bitcoin-cli" ''
           exec ${cfg.package}/bin/bitcoin-cli -datadir='${cfg.dataDir}' "$@"
         '';
         defaultText = "(See source)";

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -81,7 +81,7 @@ let
     };
     cli = mkOption {
       readOnly = true;
-      default = pkgs.writeScriptBin "lightning-cli" ''
+      default = pkgs.writers.writeBashBin "lightning-cli" ''
         ${cfg.package}/bin/lightning-cli --lightning-dir='${cfg.dataDir}' "$@"
       '';
       defaultText = "(See source)";

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -73,7 +73,7 @@ let
       '';
     };
     cli = mkOption {
-      default = pkgs.writeScriptBin "loop" ''
+      default = pkgs.writers.writeBashBin "loop" ''
         ${cfg.package}/bin/loop \
         --rpcserver ${nbLib.addressWithPort cfg.rpcAddress cfg.rpcPort} \
         --macaroonpath '${cfg.dataDir}/${network}/loop.macaroon' \

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -49,7 +49,7 @@ let
       description = "Extra lines appended to the configuration file.";
     };
     cli = mkOption {
-      default = pkgs.writeScriptBin "pool" ''
+      default = pkgs.writers.writeBashBin "pool" ''
         exec ${cfg.package}/bin/pool \
           --rpcserver ${nbLib.addressWithPort cfg.rpcAddress cfg.rpcPort} \
           --network ${network} \

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -145,14 +145,14 @@ let
       };
       cli = mkOption {
         readOnly = true;
-        default = pkgs.writeScriptBin "elements-cli" ''
+        default = pkgs.writers.writeBashBin "elements-cli" ''
           ${nbPkgs.elementsd}/bin/elements-cli -datadir='${cfg.dataDir}' "$@"
         '';
         defaultText = "(See source)";
         description = "Binary to connect with the liquidd instance.";
       };
       swapCli = mkOption {
-        default = pkgs.writeScriptBin "liquidswap-cli" ''
+        default = pkgs.writers.writeBashBin "liquidswap-cli" ''
           ${nbPkgs.liquid-swap}/bin/liquidswap-cli -c '${cfg.dataDir}/elements.conf' "$@"
         '';
         defaultText = "(See source)";

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -109,7 +109,7 @@ let
       description = "The package providing lnd binaries.";
     };
     cli = mkOption {
-      default = pkgs.writeScriptBin "lncli"
+      default = pkgs.writers.writeBashBin "lncli"
         # Switch user because lnd makes datadir contents readable by user only
         ''
           ${runAsUser} ${cfg.user} ${cfg.package}/bin/lncli \

--- a/modules/nix-bitcoin.nix
+++ b/modules/nix-bitcoin.nix
@@ -27,7 +27,7 @@ with lib;
       # Related issue: https://github.com/NixOS/nixpkgs/issues/94236
       torify = mkOption {
         readOnly = true;
-        default = pkgs.writeScriptBin "torify" ''
+        default = pkgs.writers.writeBashBin "torify" ''
           ${pkgs.tor}/bin/torify \
             --address ${config.services.tor.client.socksListenAddress.addr} \
             "$@"


### PR DESCRIPTION
#### Copy of commit msg
These scripts previously failed when called with syscalls like `execve` (used by, e.g., Python's `subprocess.run`) that use no default interpreter for scripts without a shebang.