### PR TITLE
tests/hardened: fix test for slower hardware

### DIFF
--- a/test/tests.nix
+++ b/test/tests.nix
@@ -264,6 +264,17 @@ let
         scenarios.secureNode
         ../modules/presets/hardened-extended.nix
       ];
+
+      # Patch clightning to increase the plugin init timeout.
+      # Otherwise this test can fail on slower hardware.
+      nix-bitcoin.pkgOverlays = super: self: {
+        clightning = super.clightning.overrideAttrs (old: {
+          postPatch = old.postPatch + ''
+            substituteInPlace lightningd/plugin.c \
+              --replace "#define PLUGIN_MANIFEST_TIMEOUT 60" "#define PLUGIN_MANIFEST_TIMEOUT 200"
+          '';
+        });
+      };
     };
 
     netnsBase = { config, pkgs, ... }: {


### PR DESCRIPTION
Due to the slowdown caused by the hardening features, the `hardened` test occasionally failed since the upgrade to NixOS 23.11.
Error:
```
vm-test-run-nix-bitcoin-hardened> machine # [  147.136056] lightningd[1667]: UNUSUAL plugin-cl-zmq.py: Killing plugin: timed out before replying to getmanifest
vm-test-run-nix-bitcoin-hardened> machine # [  147.151591] lightningd[1667]: UNUSUAL plugin-cl-zmq.py: Killing plugin: Invalid/missing result tok in '{"jsonrpc": "2.0","id": 16,"error": {"code":-4, "message":"Plugin terminated before replying to RPC call."}}'
vm-test-run-nix-bitcoin-hardened> machine # [  147.152555] lightningd[1667]: Can't recover from plugin failure, terminating.`
```