### PR TITLE
lnd: fix non-static patch URL

### DIFF
--- a/pkgs/lnd/default.nix
+++ b/pkgs/lnd/default.nix
@@ -5,7 +5,7 @@ lnd.overrideAttrs (_: {
     (fetchpatch {
       # https://github.com/lightningnetwork/lnd/pull/7672
       name = "fix-PKCS8-cert-key-support";
-      url = "https://github.com/lightningnetwork/lnd/pull/7672.patch";
+      url = "https://github.com/lightningnetwork/lnd/commit/bfdd5db0d97a6d65489d980a917bbd2243dfe15c.patch";
       hash = "sha256-j9EirxyNi48DGzLuHcZ36LrFlbJLXrE8L+1TYh5Yznk=";
     })
   ];


### PR DESCRIPTION
Currently, updating https://github.com/lightningnetwork/lnd/pull/7672 would break our patched `lnd` because the patch URL is not content-addressed.

After this is merged, we should make another release.

Sorry for the mishap.