### PR TITLE
Minor clightning fixes

### DIFF
--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -165,7 +165,7 @@ in {
     ];
 
     systemd.services.clightning = {
-      path  = [ nbPkgs.bitcoind ];
+      path  = [ bitcoind.package ];
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -170,8 +170,6 @@ in {
       requires = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];
       preStart = ''
-        # The RPC socket has to be removed otherwise we might have stale sockets
-        rm -f ${cfg.networkDir}/lightning-rpc
         umask u=rw,g=r,o=
         {
           cat ${configFile}


### PR DESCRIPTION
Use this to test commit `clightning: don't cleanup socket on startup`:
```bash
read -rd '' script <<'EOF' || :
  systemctl stop clightning
  echo
  echo 'clightning has stopped'
  systemctl status clightning | head -3
  echo
  echo 'the socket still exists after clightning has stopped'
  ls /var/lib/clightning/bitcoin/lightning-rpc
  echo
  systemctl start clightning
  echo 'clightning starts, rpc calls work'
  sleep 0.5
  lightning-cli getinfo
EOF
run-tests.sh -s clightning container --run c bash -c "$script"
```