### PR TITLE
rtl: 0.14.1 -> 0.15.4, add `clightning.plugins.clnrest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ NixOS modules ([src](modules/modules.nix))
     * [rebalance](https://github.com/lightningd/plugins/tree/master/rebalance): keeps your channels balanced
     * [trustedcoin](https://github.com/nbd-wtf/trustedcoin) ([experimental](docs/services.md#trustedcoin)): replaces bitcoind with trusted public explorers
     * [zmq](https://github.com/lightningd/plugins/tree/master/zmq): publishes notifications via ZeroMQ to configured endpoints
-  * [clightning-rest](https://github.com/Ride-The-Lightning/c-lightning-REST): REST server for clightning
   * [lnd](https://github.com/lightningnetwork/lnd) with support for announcing an onion service and [static channel backups](https://github.com/lightningnetwork/lnd/blob/master/docs/recovery.md)
     * [Lightning Loop](https://github.com/lightninglabs/loop)
     * [Lightning Pool](https://github.com/lightninglabs/pool)

--- a/dev/dev-scenarios.nix
+++ b/dev/dev-scenarios.nix
@@ -66,6 +66,16 @@ with lib;
         onion = true;
       };
     };
+    services.clightning = {
+      enable = true;
+      plugins.clnrest = {
+        enable = true;
+        lnconnect = {
+          enable = true;
+          onion = true;
+        };
+      };
+    };
     services.clightning-rest = {
       enable = true;
       lndconnect = {

--- a/dev/topics/lndconnect-and-wireguard.sh
+++ b/dev/topics/lndconnect-and-wireguard.sh
@@ -7,13 +7,15 @@ run-tests.sh -s wireguard-lndconnect-online container
 # 2. Test connecting via Tor
 # Print QR codes for lnd, clightning-rest connections via Tor
 c lndconnect
+c lnconnect-clnrest
 c lndconnect-clightning
-# Add these to Zeus >= 0.7.1.
+# Add these to Zeus >= 0.9.0.
 # To explicitly check if the connection is successful, press the node logo in the top
 # left corner, and then "Node Info".
 
 # Debug
 c lndconnect --url
+c lnconnect-clnrest --url
 c lndconnect-clightning --url
 
 # 3. Test connecting via WireGuard
@@ -33,13 +35,15 @@ c nix-bitcoin-wg-connect --text
 
 # Print QR codes for lnd, clightning-rest connections via WireGuard
 c lndconnect-wg
+c lnconnect-clnrest-wg
 c lndconnect-clightning-wg
-# Add these to Zeus >= 0.7.1.
-# To explicitly check if the connection is successful, press the node logo in the top
+# Add these to Zeus >= 0.9.0.
+# To explicitly check if the connection is successful, press the menu button in the top
 # left corner, and then "Node Info".
 
 # Debug
 c lndconnect-wg --url
+c lnconnect-clnrest-wg --url
 c lndconnect-clightning-wg --url
 
 # 3.3.remove external firewall port forward, remove local port forward:
@@ -55,6 +59,8 @@ c nodeinfo
 
 c lndconnect --url
 c lndconnect-wg --url
+c lndconnect-clnrest --url
+c lndconnect-clnrest-wg --url
 c lndconnect-clightning --url
 c lndconnect-clightning-wg --url
 

--- a/dev/topics/rtl.sh
+++ b/dev/topics/rtl.sh
@@ -17,8 +17,6 @@ c systemctl status rtl
 c journalctl -u rtl
 c cat /var/lib/rtl/RTL-Config.json
 
-c systemctl status clightning-rest
-
 # Open webinterface. Password: a
 runuser -u "$(logname)" -- xdg-open "http://$ip:3000"
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -143,7 +143,7 @@ The default password location is `$secretsDir/rtl-password`.
 See: [Secrets dir](./configuration.md#secrets-dir)
 
 # Use Zeus (mobile lightning wallet) via Tor
-1. Install [Zeus](https://zeusln.app) (version ≥ 0.7.1)
+1. Install [Zeus](https://zeusln.app) (version ≥ 0.9.0)
 
 2. Edit your `configuration.nix`
 
@@ -161,9 +161,9 @@ See: [Secrets dir](./configuration.md#secrets-dir)
 
    Add the following config:
    ```nix
-   services.clightning-rest = {
+   services.clightning.plugins.clnrest = {
      enable = true;
-     lndconnect = {
+     lnconnect = {
        enable = true;
        onion = true;
      };
@@ -182,7 +182,7 @@ See: [Secrets dir](./configuration.md#secrets-dir)
 
    ##### For clightning
    ```
-   lndconnect-clightning
+   lnconnect-clnrest
    ```
 
 5. Configure Zeus
@@ -212,7 +212,7 @@ There are two ways to establish a secure, direct connection:
 - Connecting via WireGuard. This approach is simpler and more versatile, and is
   described in this guide.
 
-1. Install [Zeus](https://zeusln.app) (version ≥ 0.7.1) and
+1. Install [Zeus](https://zeusln.app) (version ≥ 0.9.0) and
    [WireGuard](https://www.wireguard.com/install/) on your mobile device.
 
 2. Add the following to your `configuration.nix`:
@@ -229,9 +229,11 @@ There are two ways to establish a secure, direct connection:
    services.lnd.lndconnect.enable = true;
 
    # For clightning
-   services.clightning-rest = {
-     enable = true;
-     lndconnect.enable = true;
+   services.clightning = {
+     plugins.clnrest = {
+       enable = true;
+       lnconnect.enable = true;
+     };
    };
    ```
 3. Deploy your configuration.
@@ -275,7 +277,7 @@ There are two ways to establish a secure, direct connection:
 
    ##### For clightning
    ```
-   lndconnect-clightning-wg
+   lnconnect-clnrest-wg
    ```
 
    Configure Zeus:

--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -56,15 +56,15 @@
   #
   # == REST server
   # Set this to create a clightning REST onion service.
-  # This also adds binary `lndconnect-clightning` to the system environment.
+  # This also adds binary `lnconnect-clnrest` to the system environment.
   # This binary creates QR codes or URLs for connecting applications to clightning
   # via the REST onion service.
   # You can also connect via WireGuard instead of Tor.
   # See ../docs/services.md for details.
   #
-  # services.clightning-rest = {
+  # services.clightning.plugins.clnrest = {
   #   enable = true;
-  #   lndconnect = {
+  #   lnconnect = {
   #     enable = true;
   #     onion = true;
   #   };

--- a/modules/clightning-plugins/clnrest.nix
+++ b/modules/clightning-plugins/clnrest.nix
@@ -1,0 +1,78 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  options = {
+    services.clightning.plugins.clnrest = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Enable clnrest (clightning plugin).
+
+          clnrest provides a clightning REST API, using clightning RPC calls as its backend.
+          It also broadcasts clightning notifications to listeners connected to its websocket server.
+
+          See here for all available options:
+          https://docs.corelightning.org/docs/rest
+          Extra options can be set via `services.clightning.extraConfig`.
+        '';
+      };
+      address = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "Address to listen for REST connections.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 3010;
+        description = "REST server port.";
+      };
+      createAdminRune = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Create a rune with admin permissions at path `''${config.services.clightning.networkDir}/admin-rune`.
+        '';
+      };
+      package = mkOption {
+        type = types.package;
+        default = config.nix-bitcoin.pkgs.nbPython3Packages.clnrest;
+        defaultText = "config.nix-bitcoin.pkgs.nbPython3Packages.clnrest";
+        description = "The package providing clnrest binaries.";
+      };
+    };
+
+    # Internal read-only options used by `./nodeinfo.nix` and `./onion-services.nix`
+    services.clnrest = let
+      inherit (config.nix-bitcoin.lib) mkAlias;
+    in {
+      enable = mkAlias cfg.enable;
+      address = mkAlias cfg.address;
+      port = mkAlias cfg.port;
+    };
+  };
+
+  cfg = config.services.clightning.plugins.clnrest;
+  inherit (config.services) clightning;
+
+  runePath = "${clightning.networkDir}/admin-rune";
+in
+{
+  inherit options;
+
+  config = mkIf cfg.enable {
+    services.clightning.extraConfig = ''
+      plugin=${cfg.package}/bin/clnrest
+      clnrest-host=${cfg.address}
+      clnrest-port=${toString cfg.port}
+    '';
+
+    systemd.services.clightning.postStart = mkIf cfg.createAdminRune (mkAfter ''
+      if [[ ! -e '${runePath}' ]]; then
+        rune=$(${clightning.cli}/bin/lightning-cli createrune | ${pkgs.jq}/bin/jq -r .rune)
+        install -m 640 <(echo "$rune") '${runePath}'
+      fi
+    '');
+  };
+}

--- a/modules/clightning-plugins/default.nix
+++ b/modules/clightning-plugins/default.nix
@@ -13,6 +13,7 @@ let
 in {
   imports = [
     ./clboss.nix
+    ./clnrest.nix
     ./feeadjuster.nix
     ./trustedcoin.nix
     ./zmq.nix

--- a/modules/mempool.nix
+++ b/modules/mempool.nix
@@ -138,11 +138,7 @@ let
 
     # Internal read-only options used by `./nodeinfo.nix` and `./onion-services.nix`
     mempool-frontend = let
-      mkAlias = default: mkOption {
-        internal = true;
-        readOnly = true;
-        inherit default;
-      };
+      inherit (nbLib) mkAlias;
     in {
       enable = mkAlias cfg.frontend.enable;
       address = mkAlias cfg.frontend.address;

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -286,7 +286,7 @@ in {
         in
           optional nodes.lnd.enable "lnd" ++
           optional (nodes.lnd.enable && nodes.lnd.loop) "lightning-loop" ++
-          optional nodes.clightning.enable "clightning-rest";
+          optional nodes.clightning.enable "clightning";
       };
       clightning-rest = {
         id = 30;

--- a/modules/netns-isolation.nix
+++ b/modules/netns-isolation.nix
@@ -315,6 +315,7 @@ in {
     };
 
     services.clightning.address = netns.clightning.address;
+    services.clightning.plugins.clnrest.address = netns.clightning.address;
 
     services.lnd = {
       address = netns.lnd.address;

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -142,6 +142,10 @@ in {
       '') + ''
         info["nodeid"] = shell("lncli getinfo | jq -r '.identity_pubkey'")
       '') name cfg;
+      clnrest = name: cfg: mkInfoLong {
+        inherit name cfg;
+        systemdServiceName = "clightning";
+      };
       clightning-rest = mkInfo "";
       electrs = mkInfo "";
       fulcrum = mkInfo "";
@@ -153,7 +157,6 @@ in {
       mempool-frontend = name: cfg: mkInfoLong {
         inherit name cfg;
         systemdServiceName = "nginx";
-        extraCode = "";
       };
       # Only add sshd when it has an onion service
       sshd = name: cfg: mkIfOnionPort "sshd" (onionPort: ''

--- a/pkgs/lib.nix
+++ b/pkgs/lib.nix
@@ -123,4 +123,10 @@ let self = {
     mkIfTest = test: mkIf (config.tests.${test} or false);
   };
 
+  mkAlias = default: mkOption {
+    internal = true;
+    readOnly = true;
+    inherit default;
+  };
+
 }; in self

--- a/pkgs/python-packages/clnrest/default.nix
+++ b/pkgs/python-packages/clnrest/default.nix
@@ -1,0 +1,58 @@
+{ buildPythonPackage
+, clightning
+, python
+, poetry-core
+, flask
+, flask-cors
+, flask-restx
+, flask-socketio
+, gevent
+, gevent-websocket
+, gunicorn
+, pyln-client
+, json5
+, jsonschema
+}:
+
+let
+  self = buildPythonPackage rec {
+    pname = "clnrest";
+    version = clightning.version;
+    format = "pyproject";
+
+    inherit (clightning) src;
+
+    postUnpack = "sourceRoot=$sourceRoot/plugins/clnrest";
+
+    postPatch = ''
+      substituteInPlace pyproject.toml \
+        --replace 'gevent = "^23.9.0.post1"' 'gevent = "24.2.1"' \
+        --replace 'flask = "^2.3.3"' 'flask = "3.0.3"'
+
+      # Add extra required src files that are missing in pyproject.toml
+      sed -i '/authors/a include = [ { path = "utilities", format = ["sdist", "wheel"] } ]' pyproject.toml
+    '';
+
+    nativeBuildInputs = [ poetry-core ];
+
+    # From https://github.com/ElementsProject/lightning/blob/master/plugins/clnrest/pyproject.toml
+    propagatedBuildInputs = [
+      flask
+      flask-cors
+      flask-restx
+      flask-socketio
+      gevent
+      gevent-websocket
+      gunicorn
+      json5
+      pyln-client
+    ];
+
+    postInstall = ''
+      makeWrapper ${python}/bin/python $out/bin/clnrest \
+        --set NIX_PYTHONPATH ${python.pkgs.makePythonPath self.propagatedBuildInputs} \
+        --add-flags "$out/lib/${python.libPrefix}/site-packages/clnrest.py"
+    '';
+  };
+in
+  self

--- a/pkgs/python-packages/default.nix
+++ b/pkgs/python-packages/default.nix
@@ -10,6 +10,7 @@ rec {
       pyln-proto = clightningPkg ./pyln-proto;
       pyln-bolt7 = clightningPkg ./pyln-bolt7;
       pylightning = clightningPkg ./pylightning;
+      clnrest = clightningPkg ./clnrest;
 
       # Packages only used by joinmarket
       bencoderpyx = callPackage ./bencoderpyx {};

--- a/pkgs/rtl/default.nix
+++ b/pkgs/rtl/default.nix
@@ -9,11 +9,11 @@
 }:
 let self = stdenvNoCC.mkDerivation {
   pname = "rtl";
-  version = "0.14.1";
+  version = "0.15.2";
 
   src = fetchurl {
     url = "https://github.com/Ride-The-Lightning/RTL/archive/refs/tags/v${self.version}.tar.gz";
-    hash = "sha256-sbV7d/imdCXglpAS3hh7fETvSxMzegi63AfbS1imqbk=";
+    hash = "sha256-8Scgrr1An8vwiVgDFxVP6FQksqd6ctwZN2W2ErPp39Y=";
   };
 
   passthru = {
@@ -25,7 +25,7 @@ let self = stdenvNoCC.mkDerivation {
       # TODO-EXTERNAL: Remove `npmFlags` when no longer required
       # See: https://github.com/Ride-The-Lightning/RTL/issues/1182
       npmFlags = "--legacy-peer-deps";
-      hash = "sha256-0fu14j4OvsYGBhu/p67EUFmuHCbIPlLVm4e8qd9tk3o=";
+      hash = "sha256-LIKZOHc8FqvVX5LCJrq9Z76ZoyXLYiYsPIj6IieBWho=";
     };
   };
 

--- a/pkgs/rtl/generate.sh
+++ b/pkgs/rtl/generate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 . "${BASH_SOURCE[0]%/*}/../../helper/run-in-nix-env" "gnupg wget gnused" "$@"
 
-version="0.14.1"
+version="0.15.2"
 repo=https://github.com/Ride-The-Lightning/RTL
 
 scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -103,6 +103,7 @@ let
       nix-bitcoin.onionServices.lnd.public = true;
 
       tests.lndconnect-onion-lnd = with cfg.lnd.lndconnect; enable && onion;
+      tests.lnconnect-onion-clnrest = with cfg.clightning.plugins.clnrest.lnconnect; enable && onion;
       tests.lndconnect-onion-clightning = with cfg.clightning-rest.lndconnect; enable && onion;
 
       tests.lightning-loop = cfg.lightning-loop.enable;
@@ -194,6 +195,10 @@ let
         enable = true;
         encrypt = true;
         local.directory = "/var/backup/clightning";
+      };
+      services.clightning.plugins.clnrest = {
+        enable = true;
+        lnconnect = { enable = true; onion = true; };
       };
       test.features.clightningPlugins = true;
       services.rtl.enable = true;

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -64,6 +64,7 @@ let
         nbPkgs = config.nix-bitcoin.pkgs;
         pluginPkgs = nbPkgs.clightning-plugins // {
           clboss.path = "${plugins.clboss.package}/bin/clboss";
+          clnrest.path = "${plugins.clnrest.package}/bin/clnrest";
           trustedcoin.path = "${plugins.trustedcoin.package}/bin/trustedcoin";
         };
       in map (plugin: pluginPkgs.${plugin}.path) enabled;

--- a/test/tests.py
+++ b/test/tests.py
@@ -179,6 +179,11 @@ def _():
     assert_running("lnd")
     assert_matches("runuser -u operator -- lndconnect --url", ".onion")
 
+@test("lnconnect-onion-clnrest")
+def _():
+    assert_running("clightning")
+    assert_matches("runuser -u operator -- lnconnect-clnrest --url", ".onion")
+
 @test("lndconnect-onion-clightning")
 def _():
     assert_running("clightning-rest")

--- a/test/wireguard-lndconnect.nix
+++ b/test/wireguard-lndconnect.nix
@@ -24,12 +24,8 @@ makeTestVM {
       };
       # TODO-EXTERNAL:
       # When WAN is disabled, DNS bootstrapping slows down service startup by ~15 s.
-      # TODO-EXTERNAL:
-      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
-      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
       services.clightning.extraConfig = ''
         disable-dns
-        disable-plugin=offers
       '';
 
       services.lnd = {

--- a/test/wireguard-lndconnect.nix
+++ b/test/wireguard-lndconnect.nix
@@ -18,6 +18,14 @@ makeTestVM {
       nix-bitcoin.generateSecrets = true;
       nix-bitcoin.operator.enable = true;
 
+      services.clightning = {
+        enable = true;
+        plugins.clnrest = {
+          enable = true;
+          lnconnect.enable = true;
+        };
+      };
+
       services.clightning-rest = {
         enable = true;
         lndconnect.enable = true;
@@ -51,16 +59,19 @@ makeTestVM {
 
     def parse_lndconnect_url(url):
         u = Url.urlparse(url)
+        data = {'host': u.hostname, 'port': u.port}
         queries = Url.parse_qs(u.query)
-        macaroon = queries['macaroon'][0]
-        is_clightning = url.startswith("c-lightning-rest")
+        if url.startswith("clnrest"):
+            data['rune'] = queries['rune'][0]
+        else:
+            macaroon = queries['macaroon'][0]
+            if url.startswith("c-lightning-rest"):
+              data['macaroon_hex'] = macaroon
+            else:
+              # lnd
+              data['macaroon_hex'] = base64.urlsafe_b64decode(macaroon + '===').hex().upper()
 
-        return SimpleNamespace(
-            host = u.hostname,
-            port = u.port,
-            macaroon_hex =
-              macaroon if is_clightning else base64.urlsafe_b64decode(macaroon + '===').hex().upper()
-        )
+        return SimpleNamespace(**data)
 
     client.start()
     server.connect()
@@ -90,6 +101,16 @@ makeTestVM {
           client.succeed(
               f"curl -fsS --max-time 3 --insecure --header 'Grpc-Metadata-macaroon: {api.macaroon_hex}' "
               f"-X GET https://{api.host}:{api.port}/v1/getinfo"
+          )
+
+      with subtest("lnconnect-clnrest-wg"):
+          server.wait_for_unit("clightning.service")
+          lndconnect_url = server.succeed("runuser -u operator -- lnconnect-clnrest-wg --url")
+          api = parse_lndconnect_url(lndconnect_url)
+          # Make clnrest API call
+          client.succeed(
+              f"curl -fsS --max-time 3 --insecure --header 'rune: {api.rune}' "
+              f"-X POST https://{api.host}:{api.port}/v1/getinfo"
           )
 
       with subtest("lndconnect-clightning-wg"):


### PR DESCRIPTION
This fixes `lndconnect` for recent versions of Zeus

Todo:
- [x] Manually test RTL
- [x] Manually run [test lndconnect-wg](https://github.com/erikarvstedt/nix-bitcoin/blob/clnrest/dev/topics/lndconnect-and-wireguard.sh)
- [x] Deploy on nixbitcoin.org
- [x] Deploy locally and investigate `Too many files` gevent error (possible upstream bug)