### PR TITLE
secure-node: add `sudo` shell alias for `doas`

### DIFF
--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -25,6 +25,7 @@ in {
     # Use doas instead of sudo
     security.doas.enable = true;
     security.sudo.enable = false;
+    environment.shellAliases.sudo = "doas";
 
     environment.systemPackages = with pkgs; [
       jq


### PR DESCRIPTION
#### Copy of commit msg

A convenience helper which allows running most `sudo` cmds while `doas` is enabled.

This is safe because all args supported by both `sudo` and `doas` that lead to command execution (like `-u <user>`) have identical semantics.