### PR TITLE
treewide: ensure services are started after secrets setup

### DIFF
--- a/modules/backups.nix
+++ b/modules/backups.nix
@@ -106,7 +106,7 @@ in {
 
       systemd.services.duplicity = {
         wants = postgresqlBackupServices;
-        after = postgresqlBackupServices;
+        after = postgresqlBackupServices ++ [ "nix-bitcoin-secrets.target" ];
       };
 
       services.postgresqlBackup = {

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -174,7 +174,7 @@ in {
     in rec {
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" "postgresql.service" ] ++ optional cfg.btcpayserver.lbtc "liquidd.service";
-      after = requires;
+      after = requires ++ [ "nix-bitcoin-secrets.target" ];
       preStart = ''
         install -m 600 ${configFile} '${cfg.nbxplorer.dataDir}/settings.config'
         {

--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -168,7 +168,7 @@ in {
       path  = [ bitcoind.package ];
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         umask u=rw,g=r,o=
         {

--- a/modules/electrs.nix
+++ b/modules/electrs.nix
@@ -68,7 +68,7 @@ in {
     systemd.services.electrs = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         echo "auth = \"${bitcoind.rpc.users.public.name}:$(cat ${secretsDir}/bitcoin-rpcpassword-public)\"" \
           > electrs.toml

--- a/modules/fulcrum.nix
+++ b/modules/fulcrum.nix
@@ -112,7 +112,7 @@ in {
     systemd.services.fulcrum = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         {
           cat ${configFile}

--- a/modules/joinmarket-ob-watcher.nix
+++ b/modules/joinmarket-ob-watcher.nix
@@ -75,7 +75,7 @@ in {
     systemd.services.joinmarket-ob-watcher = rec {
       wantedBy = [ "multi-user.target" ];
       requires = [ "tor.service" "bitcoind.service" ];
-      after = requires;
+      after = requires ++ [ "nix-bitcoin-secrets.target" ];
       # The service writes to HOME/.config/matplotlib
       environment.HOME = cfg.dataDir;
       preStart = ''

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -303,7 +303,7 @@ in {
     systemd.services.joinmarket = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         {
           cat ${configFile}
@@ -387,7 +387,7 @@ in {
     systemd.services.joinmarket-yieldgenerator = {
       wantedBy = [ "joinmarket.service" ];
       requires = [ "joinmarket.service" ];
-      after = [ "joinmarket.service" ];
+      after = [ "joinmarket.service" "nix-bitcoin-secrets.target" ];
       script = ''
         tr -d "\n" <"${secretsDir}/jm-wallet-password" \
         | ${nbPkgs.joinmarket}/bin/jm-yg-privacyenhanced --datadir='${cfg.dataDir}' \

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -126,7 +126,7 @@ in {
     systemd.services.lightning-loop = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "lnd.service" ];
-      after = [ "lnd.service" ];
+      after = [ "lnd.service" "nix-bitcoin-secrets.target" ];
       serviceConfig = nbLib.defaultHardening // {
         ExecStart = "${cfg.package}/bin/loopd --configfile=${configFile}";
         User = lnd.user;

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -256,7 +256,7 @@ in {
 
     systemd.services.liquidd = {
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''
         install -m 640 ${configFile} '${cfg.dataDir}/elements.conf'

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -229,7 +229,7 @@ in {
     systemd.services.lnd = {
       wantedBy = [ "multi-user.target" ];
       requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         install -m600 ${configFile} '${cfg.dataDir}/lnd.conf'
         {

--- a/modules/rtl.nix
+++ b/modules/rtl.nix
@@ -189,7 +189,7 @@ in {
       wantedBy = [ "multi-user.target" ];
       requires = optional cfg.nodes.clightning.enable "clightning-rest.service" ++
                  optional cfg.nodes.lnd.enable "lnd.service";
-      after = requires;
+      after = requires ++ [ "nix-bitcoin-secrets.target" ];
       environment.RTL_CONFIG_PATH = cfg.dataDir;
       environment.DB_DIRECTORY_PATH = cfg.dataDir;
       serviceConfig = nbLib.defaultHardening // {


### PR DESCRIPTION
#### Copy of commit msg
Now all services that access secrets only run after the secrets setup has finished.

Previously, we assumed that the systemd `after` dependency is transitive, i.e. that adding an `after = [ "bitcoind.service" ]` to a service implicitly pulled in the `after` dependency to `nix-bitcoin-secrets.target` (which is defined for `bitcoind`).
This is not the case. Services could start before secrets setup had finished, leading to service failure.