### PR TITLE
Update clightning-rest 0.9.0 -> 0.10.2

### DIFF
--- a/pkgs/clightning-rest/default.nix
+++ b/pkgs/clightning-rest/default.nix
@@ -9,11 +9,11 @@
 }:
 let self = stdenvNoCC.mkDerivation {
   pname = "clightning-rest";
-  version = "0.9.0";
+  version = "0.10.2";
 
   src = fetchurl {
     url = "https://github.com/Ride-The-Lightning/c-lightning-REST/archive/refs/tags/v${self.version}.tar.gz";
-    hash = "sha256-1thorV/UivDDH7oqjfm8VTd47LYSGooR2yEoETgBOH4=";
+    hash = "sha256-sWHaiGaEB3u8ZvTSzIqXV1g3c8DrxM4ywUPrRoFoFzg=";
   };
 
   passthru = {
@@ -22,7 +22,7 @@ let self = stdenvNoCC.mkDerivation {
 
     nodeModules = fetchNodeModules {
       inherit (self) src nodejs;
-      hash = "sha256-rQrAt2BDmNMUCVWxTJN3qoPonKlRWeJ8C4ZvF/gPygk=";
+      hash = "sha256-+qnrVTIkxpWQPz/ZTqhM2JK+fZoziBAW4vLkqCyrLO4=";
     };
   };
 

--- a/pkgs/clightning-rest/generate.sh
+++ b/pkgs/clightning-rest/generate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 . "${BASH_SOURCE[0]%/*}/../../helper/run-in-nix-env" "gnupg wget gnused" "$@"
 
-version="0.9.0"
+version="0.10.2"
 repo=https://github.com/Ride-The-Lightning/c-lightning-REST
 
 scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)


### PR DESCRIPTION
Update required to fix setting channel fees in RTL because setchannelfee has been removed from cln rpc API