### PR TITLE
fix pkgconfig -> pkg-config rename

### DIFF
--- a/pkgs/clboss/default.nix
+++ b/pkgs/clboss/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, autoconf-archive, autoreconfHook, pkgconfig, curl, libev, sqlite }:
+{ lib, stdenv, fetchFromGitHub, autoconf-archive, autoreconfHook, pkg-config, curl, libev, sqlite }:
 
 let
   curlWithGnuTLS = curl.override { gnutlsSupport = true; opensslSupport = false; };
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     autoconf-archive
-    pkgconfig
+    pkg-config
     libev
     curlWithGnuTLS
     sqlite


### PR DESCRIPTION
If I use the latest nixpkgs-unstable, i get this error when enabling clboss:

```
$ sudo nixos-rebuild switch 
building the system configuration...
error:
       … while calling the 'head' builtin

         at /nix/store/mj0hy52z22q5gpsf33akndxiclxd8ray-source/lib/attrsets.nix:850:11:

          849|         || pred here (elemAt values 1) (head values) then
          850|           head values
             |           ^
          851|         else

       … while evaluating the attribute 'value'

         at /nix/store/mj0hy52z22q5gpsf33akndxiclxd8ray-source/lib/modules.nix:807:9:

          806|     in warnDeprecation opt //
          807|       { value = builtins.addErrorContext "while evaluating the option `${showOption loc}':" value;
             |         ^
          808|         inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 'pkgconfig' has been renamed to/replaced by 'pkg-config'
```

This PR renames `pkgconfig` to the new name, `pkg-config`.