### PR TITLE
rtl: fix lnd, lightning-loop connection errors

### DIFF
--- a/dev/dev-features.sh
+++ b/dev/dev-features.sh
@@ -275,9 +275,9 @@ c journalctl -u joinmarket-ob-watcher
 c journalctl -f -u joinmarket-ob-watcher
 
 # Check webinterface
-c curl localhost:62601
+c curl 127.0.0.1:62601
 nix run --inputs-from . nixpkgs#lynx -- --dump $ip:62601
-c curl -s localhost:62601 | grep -i "orders found"
+c curl -s 127.0.0.1:62601 | grep -i "orders found"
 
 #―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
 # rtl

--- a/docs/services.md
+++ b/docs/services.md
@@ -128,7 +128,7 @@ yourself with custom permissions.
 Normally you would connect to RTL via SSH tunneling with a command like this
 
 ```
-ssh -L 3000:localhost:3000 root@bitcoin-node
+ssh -L 3000:127.0.0.1:3000 root@bitcoin-node
 ```
 
 Or like this, if you are using `netns-isolation`
@@ -326,7 +326,7 @@ lndconnect-wg --url
 
     On Desktop
     ```
-    electrum --oneserver -1 -s "<electrs onion address>:t" -p socks5:localhost:9050
+    electrum --oneserver -1 -s "<electrs onion address>:t" -p socks5:127.0.0.1:9050
     ```
 
     On Android
@@ -365,11 +365,11 @@ lndconnect-wg --url
 4. Connect to your nix-bitcoin node's SSH onion service, forwarding a local port to the nix-bitcoin node's SSH server
 
     ```
-    ssh -i ~/.ssh/id_ed25519 -L <random port of your choosing>:localhost:22 root@<SSH onion address>
+    ssh -i ~/.ssh/id_ed25519 -L <random port of your choosing>:127.0.0.1:22 root@<SSH onion address>
     ```
 
-5. Edit your deployment tool's configuration and change the node's address to `localhost` and the ssh port to `<random port of your choosing>`.
-   If you use krops as described in the [installation tutorial](./install.md), set `target = "localhost:<random port of your choosing>";` in `krops/deploy.nix`.
+5. Edit your deployment tool's configuration and change the node's address to `127.0.0.1` and the ssh port to `<random port of your choosing>`.
+   If you use krops as described in the [installation tutorial](./install.md), set `target = "127.0.0.1:<random port of your choosing>";` in `krops/deploy.nix`.
 
 6. After deploying the new configuration, it will connect through the SSH tunnel you established in step iv. This also allows you to do more complex SSH setups that some deployment tools don't support. An example would be authenticating with [Trezor's SSH agent](https://github.com/romanz/trezor-agent), which provides extra security.
 

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -191,7 +191,7 @@ let
     [DAEMON]
     no_daemon = 0
     daemon_port = 27183
-    daemon_host = localhost
+    daemon_host = 127.0.0.1
     use_ssl = false
 
     [BLOCKCHAIN]

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -6,7 +6,7 @@ let
     enable = mkEnableOption "Lightning Loop, a non-custodial off/on chain bridge";
     rpcAddress = mkOption {
        type = types.str;
-       default = "localhost";
+       default = "127.0.0.1";
        description = mdDoc "Address to listen for gRPC connections.";
     };
     rpcPort = mkOption {
@@ -121,7 +121,7 @@ in {
       "d '${cfg.dataDir}' 0770 ${lnd.user} ${lnd.group} - -"
     ];
 
-    services.lightning-loop.certificate.extraIPs = mkIf (cfg.rpcAddress != "localhost") [ "${cfg.rpcAddress}" ];
+    services.lightning-loop.certificate.extraIPs = mkIf (cfg.rpcAddress != "127.0.0.1") [ "${cfg.rpcAddress}" ];
 
     systemd.services.lightning-loop = {
       wantedBy = [ "multi-user.target" ];

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -6,7 +6,7 @@ let
     enable = mkEnableOption "Lightning Pool, a marketplace for inbound lightning liquidity ";
     rpcAddress = mkOption {
        type = types.str;
-       default = "localhost";
+       default = "127.0.0.1";
        description = mdDoc "Address to listen for gRPC connections.";
     };
     rpcPort = mkOption {

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -6,7 +6,7 @@ let
     enable = mkEnableOption "Lightning Network daemon, a Lightning Network implementation in Go";
     address = mkOption {
       type = types.str;
-      default = "localhost";
+      default = "127.0.0.1";
       description = mdDoc "Address to listen for peer connections";
     };
     port = mkOption {
@@ -16,7 +16,7 @@ let
     };
     rpcAddress = mkOption {
       type = types.str;
-      default = "localhost";
+      default = "127.0.0.1";
       description = mdDoc "Address to listen for RPC connections.";
     };
     rpcPort = mkOption {
@@ -26,7 +26,7 @@ let
     };
     restAddress = mkOption {
       type = types.str;
-      default = "localhost";
+      default = "127.0.0.1";
       description = mdDoc "Address to listen for REST connections.";
     };
     restPort = mkOption {
@@ -224,7 +224,7 @@ in {
       "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
     ];
 
-    services.lnd.certificate.extraIPs = mkIf (cfg.rpcAddress != "localhost") [ "${cfg.rpcAddress}" ];
+    services.lnd.certificate.extraIPs = mkIf (cfg.rpcAddress != "127.0.0.1") [ "${cfg.rpcAddress}" ];
 
     systemd.services.lnd = {
       wantedBy = [ "multi-user.target" ];

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -279,13 +279,13 @@ let
       # lightning-loop contains no builtin swap server for regtest.
       # Add a dummy definition.
       services.lightning-loop.extraConfig = ''
-        server.host=localhost
+        server.host=127.0.0.1
       '';
 
       # lightning-pool contains no builtin auction server for regtest.
       # Add a dummy definition
       services.lightning-pool.extraConfig = ''
-        auctionserver=localhost
+        auctionserver=127.0.0.1
       '';
 
       # `validatepegin` is incompatible with regtest


### PR DESCRIPTION
#### Copy of commit msg

lnd and lightning-loop resolve `localhost` to an IPv4 address when creating RPC sockets.

Since NixOS 23.05, RTL (nodejs) resolves `localhost` to an IPv6 address when connecting to lnd and lightning-loop, which leads to connection errors.

To fix these and other potential errors, replace all instances of `localhost` with `127.0.0.1`.