### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681482634,
-        "narHash": "sha256-cT/nr3L8khEYZSGp8qqwxFH+/q4/547MfyOdSj6MhBk=",
+        "lastModified": 1683207485,
+        "narHash": "sha256-gs+PHt/y/XQB7S8+YyBLAM8LjgYpPZUVFQBwpFSmJro=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fda0d99c2cbbb5c89d8855d258cb0821bd9113ad",
+        "rev": "cc45a3f8c98e1c33ca996e3504adefbf660a72d1",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1681571934,
-        "narHash": "sha256-Q3B3HTqhTahhPCT53ahK1FPktOXlEWmudSttd9CWGbE=",
+        "lastModified": 1683353485,
+        "narHash": "sha256-Skp5El3egmoXPiINWjnoW0ktVfB7PR/xc4F4bhD+BJY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29176972b4be60f7d3eb3101f696c99f2e6ada57",
+        "rev": "caf436a52b25164b71e0d48b671127ac2e2a5b75",
         "type": "github"
       },
       "original": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -22,6 +22,11 @@ let self = {
   spark-wallet = pkgs.callPackage ./spark-wallet { };
   trustedcoin = pkgs.callPackage ./trustedcoin { };
 
+  # TODO-EXTERNAL:
+  # Remove this when https://github.com/lightningnetwork/lnd/pull/7672
+  # has been resolved
+  lnd = pkgsUnstable.callPackage ./lnd { };
+
   pyPkgs = import ./python-packages self pkgs.python3;
   inherit (self.pyPkgs)
     nbPython3Packages

--- a/pkgs/lnd/default.nix
+++ b/pkgs/lnd/default.nix
@@ -1,0 +1,12 @@
+{ lnd, fetchpatch }:
+
+lnd.overrideAttrs (_: {
+  patches = [
+    (fetchpatch {
+      # https://github.com/lightningnetwork/lnd/pull/7672
+      name = "fix-PKCS8-cert-key-support";
+      url = "https://github.com/lightningnetwork/lnd/pull/7672.patch";
+      hash = "sha256-j9EirxyNi48DGzLuHcZ36LrFlbJLXrE8L+1TYh5Yznk=";
+    })
+  ];
+})

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -17,7 +17,6 @@ pkgs: pkgsUnstable:
     fulcrum
     hwi
     lightning-loop
-    lnd
     nbxplorer;
 
   inherit pkgs pkgsUnstable;

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -5,7 +5,6 @@ pkgs: pkgsUnstable:
     bitcoin
     bitcoind
     extra-container
-    lightning-loop
     lightning-pool
     lndconnect;
 
@@ -17,6 +16,7 @@ pkgs: pkgsUnstable:
     elementsd
     fulcrum
     hwi
+    lightning-loop
     lnd
     nbxplorer;
 

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -39,11 +39,11 @@
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1681159207,
-        "narHash": "sha256-GQqLPhFm9WM2n5sQGwtjWlYe5J5uTHpsZ9rdO5q0fzM=",
+        "lastModified": 1683204679,
+        "narHash": "sha256-GrZj4skt6pjcNMmGQxvf5bSDYPzNahWKSNsHAtx5ERI=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "eb2910bffae596c379e2000efda780c0e47331b6",
+        "rev": "0498effc4137095938f16fd752cc81a96901554f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
#### Copy of commit msg
fulcrum: 1.9.0 -> 1.9.1
lightning-loop: 0.20.0-beta -> 0.23.0-beta
lnd: 0.15.5-beta -> 0.16.2-beta

#### Error
`lnd` currently fails with error:
```
[ERR] LTND: Shutting down because error in main method: error setting cert before unlock: unable to generate or renew TLS certificate:
the TLS key is encrypted but the --tlsencryptkey flag is not passed.
Please either restart lnd with the --tlsencryptkey flag or delete the TLS files for regeneration
```
This looks like an incompatibility with our self-generated certs.
Didn't have time to investigate this yet.
I'd be happy about hints on what's causing this.

Fixes #605
