### PR TITLE
Docs: fix small error in installation.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -337,6 +337,6 @@ Other available systems:
 For security reasons, all normal system management tasks can and should be performed with the `operator` user. Logging in as `root` should be done as rarely as possible.
 
 See also:
-- [Migrating existing services to bitcoind](configuration.md#migrate-existing-services-to-nix-bitcoin)
+- [Migrating existing services to nix-bitcoin](configuration.md#migrate-existing-services-to-nix-bitcoin)
 - [Managing your deployment](configuration.md#managing-your-deployment)
 - [Using services](services.md)


### PR DESCRIPTION
"Migrating existing services to bitcoind" at the bottom of nix-bitcoin/docs/install.md should read "Migrating existing services to nix-bitcoin" since it links to the section of configuration.md called "Migrate existing services to nix-bitcoin"