### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686656049,
-        "narHash": "sha256-rkYYVslFtRnhzryUFqJeYjPxorasymOg00z30GtR3iE=",
+        "lastModified": 1687083327,
+        "narHash": "sha256-1ZHIwhBaieb/Lvbph5NTgPta+r7V0RlaffgX3kbO9Jw=",
         "owner": "erikarvstedt",
         "repo": "extra-container",
-        "rev": "a6f74b9deb7bb2fdd346b74483c6a56946d5d332",
+        "rev": "8f729fcbb4deccb0a588f1ec2fdb01785b4f0059",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687171271,
+        "narHash": "sha256-BJlq+ozK2B1sJDQXS3tzJM5a+oVZmi1q0FlBK/Xqv7M=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "abfb11bd1aec8ced1c9bb9adfe68018230f4fb3c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686476475,
-        "narHash": "sha256-W9yUePvCSDghn+YUXewuodyPxt+kJl/a7zdY4Q6r4MU=",
+        "lastModified": 1687376262,
+        "narHash": "sha256-xtenf0Nc6So/5uaQqe8u3GVoAs/YdMUFsysPUuK8w1s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eef86b8a942913a828b9ef13722835f359deef29",
+        "rev": "7859e9c101fabbd62551b8f4260124a6e2f01a46",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1686582075,
-        "narHash": "sha256-vtflsfKkHtF8IduxDNtbme4cojiqvlvjp5QNYhvoHXc=",
+        "lastModified": 1687518131,
+        "narHash": "sha256-KirltRIc4SFfk8bTNudIqgKAALH5oqpW3PefmkfWK5M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e63eed145566cca98158613f3700515b4009ce3",
+        "rev": "3d8a93602bc54ece7a4e689d9aea1a574e2bbc24",
         "type": "github"
       },
       "original": {

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -2,7 +2,6 @@
 pkgs: pkgsUnstable:
 {
   inherit (pkgs)
-    extra-container
     lightning-pool
     lndconnect;
 
@@ -12,6 +11,7 @@ pkgs: pkgsUnstable:
     clightning
     electrs
     elementsd
+    extra-container
     fulcrum
     hwi
     lightning-loop

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -39,11 +39,11 @@
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1686481587,
-        "narHash": "sha256-sYBB4rIjp47t7WjpQXJ1wgkZ6TKfCfgDZ+eVWVAXXWY=",
+        "lastModified": 1687164217,
+        "narHash": "sha256-e1PcI2Zf6IKQZuH77CvEgAKjXj3URPWJ67Tups40UOI=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "d8a2c52c643eea5c8e37c8566526139c829500ab",
+        "rev": "b5acb880d160a478e8d3ad42aee8806979171135",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
extra-container: 0.11 -> 0.12
lnd: 0.16.2-beta -> 0.16.3-beta

Afaics 0.16.3-beta does not contain https://github.com/lightningnetwork/lnd/pull/7678 (see [comparison](https://github.com/lightningnetwork/lnd/compare/v0.16.2-beta...v0.16.3-beta) of tags)