### PR TITLE
trustedcoin: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -1,24 +1,15 @@
-{ lib, buildGoModule, fetchFromGitHub, fetchpatch }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
 buildGoModule rec {
   pname = "trustedcoin";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "nbd-wtf";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-UNQjxhAT0mK1In7vUtIoMoMNBV+0wkrwbDmm7m+0R3o=";
+    hash = "sha256-uEJVxpNKInIroHf22GQs+0xzJCijtIo+6KOM2Yefu6o=";
   };
-
-  patches = [
-    # https://github.com/nbd-wtf/trustedcoin/pull/22 required for regtest
-    (fetchpatch {
-      name = "add-regtest-support";
-      url = "https://github.com/nbd-wtf/trustedcoin/commit/aba05c55ccbfc50785328f556be8a5bd46e76beb.patch";
-      hash = "sha256-24mYyXjUMVSlr9IlaqaTVAPE6bxxScNgR8Bb3x2t90Y=";
-    })
-  ];
 
   vendorHash = "sha256-xvkK9rMQlXTnNyOMd79qxVSvhgPobcBk9cq4/YWbupY=";
 


### PR DESCRIPTION
There is a new release of trustedcoin:
- https://github.com/nbd-wtf/trustedcoin/releases/tag/v0.7.0