### PR TITLE
Revert "clightning: don't cleanup socket on startup"

### DIFF
--- a/modules/clightning.nix
+++ b/modules/clightning.nix
@@ -170,6 +170,11 @@ in {
       requires = [ "bitcoind.service" ];
       after = [ "bitcoind.service" ];
       preStart = ''
+        # Remove an existing socket so that `postStart` can detect when when a new
+        # socket has been created and clightning is ready to accept RPC connections.
+        # This will no longer be needed when clightning supports systemd startup notifications.
+        rm -f ${cfg.networkDir}/lightning-rpc
+
         umask u=rw,g=r,o=
         {
           cat ${configFile}


### PR DESCRIPTION
#### Copy of commit msg
Also, add a detailed comment.

Without this commit, clightning client services may fail to start because of clightning RPC connection failures. This can happen unnoticed due to the service auto restart mechanism.