### PR TITLE
Add torq

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ NixOS modules ([src](modules/modules.nix))
     * [Lightning Loop](https://github.com/lightninglabs/loop)
     * [Lightning Pool](https://github.com/lightninglabs/pool)
     * [charge-lnd](https://github.com/accumulator/charge-lnd): policy-based channel fee manager
+    * [torq](https://github.com/lncapital/torq): capital management tool for routing nodes
   * [lndconnect](https://github.com/LN-Zap/lndconnect): connect your wallet to lnd or
     clightning [via WireGuard](./docs/services.md#use-zeus-mobile-lightning-wallet-via-wireguard) or
     [Tor](./docs/services.md#use-zeus-mobile-lightning-wallet-via-tor)

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -236,6 +236,11 @@
   # Set this to enable the JoinMarket order book watcher.
   # services.joinmarket-ob-watcher.enable = true;
 
+  ### torq
+  # Set this to enable Torq, node management software for large Lightning Network nodes.
+  #
+  # services.torq.enable = true;
+
   ### Backups
   # Set this to enable nix-bitcoin's own backup service. By default, it
   # uses duplicity to incrementally back up all important files in /var/lib to

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -20,6 +20,7 @@
     ./lightning-pool.nix
     ./charge-lnd.nix
     ./lndconnect.nix # Requires onion-addresses.nix
+    ./torq.nix
     ./rtl.nix
     ./electrs.nix
     ./fulcrum.nix

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -300,6 +300,10 @@ in {
         connections = [ "bitcoind" ];
       };
       # id = 32 reserved for the upcoming mempool module
+      torq = {
+        id = 33; # TODO
+        connections = [ "lnd" ];
+      };
     };
 
     services.bitcoind = {
@@ -358,6 +362,8 @@ in {
     services.rtl.address = netns.rtl.address;
 
     services.clightning-rest.address = netns.clightning-rest.address;
+
+    services.torq.address = netns.torq.address;
   }
   ]);
 }

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -150,6 +150,7 @@ in {
       liquidd = mkInfo "";
       joinmarket-ob-watcher = mkInfo "";
       rtl = mkInfo "";
+      torq = mkInfo "";
       # Only add sshd when it has an onion service
       sshd = name: cfg: mkIfOnionPort "sshd" (onionPort: ''
         add_service("sshd", """info["onion_address"] = get_onion_address("sshd", ${onionPort})""")

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -122,6 +122,9 @@ in {
         rtl = {
           externalPort = 80;
         };
+        torq = {
+          externalPort = 80;
+        };
       };
     }
   ];

--- a/modules/presets/enable-tor.nix
+++ b/modules/presets/enable-tor.nix
@@ -40,6 +40,7 @@ in {
     joinmarket = defaultEnforceTor;
     joinmarket-ob-watcher = defaultEnforceTor;
     clightning-rest = defaultEnforceTor;
+    torq = defaultEnforceTor;
   };
 
   # Add onion services for incoming connections
@@ -51,5 +52,6 @@ in {
     spark-wallet.enable = defaultTrue;
     joinmarket-ob-watcher.enable = defaultTrue;
     rtl.enable = defaultTrue;
+    torq.enable = defaultTrue;
   };
 }

--- a/modules/torq.nix
+++ b/modules/torq.nix
@@ -1,0 +1,159 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  options.services = {
+    torq = {
+      enable = mkEnableOption "torq, a capital management tool for lnd";
+      address = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = mdDoc "Address to listen on.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 8089;
+        description = mdDoc "Port to listen on.";
+      };
+      settings = mkOption {
+        type = settingsFormat.type;
+        default = {};
+        example = { torq.debug = true; };
+        description = ''torq settings. See `torq --help` for possible options.'';
+      };
+      package = mkOption {
+        type = types.package;
+        default = config.nix-bitcoin.pkgs.torq;
+        defaultText = "config.nix-bitcoin.pkgs.torq";
+        description = "The package providing torq binaries.";
+      };
+      user = mkOption {
+        type = types.str;
+        default = "torq";
+        description = "The user as which to run torq.";
+      };
+      group = mkOption {
+        type = types.str;
+        default = cfg.user;
+        description = "The group as which to run torq.";
+      };
+      tor.enforce = nbLib.tor.enforce;
+    };
+  };
+
+  macaroonPermissions = {
+    invoices = ["read" "write"];
+    onchain = ["read" /*"write"*/];
+    offchain = ["read" /*"write"*/];
+    address = ["read" "write"];
+    message = ["read" "write"];
+    peers = ["read" "write"];
+    info = ["read"];
+    uri = ["/lnrpc.Lightning/UpdateChannelPolicy"];
+  };
+  macaroonPermissionsStr = concatStringsSep "," (
+    mapAttrsToList (entity: actions: (
+      concatStringsSep "," (map (action: ''{"entity":"${entity}","action":"${action}"}'') actions)
+    )) macaroonPermissions
+  );
+
+  cfg = config.services.torq;
+  nbLib = config.nix-bitcoin.lib;
+  secretsDir = config.nix-bitcoin.secretsDir;
+
+  settingsFormat = pkgs.formats.toml {};
+  configFile = settingsFormat.generate "torq.toml" cfg.settings;
+
+  dbName = "torq";
+  dataDir = "/var/lib/torq";
+in {
+  inherit options;
+
+  config = mkIf cfg.enable {
+    services.lnd = {
+      enable = true;
+      macaroons.torq = {
+        inherit (cfg) user;
+        permissions = macaroonPermissionsStr;
+      };
+    };
+
+    services.postgresql = let
+      postgresqlPackages = config.services.postgresql.package.pkgs;
+    in {
+      enable = true;
+      ensureDatabases = [ dbName ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensurePermissions."DATABASE \"${dbName}\"" = "ALL PRIVILEGES";
+        }
+      ];
+      extraPlugins = with postgresqlPackages; [ timescaledb ];
+      settings.shared_preload_libraries = "timescaledb";
+    };
+
+    services.torq.settings = {
+      torq.port = toString cfg.port;
+      torq.password = "";
+      lnd.macaroon-path = "/run/lnd/torq.macaroon";
+      lnd.tls-path = "/etc/nix-bitcoin-secrets/lnd-cert";
+      lnd.url = "localhost:10009";
+      db.name = "torq";
+      db.host = "/run/postgresql";
+      db.user = "torq";
+    };
+
+    systemd.services.torq-setup-db = rec {
+      requires = [ "postgresql.service" ];
+      after = requires;
+      serviceConfig = nbLib.defaultHardening // {
+        Type = "oneshot";
+        User = "postgres";
+        Group = "postgres";
+        RemainAfterExit = true;
+      };
+      script = ''
+        ${config.services.postgresql.package}/bin/psql ${dbName} -c "ALTER EXTENSION timescaledb UPDATE" || true
+        ${config.services.postgresql.package}/bin/psql ${dbName} -c "CREATE EXTENSION IF NOT EXISTS timescaledb"
+      '';
+    };
+
+    systemd.services.torq = rec {
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "lnd.service" "postgresql.service" "torq-setup-db.service" ];
+      after = requires;
+      serviceConfig = nbLib.defaultHardening // {
+        ExecStartPre = [
+          (nbLib.script "torq-setup-config" ''
+            <${configFile} sed "s|^password = \".*\"$|password = \"$(cat ${secretsDir}/torq-password)\"|" \
+              > '${dataDir}/torq.toml'
+          '')
+        ];
+        ExecStart = "${cfg.package}/bin/torq --config ${dataDir}/torq.toml start";
+        StateDirectory = "torq";
+        StateDirectoryMode = "770";
+        WorkingDirectory = dataDir;
+        User = cfg.user;
+        Restart = "on-failure";
+        RestartSec = "10s";
+      } // nbLib.allowedIPAddresses cfg.tor.enforce;
+    };
+
+    systemd.tmpfiles.rules = [
+      "d  '${dataDir}'     0770 ${cfg.user} ${cfg.group} - -"
+      "L+ '${dataDir}/web' -    -           -            - ${cfg.package}/web"
+    ];
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+    };
+    users.groups.${cfg.group} = {};
+
+    nix-bitcoin.secrets.torq-password.user = cfg.user;
+    nix-bitcoin.generateSecretsCmds.torq = ''
+      makePasswordSecret torq-password
+    '';
+  };
+}

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -18,7 +18,8 @@ pkgs: pkgsUnstable:
     fulcrum
     hwi
     lnd
-    nbxplorer;
+    nbxplorer
+    torq;
 
   inherit pkgs pkgsUnstable;
 }

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -123,6 +123,8 @@ let
         txfee = 200;
       };
 
+      tests.torq = cfg.torq.enable;
+
       tests.nodeinfo = config.nix-bitcoin.nodeinfo.enable;
 
       tests.backups = cfg.backups.enable;
@@ -199,6 +201,7 @@ let
       services.btcpayserver.enable = true;
       services.joinmarket.enable = true;
       services.joinmarket-ob-watcher.enable = true;
+      services.torq.enable = true;
       services.backups.enable = true;
 
       nix-bitcoin.nodeinfo.enable = true;

--- a/test/tests.py
+++ b/test/tests.py
@@ -279,6 +279,12 @@ def _():
     assert_running("joinmarket-ob-watcher")
     machine.wait_until_succeeds(log_has_string("joinmarket-ob-watcher", "Starting ob-watcher"))
 
+@test("torq")
+def _():
+    assert_running("torq")
+    wait_for_open_port(ip("torq"), 8089)
+    machine.wait_until_succeeds(log_has_string("torq", "ImportNodeInformation was imported successfully"))
+
 @test("nodeinfo")
 def _():
     status, _ = machine.execute("systemctl is-enabled --quiet onion-addresses 2> /dev/null")


### PR DESCRIPTION
Module for [torq](https://github.com/lncapital/torq), a capital management tool for LND. Closes #581.

----

- [x] DB setup
  * lncapital/torq#397
  * lncapital/torq#398
- [x] Automatically enable timescaledb
- [x] Add onion service
- [x] Build frontend nixos/nixpkgs#215288
- [x] Generate password
- [x] Bump torq in nixpkgs to >= 0.18.19 NixOS/nixpkgs#219903, then update nixpkgs here
- [ ] `config.services.torq.address` does nothing, torq always listens on 0.0.0.0