### PR TITLE
joinmarket: include the bond-calculator script

### DIFF
--- a/pkgs/joinmarket/default.nix
+++ b/pkgs/joinmarket/default.nix
@@ -43,6 +43,7 @@ stdenv.mkDerivation {
     cpBin wallet-tool.py
     cpBin yg-privacyenhanced.py
     cpBin genwallet.py
+    cpBin bond-calculator.py
 
     chmod +x -R "$out/bin"
     patchShebangs "$out/bin"


### PR DESCRIPTION
Closes #693 

Include the [bond-calculator.py](https://github.com/JoinMarket-Org/joinmarket-clientserver/blob/master/scripts/bond-calculator.py) script into joinmarket's CLI commands.