### PR TITLE
Add versioned release branches

### DIFF
--- a/examples/flakes/flake.nix
+++ b/examples/flakes/flake.nix
@@ -2,6 +2,8 @@
   description = "A basic nix-bitcoin node";
 
   inputs.nix-bitcoin.url = "github:fort-nix/nix-bitcoin/release";
+  # You can also use a version branch to track a specific NixOS release
+  # inputs.nix-bitcoin.url = "github:fort-nix/nix-bitcoin/nixos-23.05";
 
   outputs = { self, nix-bitcoin }: {
 

--- a/helper/push-release.sh
+++ b/helper/push-release.sh
@@ -36,7 +36,7 @@ fi
 
 cd "${BASH_SOURCE[0]%/*}"
 
-RESPONSE=$(curl https://api.github.com/repos/$REPO/releases/latest 2> /dev/null)
+RESPONSE=$(curl -fsS https://api.github.com/repos/$REPO/releases/latest)
 echo "Latest release" "$(echo "$RESPONSE" | jq -r '.tag_name' | tail -c +2)"
 
 if [[ ! $DRY_RUN ]]; then
@@ -75,7 +75,7 @@ if [[ $DRY_RUN ]]; then
 fi
 
 POST_DATA="{ \"tag_name\": \"v$releaseVersion\", \"name\": \"nix-bitcoin-$releaseVersion\", \"body\": \"nix-bitcoin-$releaseVersion\", \"target_comitish\": \"$BRANCH\" }"
-RESPONSE=$(curl -H "Authorization: token $OAUTH_TOKEN" -d "$POST_DATA" https://api.github.com/repos/$REPO/releases 2> /dev/null)
+RESPONSE=$(curl -fsS -H "Authorization: token $OAUTH_TOKEN" -d "$POST_DATA" https://api.github.com/repos/$REPO/releases)
 ID=$(echo "$RESPONSE" | jq -r '.id')
 if [[ $ID == null ]]; then
     echo "Failed to create release with $POST_DATA"
@@ -84,8 +84,8 @@ fi
 
 post_asset() {
     GH_ASSET="https://uploads.github.com/repos/$REPO/releases/$ID/assets?name="
-    curl -H "Authorization: token $OAUTH_TOKEN" --data-binary "@$1" -H "Content-Type: application/octet-stream" \
-         "$GH_ASSET/$(basename "$1")" &> /dev/null
+    curl -fsS -H "Authorization: token $OAUTH_TOKEN" --data-binary "@$1" -H "Content-Type: application/octet-stream" \
+         "$GH_ASSET/$(basename "$1")"
 }
 post_asset nar-hash.txt
 post_asset nar-hash.txt.asc

--- a/helper/push-release.sh
+++ b/helper/push-release.sh
@@ -35,7 +35,8 @@ if [[ $DRY_RUN ]]; then
 else
     OAUTH_TOKEN=$(pass show nix-bitcoin/github/oauth-token)
     if [[ ! $OAUTH_TOKEN ]]; then
-        echo "Please set OAUTH_TOKEN variable"
+        echo "Error fetching OAUTH_TOKEN"
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
#### Copy of main commit msg
`push-release` now pushes to an extra branch named `nixos-<VERSION>`, alongside branch `release`.
This allows users to track a specific NixOS release, so that their config doesn't break when nix-bitcoin switches to a new NixOS release.