### PR TITLE
pkgs/bitcoind: use `pkgs` instead of `pkgsUnstable`

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -13,15 +13,15 @@ let self = {
   # TODO-EXTERNAL:
   # Remove bitcoin and bitcoind 24.1 packages and replace with 25.0 from nixpkgs
   # when https://github.com/bitcoin/bitcoin/issues/27722 has been resolved
-  bitcoin  = pkgsUnstable.libsForQt5.callPackage ./bitcoin {
-    stdenv = if pkgsUnstable.stdenv.isDarwin then pkgsUnstable.darwin.apple_sdk_11_0.stdenv else pkgsUnstable.stdenv;
+  bitcoin  = pkgs.libsForQt5.callPackage ./bitcoin {
+    stdenv = if pkgs.stdenv.isDarwin then pkgs.darwin.apple_sdk_11_0.stdenv else pkgs.stdenv;
     withGui = true;
-    inherit (pkgsUnstable.darwin) autoSignDarwinBinariesHook;
+    inherit (pkgs.darwin) autoSignDarwinBinariesHook;
   };
 
-  bitcoind = pkgsUnstable.callPackage ./bitcoin {
+  bitcoind = pkgs.callPackage ./bitcoin {
     withGui = false;
-    inherit (pkgsUnstable.darwin) autoSignDarwinBinariesHook;
+    inherit (pkgs.darwin) autoSignDarwinBinariesHook;
   };
   clightning-rest = pkgs.callPackage ./clightning-rest { inherit (self) fetchNodeModules; };
   clboss = pkgs.callPackage ./clboss { };


### PR DESCRIPTION
#### Copy of commit msg
All deps required by `bitcoind` are available in `pkgs`.