### PR TITLE
treewide: use `substituteInPlace --replace-fail`

### DIFF
--- a/pkgs/python-packages/python-bitcointx/default.nix
+++ b/pkgs/python-packages/python-bitcointx/default.nix
@@ -14,7 +14,7 @@ buildPythonPackageWithDepsCheck rec {
   patchPhase = ''
     for path in core/secp256k1.py tests/test_load_secp256k1.py; do
       substituteInPlace "bitcointx/$path" \
-        --replace "ctypes.util.find_library('secp256k1')" "'${secp256k1}/lib/libsecp256k1.so'"
+        --replace-fail "ctypes.util.find_library('secp256k1')" "'${secp256k1}/lib/libsecp256k1.so'"
     done
   '';
 

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -271,7 +271,7 @@ let
         clightning = super.clightning.overrideAttrs (old: {
           postPatch = old.postPatch + ''
             substituteInPlace lightningd/plugin.c \
-              --replace "#define PLUGIN_MANIFEST_TIMEOUT 60" "#define PLUGIN_MANIFEST_TIMEOUT 200"
+              --replace-fail "#define PLUGIN_MANIFEST_TIMEOUT 60" "#define PLUGIN_MANIFEST_TIMEOUT 200"
           '';
         });
       };


### PR DESCRIPTION
#### Copy of commit msg
Now substitution failures result in a script error.
This has recently been backported to nixpkgs 23.11.