### PR TITLE
Integrate trustedcoin clightning plugin

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,6 +27,7 @@ task:
           - scenario: default
           - scenario: netns
           - scenario: netnsRegtest
+          - scenario: trustedcoin
       # This script is run as root
       build_script:
         - echo "sandbox = true" >> /etc/nix/nix.conf

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ NixOS modules ([src](modules/modules.nix))
     * [prometheus](https://github.com/lightningd/plugins/tree/master/prometheus): lightning node exporter for the prometheus timeseries server
     * [rebalance](https://github.com/lightningd/plugins/tree/master/rebalance): keeps your channels balanced
     * [summary](https://github.com/lightningd/plugins/tree/master/summary): print a nice summary of the node status
-    * [trustedcoin](https://github.com/nbd-wtf/trustedcoin): replaces bitcoind with trusted public explorers
+    * [trustedcoin](https://github.com/nbd-wtf/trustedcoin) [[experimental](docs/services.md#trustedcoin-hints)]: replaces bitcoind with trusted public explorers
     * [zmq](https://github.com/lightningd/plugins/tree/master/zmq): publishes notifications via ZeroMQ to configured endpoints
   * [clightning-rest](https://github.com/Ride-The-Lightning/c-lightning-REST): REST server for clightning
   * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service and [static channel backups](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ NixOS modules ([src](modules/modules.nix))
     * [prometheus](https://github.com/lightningd/plugins/tree/master/prometheus): lightning node exporter for the prometheus timeseries server
     * [rebalance](https://github.com/lightningd/plugins/tree/master/rebalance): keeps your channels balanced
     * [summary](https://github.com/lightningd/plugins/tree/master/summary): print a nice summary of the node status
+    * [trustedcoin](https://github.com/nbd-wtf/trustedcoin): replaces bitcoind with trusted public explorers
     * [zmq](https://github.com/lightningd/plugins/tree/master/zmq): publishes notifications via ZeroMQ to configured endpoints
   * [clightning-rest](https://github.com/Ride-The-Lightning/c-lightning-REST): REST server for clightning
   * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service and [static channel backups](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)

--- a/docs/services.md
+++ b/docs/services.md
@@ -621,3 +621,27 @@ services.clightning = {
 ```
 
 Please have a look at the module for a plugin (e.g. [prometheus.nix](../modules/clightning-plugins/prometheus.nix)) to learn its configuration options.
+
+### Trustedcoin hints
+The [trustedcoin](https://github.com/nbd-wtf/trustedcoin) plugin use a Tor
+proxy for all of its external connections by default. That's why you can
+sometimes face issues with your connections to esploras getting blocked.
+
+An example of clightning log error output in a case your connections are getting blocked:
+
+```
+lightningd[5138]: plugin-trustedcoin estimatefees error: https://blockstream.info/api error: 403 Forbidden
+```
+
+```
+lightningd[4933]: plugin-trustedcoin getblock error: got something that isn't a block hash: <html><head>
+lightningd[4933]: <meta http-equiv="content-type" content="text/html;
+```
+
+If you face these issues and you still need to use trustedcoin, use can disable
+clightning's tor hardening by setting this option in your `configuration.nix`
+file:
+
+```
+services.clightning.tor.enforce = false;
+```

--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -17,6 +17,7 @@ in {
     ./feeadjuster.nix
     ./prometheus.nix
     ./summary.nix
+    ./trustedcoin.nix
     ./zmq.nix
   ];
 

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -1,0 +1,21 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let cfg = config.services.clightning.plugins.trustedcoin; in
+{
+  options.services.clightning.plugins.trustedcoin = {
+    enable = mkEnableOption "Trustedcoin (clightning plugin)";
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.trustedcoin;
+      defaultText = "config.nix-bitcoin.pkgs.trustedcoin";
+      description = "The package providing trustedcoin binaries.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.clightning.extraConfig = ''
+      plugin=${cfg.package}/bin/trustedcoin
+    '';
+  };
+}

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -9,7 +9,7 @@ let cfg = config.services.clightning.plugins.trustedcoin; in
       type = types.package;
       default = config.nix-bitcoin.pkgs.trustedcoin;
       defaultText = "config.nix-bitcoin.pkgs.trustedcoin";
-      description = ''
+      description = mdDoc ''
         The package providing trustedcoin binaries. Trustedcoin will try to
         use a bitcoind as a trusted source for getting block data. If this
         fails, it will use a trustedcoin providers instead.

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -9,7 +9,11 @@ let cfg = config.services.clightning.plugins.trustedcoin; in
       type = types.package;
       default = config.nix-bitcoin.pkgs.trustedcoin;
       defaultText = "config.nix-bitcoin.pkgs.trustedcoin";
-      description = "The package providing trustedcoin binaries.";
+      description = ''
+        The package providing trustedcoin binaries. Trustedcoin will try to
+        use a bitcoind as a trusted source for getting block data. If this
+        fails, it will use a trustedcoin providers instead.
+      '';
     };
   };
 

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -9,17 +9,14 @@ let cfg = config.services.clightning.plugins.trustedcoin; in
       type = types.package;
       default = config.nix-bitcoin.pkgs.trustedcoin;
       defaultText = "config.nix-bitcoin.pkgs.trustedcoin";
-      description = mdDoc ''
-        The package providing trustedcoin binaries. Trustedcoin will try to
-        use a bitcoind as a trusted source for getting block data. If this
-        fails, it will use a trustedcoin providers instead.
-      '';
+      description = mdDoc "The package providing trustedcoin binaries.";
     };
   };
 
   config = mkIf cfg.enable {
     services.clightning.extraConfig = ''
       plugin=${cfg.package}/bin/trustedcoin
+      disable-plugin=bcli
     '';
   };
 }

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -18,5 +18,11 @@ let cfg = config.services.clightning.plugins.trustedcoin; in
       plugin=${cfg.package}/bin/trustedcoin
       disable-plugin=bcli
     '';
+
+    # Trustedcoin does not honor the clightning's proxy configuration.
+    # Ref.: https://github.com/nbd-wtf/trustedcoin/pull/19
+    systemd.services.clightning.environment = mkIf (config.services.clightning.proxy != null) {
+      HTTPS_PROXY = "socks5://${config.services.clightning.proxy}";
+    };
   };
 }

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -33,7 +33,7 @@ let
     useBcli = mkOption {
       type = types.bool;
       default = true;
-      description = ''
+      description = mdDoc ''
         If clightning should use the bitcoind as a main source for getting
         on-chain block data. Disable this to use a trustedcoin provider (the
         trustedcoin plugin will be automatically enabled).

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -20,6 +20,7 @@ let self = {
   # The secp256k1 version used by joinmarket
   secp256k1 = pkgs.callPackage ./secp256k1 { };
   spark-wallet = pkgs.callPackage ./spark-wallet { };
+  trustedcoin = pkgs.callPackage ./trustedcoin { };
 
   pyPkgs = import ./python-packages self pkgs.python3;
   inherit (self.pyPkgs)

--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -2,15 +2,15 @@
 
 buildGoModule rec {
   pname = "trustedcoin";
-  version = "0.5.2";
+  version = "0.6.1";
   src = fetchFromGitHub {
     owner = "nbd-wtf";
     repo = pname;
     rev = "v${version}";
-    sha256 = "sha256-s8zgY+TDABK96BehY+SVl86wCMd+e8BKdxw0kGV1jAI=";
+    sha256 = "sha256-UNQjxhAT0mK1In7vUtIoMoMNBV+0wkrwbDmm7m+0R3o=";
   };
 
-  vendorSha256 = "sha256-wpK5SW9nOMO/e4DoEk8LRxLykxYt06LoBBxjeEujOiU=";
+  vendorSha256 = "sha256-xvkK9rMQlXTnNyOMd79qxVSvhgPobcBk9cq4/YWbupY=";
 
   subPackages = [ "." ];
 

--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -1,0 +1,23 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "trustedcoin";
+  version = "0.5.2";
+  src = fetchFromGitHub {
+    owner = "nbd-wtf";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-s8zgY+TDABK96BehY+SVl86wCMd+e8BKdxw0kGV1jAI=";
+  };
+
+  vendorSha256 = "sha256-wpK5SW9nOMO/e4DoEk8LRxLykxYt06LoBBxjeEujOiU=";
+
+  subPackages = [ "." ];
+
+  meta = with lib; {
+    description = "Light bitcoin node implementation";
+    homepage = "https://github.com/nbd-wtf/trustedcoin";
+    maintainers = with maintainers; [ seberm fort-nix ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/trustedcoin/get-sha256.sh
+++ b/pkgs/trustedcoin/get-sha256.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p git gnupg curl jq
+set -euo pipefail
+
+
+TMPDIR="$(mktemp -d -p /tmp)"
+trap 'rm -rf $TMPDIR' EXIT
+cd "$TMPDIR"
+
+echo "Fetching latest release"
+repo='nbd-wtf/trustedcoin'
+latest=$(curl --location --silent --show-error https://api.github.com/repos/${repo}/releases/latest | jq -r .tag_name)
+echo "Latest release is $latest"
+git clone --depth 1 --branch "$latest" "https://github.com/${repo}" 2>/dev/null
+cd trustedcoin
+
+echo "tag: $latest"
+git checkout -q "tags/$latest"
+rm -rf .git
+nix --extra-experimental-features nix-command hash path .

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -45,7 +45,7 @@ let
       services.clightning.extraConfig = mkIf config.test.noConnections "disable-dns";
       test.data.clightning-plugins = let
         plugins = config.services.clightning.plugins;
-        removed = [ "commando" ];
+        removed = [ "commando" "trustedcoin" ];
         enabled = builtins.filter (plugin: plugins.${plugin}.enable)
                                   (subtractLists removed (builtins.attrNames plugins));
         nbPkgs = config.nix-bitcoin.pkgs;
@@ -314,6 +314,15 @@ let
     lndPruned = {
       services.lnd.enable = true;
       services.bitcoind.prune = 1000;
+    };
+
+    # Test the special clightning setup where trustedcoin plugin is used
+    trustedcoin = {
+      tests.trustedcoin = true;
+      services.clightning = {
+        enable = true;
+        plugins.trustedcoin.enable = true;
+      };
     };
   } // (import ../dev/dev-scenarios.nix {
     inherit lib scenarios;

--- a/test/tests.py
+++ b/test/tests.py
@@ -433,6 +433,18 @@ def _():
     if enabled("btcpayserver"):
         machine.wait_until_succeeds(log_has_string("nbxplorer", f"At height: {num_blocks}"))
 
+@test("trustedcoin")
+def _():
+    machine.wait_for_unit("bitcoind")
+    machine.wait_for_unit("clightning")
+
+    # Let's check the trustedcoin plugin was correctly initialized
+    machine.wait_until_succeeds(log_has_string("clightning", "plugin-trustedcoin[^^]\[0m\s+initialized plugin"))
+    machine.wait_until_succeeds(log_has_string("clightning", "plugin-trustedcoin[^^]\[0m\s+bitcoind RPC working"))
+    machine.wait_until_succeeds(log_has_string("clightning", "plugin-trustedcoin[^^]\[0m\s+tip: 0"))
+    machine.wait_until_succeeds(log_has_string("clightning", "plugin-trustedcoin[^^]\[0m\s+estimatefees error: none of the esploras returned usable responses"))
+
+
 if "netns-isolation" in enabled_tests:
     def ip(name):
         return test_data["netns"][name]["address"]


### PR DESCRIPTION
This PR tries to add a trustedcoin support into the nix-bitcoin.

The work is based on PRs:
- https://github.com/fort-nix/nix-bitcoin/pull/533 
- https://github.com/fort-nix/nix-bitcoin/pull/583

The code is rebased on current master.

I have removed the `clightning.useBcli` option and replaced it with `clightning.useBitcoind`. When setting this option to `true`, the bitcoind unit is forcerly disabled and `clightning.plugins.trustedcoin.enabled` is set to `true` as suggested in https://github.com/fort-nix/nix-bitcoin/pull/533#issuecomment-1229428074.

I also tried to add some basic tests.

@erikarvstedt , could you please take a look and give me some suggestions? Please keep in mind this is only a draft but I would like to move this feature forward.

Thanks!

CC: @neverupdate , @MatthewCroughan , @elsirion 
Closes #533 
