### PR TITLE
clboss: 0.13 -> 0.13.1

### DIFF
--- a/pkgs/clboss/default.nix
+++ b/pkgs/clboss/default.nix
@@ -5,13 +5,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "clboss";
-  version = "0.13";
+  version = "0.13.1";
 
   src = fetchFromGitHub {
     owner = "ZmnSCPxj";
     repo = "clboss";
     rev = "v${version}";
-    hash = "sha256-NP9blymdqDXo/OtGLQg/MXK24PpPvCrzqXRdtfCvpfI=";
+    hash = "sha256-DQvcf+y73QQYQanEvbOCOgwQzvNOXS1ZY+hVvS6N+G0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Opening new channels, the main feature of clboss, was broken with clightning v24.02 + clboss 0.13:
https://github.com/ZmnSCPxj/clboss/issues/189