### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688764204,
-        "narHash": "sha256-FsvK+tIvelCI0tWwlMDKfiyb7P/KfxpGbXMrdCKiT8s=",
+        "lastModified": 1690558459,
+        "narHash": "sha256-5W7y1l2cLYPkpJGNlAja7XW2X2o9rjf0O1mo9nxS9jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8bb6c681cf86265fdcf3cc3119f757bbb085835",
+        "rev": "48e82fe1b1c863ee26a33ce9bd39621d2ada0a33",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1688798537,
-        "narHash": "sha256-+3QEnDgBiso8lgUJpMagn6xCujmarc6zCWfKYAd6nqU=",
+        "lastModified": 1690593349,
+        "narHash": "sha256-i6jdORO+YiP19pFNeR7oYIIwmzQvdxwNO+BmtATcYpA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842e90934a352f517d23963df3ec0474612e483c",
+        "rev": "11cf5e1c74fe6892e860afeeaf3bfb84fdb7b1c3",
         "type": "github"
       },
       "original": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -15,13 +15,11 @@ let self = {
   # when https://github.com/bitcoin/bitcoin/issues/27722 has been resolved
   bitcoin  = pkgsUnstable.libsForQt5.callPackage ./bitcoin {
     stdenv = if pkgsUnstable.stdenv.isDarwin then pkgsUnstable.darwin.apple_sdk_11_0.stdenv else pkgsUnstable.stdenv;
-    boost = pkgsUnstable.boost17x;
     withGui = true;
     inherit (pkgsUnstable.darwin) autoSignDarwinBinariesHook;
   };
 
   bitcoind = pkgsUnstable.callPackage ./bitcoin {
-    boost = pkgsUnstable.boost17x;
     withGui = false;
     inherit (pkgsUnstable.darwin) autoSignDarwinBinariesHook;
   };


### PR DESCRIPTION
btcpayserver: 1.10.2 -> 1.10.3

Also, don't override boost provided to the bitcoin package, same as in the nixpkgs.