### PR TITLE
test: use `nixpkgs-unstable` flake input for nix-bitcoin pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
         # "armv7l-linux"
       ];
 
-      test = import ./test/tests.nix nixpkgs.lib;
+      test = import ./test/tests.nix nixpkgs.lib self.nixosModules.default;
     in {
       lib = {
         mkNbPkgs = {

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -1,6 +1,6 @@
 # Integration tests, can be run without internet access.
 
-lib:
+lib: nixBitcoinModule:
 let
   # Included in all scenarios
   baseConfig = { config, pkgs, ... }: with lib; let
@@ -9,7 +9,7 @@ let
   in {
     imports = [
       ./lib/test-lib.nix
-      ../modules/modules.nix
+      nixBitcoinModule
       {
         # Features required by the Python test suite
         nix-bitcoin.secretsDir = "/secrets";


### PR DESCRIPTION
#### Copy of commit msg
By using the `default` flake module for tests, `pkgsUnstable` in `pkgs/default.nix` gets passed the `nixpkgs-unstable` flake input instead of falling back to importing `nixpkgsPinned.nixpkgs-unstable`.

For some use cases this prevents importing `nixpkgs-unstable` twice (once via the `nixpkgs-unstable` flake input, once via `import nixpkgsPinned.nixpkgs-unstable`).