### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -40,11 +40,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672844754,
-        "narHash": "sha256-o26WabuHABQsaHxxmIrR3AQRqDFUEdLckLXkVCpIjSU=",
+        "lastModified": 1674407282,
+        "narHash": "sha256-2qwc8mrPINSFdWffPK+ji6nQ9aGnnZyHSItVcYDZDlk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9ade2c8240e00a4784fac282a502efff2786bdc",
+        "rev": "ab1254087f4cdf4af74b552d7fc95175d9bdbb49",
         "type": "github"
       },
       "original": {
@@ -56,11 +56,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1672756850,
-        "narHash": "sha256-Smbq3+fitwA13qsTMeaaurv09/KVbZfW7m7lINwzDGA=",
+        "lastModified": 1674487464,
+        "narHash": "sha256-Jgq50e4S4JVCYpWLqrabBzDp/1mfaxHCh8/OOorHTy0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "298add347c2bbce14020fcb54051f517c391196b",
+        "rev": "3954218cf613eba8e0dcefa9abe337d26bc48fd0",
         "type": "github"
       },
       "original": {

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -4,20 +4,20 @@ pkgs: pkgsUnstable:
   inherit (pkgs)
     bitcoin
     bitcoind
-    btcpayserver
-    electrs
     elementsd
     extra-container
-    hwi
     lightning-loop
     lightning-pool
     lndconnect
     nbxplorer;
 
   inherit (pkgsUnstable)
+    btcpayserver
     charge-lnd
     clightning
+    electrs
     fulcrum
+    hwi
     lnd;
 
   inherit pkgs pkgsUnstable;

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -18,11 +18,11 @@
     "nixos-org-configurations": {
       "flake": false,
       "locked": {
-        "lastModified": 1669836977,
-        "narHash": "sha256-21+3DkUXbWmIhXnQmJ9Tp/+QnyQnSiWuW8UDjjvPX2w=",
+        "lastModified": 1674564797,
+        "narHash": "sha256-MgGsFleE8Wzhu8XX3ulcBojkHzFLkII+D9sxkTHg7OU=",
         "owner": "NixOS",
         "repo": "nixos-org-configurations",
-        "rev": "241f12bc9218ee081dc12b6c1b4a10e5e78ffeb3",
+        "rev": "3ce43a1fb5181a0e33b1f67d36fa0f3affa6bc6c",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1673019806,
-        "narHash": "sha256-iZousPg/4eDv2c9MTRo9RP8jjjp7luP7JYWU71MXCds=",
+        "lastModified": 1674593115,
+        "narHash": "sha256-P4bjLR/8tJ/jVBBeHDzNS2BgVUdB6vS7Udfh30kULJs=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "1d9fac3a575623c79c1f56c771360b049888447b",
+        "rev": "be9a717b8032c7410337139f9dcfd6227b7407a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
btcpayserver: 1.7.2 -> 1.7.3
electrs: 0.9.10 -> 0.9.11
hwi: 2.1.1 -> 2.2.0

[Fixes](https://github.com/NixOS/nixpkgs/pull/211286) Git vulnerabilities CVE-2022-23521, CVE-2022-41903