### PR TITLE
Add statix into CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,3 +40,7 @@ task:
     - name: shellcheck
       build_script:
         - ./test/shellcheck.sh
+
+    - name: statix
+      build_script:
+        - ./test/statix.sh

--- a/modules/btcpayserver.nix
+++ b/modules/btcpayserver.nix
@@ -110,170 +110,188 @@ in {
   inherit options;
 
   config = mkIf cfg.btcpayserver.enable {
-    services.bitcoind = {
-      enable = true;
-      rpc.users.btcpayserver = {
-        passwordHMACFromFile = true;
-        rpcwhitelist = cfg.bitcoind.rpc.users.public.rpcwhitelist ++ [
-          "setban"
-          "generatetoaddress"
-          "getpeerinfo"
+    services = {
+      bitcoind = {
+        enable = true;
+        rpc.users.btcpayserver = {
+          passwordHMACFromFile = true;
+          rpcwhitelist = cfg.bitcoind.rpc.users.public.rpcwhitelist ++ [
+            "setban"
+            "generatetoaddress"
+            "getpeerinfo"
+          ];
+        };
+        listenWhitelisted = true;
+      };
+      clightning.enable = mkIf (cfg.btcpayserver.lightningBackend == "clightning") true;
+      lnd = mkIf (cfg.btcpayserver.lightningBackend == "lnd") {
+        enable = true;
+        macaroons.btcpayserver = {
+          inherit (cfg.btcpayserver) user;
+          permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"address","action":"read"},{"entity":"message","action":"read"},{"entity":"peers","action":"read"},{"entity":"signer","action":"read"},{"entity":"invoices","action":"read"},{"entity":"invoices","action":"write"},{"entity":"address","action":"write"}'';
+        };
+      };
+      liquidd = mkIf cfg.btcpayserver.lbtc {
+        enable = true;
+        listenWhitelisted = true;
+      };
+      postgresql = {
+        enable = true;
+        ensureDatabases = [ "btcpaydb" "nbxplorer" ];
+        ensureUsers = [
+          { name = cfg.btcpayserver.user; }
+          { name = cfg.nbxplorer.user; }
         ];
       };
-      listenWhitelisted = true;
     };
-    services.clightning.enable = mkIf (cfg.btcpayserver.lightningBackend == "clightning") true;
-    services.lnd = mkIf (cfg.btcpayserver.lightningBackend == "lnd") {
-      enable = true;
-      macaroons.btcpayserver = {
-        inherit (cfg.btcpayserver) user;
-        permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"address","action":"read"},{"entity":"message","action":"read"},{"entity":"peers","action":"read"},{"entity":"signer","action":"read"},{"entity":"invoices","action":"read"},{"entity":"invoices","action":"write"},{"entity":"address","action":"write"}'';
-      };
-    };
-    services.liquidd = mkIf cfg.btcpayserver.lbtc {
-      enable = true;
-      listenWhitelisted = true;
-    };
-    services.postgresql = {
-      enable = true;
-      ensureDatabases = [ "btcpaydb" "nbxplorer" ];
-      ensureUsers = [
-        { name = cfg.btcpayserver.user; }
-        { name = cfg.nbxplorer.user; }
+
+    systemd = {
+      tmpfiles.rules = [
+        "d '${cfg.nbxplorer.dataDir}' 0770 ${cfg.nbxplorer.user} ${cfg.nbxplorer.group} - -"
+        "d '${cfg.btcpayserver.dataDir}' 0770 ${cfg.btcpayserver.user} ${cfg.btcpayserver.group} - -"
       ];
-    };
-    systemd.services.postgresql.postStart = lib.mkAfter ''
-      $PSQL -tAc '
-        ALTER DATABASE "btcpaydb" OWNER TO "${cfg.btcpayserver.user}";
-        ALTER DATABASE "nbxplorer" OWNER TO "${cfg.nbxplorer.user}";
-      '
-    '';
 
-    systemd.tmpfiles.rules = [
-      "d '${cfg.nbxplorer.dataDir}' 0770 ${cfg.nbxplorer.user} ${cfg.nbxplorer.group} - -"
-      "d '${cfg.btcpayserver.dataDir}' 0770 ${cfg.btcpayserver.user} ${cfg.btcpayserver.group} - -"
-    ];
-
-    systemd.services.nbxplorer = let
-      configFile = builtins.toFile "config" ''
-        network=${bitcoind.network}
-        btcrpcuser=${cfg.bitcoind.rpc.users.btcpayserver.name}
-        btcrpcurl=http://${nbLib.addressWithPort bitcoind.rpc.address cfg.bitcoind.rpc.port}
-        btcnodeendpoint=${nbLib.addressWithPort bitcoind.address bitcoind.whitelistedPort}
-        bind=${cfg.nbxplorer.address}
-        port=${toString cfg.nbxplorer.port}
-        ${optionalString cfg.btcpayserver.lbtc ''
-          chains=btc,lbtc
-          lbtcrpcuser=${liquidd.rpcuser}
-          lbtcrpcurl=http://${nbLib.addressWithPort liquidd.rpc.address liquidd.rpc.port}
-          lbtcnodeendpoint=${nbLib.addressWithPort liquidd.address liquidd.whitelistedPort}
-        ''}
-        postgres=User ID=${cfg.nbxplorer.user};Host=/run/postgresql;Database=nbxplorer
-        automigrate=1
-      '';
-    in rec {
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "bitcoind.service" "postgresql.service" ] ++ optional cfg.btcpayserver.lbtc "liquidd.service";
-      after = requires ++ [ "nix-bitcoin-secrets.target" ];
-      preStart = ''
-        install -m 600 ${configFile} '${cfg.nbxplorer.dataDir}/settings.config'
-        {
-          echo "btcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-btcpayserver)"
-          ${optionalString cfg.btcpayserver.lbtc ''
-            echo "lbtcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/liquid-rpcpassword)"
-          ''}
-        } >> '${cfg.nbxplorer.dataDir}/settings.config'
-      '';
-      serviceConfig = nbLib.defaultHardening // {
-        ExecStart = ''
-          ${cfg.nbxplorer.package}/bin/nbxplorer --conf=${cfg.nbxplorer.dataDir}/settings.config \
-            --datadir=${cfg.nbxplorer.dataDir}
+      services = {
+        postgresql.postStart = lib.mkAfter ''
+          $PSQL -tAc '
+            ALTER DATABASE "btcpaydb" OWNER TO "${cfg.btcpayserver.user}";
+            ALTER DATABASE "nbxplorer" OWNER TO "${cfg.nbxplorer.user}";
+          '
         '';
-        User = cfg.nbxplorer.user;
-        Restart = "on-failure";
-        RestartSec = "10s";
-        ReadWritePaths = [ cfg.nbxplorer.dataDir ];
-        MemoryDenyWriteExecute = false;
-      } // nbLib.allowedIPAddresses cfg.nbxplorer.tor.enforce;
-    };
 
-    systemd.services.btcpayserver = let
-      nbExplorerUrl = "http://${nbLib.addressWithPort cfg.nbxplorer.address cfg.nbxplorer.port}/";
-      nbExplorerCookie = "${cfg.nbxplorer.dataDir}/${bitcoind.makeNetworkName "Main" "RegTest"}/.cookie";
-      configFile = builtins.toFile "btcpayserver-config" (''
-        network=${bitcoind.network}
-        bind=${cfg.btcpayserver.address}
-        port=${toString cfg.btcpayserver.port}
-        socksendpoint=${config.nix-bitcoin.torClientAddressWithPort}
-        btcexplorerurl=${nbExplorerUrl}
-        btcexplorercookiefile=${nbExplorerCookie}
-        postgres=User ID=${cfg.btcpayserver.user};Host=/run/postgresql;Database=btcpaydb
-      '' + optionalString (cfg.btcpayserver.rootpath != null) ''
-        rootpath=${cfg.btcpayserver.rootpath}
-      '' + optionalString (cfg.btcpayserver.lightningBackend == "clightning") ''
-        btclightning=type=clightning;server=unix:///${cfg.clightning.dataDir}/${bitcoind.makeNetworkName "bitcoin" "regtest"}/lightning-rpc
-      '' + optionalString (cfg.btcpayserver.lightningBackend == "lnd")
-        (
-          "btclightning=type=lnd-rest;" +
-          "server=https://${cfg.lnd.restAddress}:${toString cfg.lnd.restPort}/;" +
-          "macaroonfilepath=/run/lnd/btcpayserver.macaroon;" +
-          "certfilepath=${config.services.lnd.certPath}" +
-          "\n"
-        )
-      + optionalString cfg.btcpayserver.lbtc ''
-        chains=btc,lbtc
-        lbtcexplorerurl=${nbExplorerUrl}
-        lbtcexplorercookiefile=${nbExplorerCookie}
-      '');
-    in let self = {
-      wantedBy = [ "multi-user.target" ];
-      requires = [ "nbxplorer.service" "postgresql.service" ]
-                 ++ optional (cfg.btcpayserver.lightningBackend != null) "${cfg.btcpayserver.lightningBackend}.service";
-      after = self.requires;
-      serviceConfig = nbLib.defaultHardening // {
-        ExecStart = ''
-          ${cfg.btcpayserver.package}/bin/btcpayserver --conf=${configFile} \
-            --datadir='${cfg.btcpayserver.dataDir}'
-        '';
-        User = cfg.btcpayserver.user;
-        # Also restart after the program has exited successfully.
-        # This is required to support restarting from the web interface after
-        # interactive plugin installation.
-        # Restart rate limiting is implemented via the `startLimit*` options below.
-        Restart = "always";
-        ReadWritePaths = [ cfg.btcpayserver.dataDir ];
-        MemoryDenyWriteExecute = false;
-      } // nbLib.allowedIPAddresses cfg.btcpayserver.tor.enforce;
-      startLimitIntervalSec = 30;
-      startLimitBurst = 10;
-    }; in self;
+        nbxplorer = let
+          configFile = builtins.toFile "config" ''
+            network=${bitcoind.network}
+            btcrpcuser=${cfg.bitcoind.rpc.users.btcpayserver.name}
+            btcrpcurl=http://${nbLib.addressWithPort bitcoind.rpc.address cfg.bitcoind.rpc.port}
+            btcnodeendpoint=${nbLib.addressWithPort bitcoind.address bitcoind.whitelistedPort}
+            bind=${cfg.nbxplorer.address}
+            port=${toString cfg.nbxplorer.port}
+            ${optionalString cfg.btcpayserver.lbtc ''
+              chains=btc,lbtc
+              lbtcrpcuser=${liquidd.rpcuser}
+              lbtcrpcurl=http://${nbLib.addressWithPort liquidd.rpc.address liquidd.rpc.port}
+              lbtcnodeendpoint=${nbLib.addressWithPort liquidd.address liquidd.whitelistedPort}
+            ''}
+            postgres=User ID=${cfg.nbxplorer.user};Host=/run/postgresql;Database=nbxplorer
+            automigrate=1
+          '';
+        in rec {
+          wantedBy = [ "multi-user.target" ];
+          requires = [ "bitcoind.service" "postgresql.service" ] ++ optional cfg.btcpayserver.lbtc "liquidd.service";
+          after = requires ++ [ "nix-bitcoin-secrets.target" ];
+          preStart = ''
+            install -m 600 ${configFile} '${cfg.nbxplorer.dataDir}/settings.config'
+            {
+              echo "btcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/bitcoin-rpcpassword-btcpayserver)"
+              ${optionalString cfg.btcpayserver.lbtc ''
+                echo "lbtcrpcpassword=$(cat ${config.nix-bitcoin.secretsDir}/liquid-rpcpassword)"
+              ''}
+            } >> '${cfg.nbxplorer.dataDir}/settings.config'
+          '';
+          serviceConfig = nbLib.defaultHardening // {
+            ExecStart = ''
+              ${cfg.nbxplorer.package}/bin/nbxplorer --conf=${cfg.nbxplorer.dataDir}/settings.config \
+                --datadir=${cfg.nbxplorer.dataDir}
+            '';
+            User = cfg.nbxplorer.user;
+            Restart = "on-failure";
+            RestartSec = "10s";
+            ReadWritePaths = [ cfg.nbxplorer.dataDir ];
+            MemoryDenyWriteExecute = false;
+          } // nbLib.allowedIPAddresses cfg.nbxplorer.tor.enforce;
+        };
 
-    users.users.${cfg.nbxplorer.user} = {
-      isSystemUser = true;
-      group = cfg.nbxplorer.group;
-      extraGroups = [ "bitcoinrpc-public" ]
-                    ++ optional cfg.btcpayserver.lbtc liquidd.group;
-      home = cfg.nbxplorer.dataDir;
-    };
-    users.groups.${cfg.nbxplorer.group} = {};
-    users.users.${cfg.btcpayserver.user} = {
-      isSystemUser = true;
-      group = cfg.btcpayserver.group;
-      extraGroups = [ cfg.nbxplorer.group ]
-                    ++ optional (cfg.btcpayserver.lightningBackend == "clightning") cfg.clightning.user;
-      home = cfg.btcpayserver.dataDir;
-    };
-    users.groups.${cfg.btcpayserver.group} = {};
-
-    nix-bitcoin.secrets = {
-      bitcoin-rpcpassword-btcpayserver = {
-        user = cfg.bitcoind.user;
-        group = cfg.nbxplorer.group;
+        btcpayserver = let
+          nbExplorerUrl = "http://${nbLib.addressWithPort cfg.nbxplorer.address cfg.nbxplorer.port}/";
+          nbExplorerCookie = "${cfg.nbxplorer.dataDir}/${bitcoind.makeNetworkName "Main" "RegTest"}/.cookie";
+          configFile = builtins.toFile "btcpayserver-config" (''
+            network=${bitcoind.network}
+            bind=${cfg.btcpayserver.address}
+            port=${toString cfg.btcpayserver.port}
+            socksendpoint=${config.nix-bitcoin.torClientAddressWithPort}
+            btcexplorerurl=${nbExplorerUrl}
+            btcexplorercookiefile=${nbExplorerCookie}
+            postgres=User ID=${cfg.btcpayserver.user};Host=/run/postgresql;Database=btcpaydb
+          '' + optionalString (cfg.btcpayserver.rootpath != null) ''
+            rootpath=${cfg.btcpayserver.rootpath}
+          '' + optionalString (cfg.btcpayserver.lightningBackend == "clightning") ''
+            btclightning=type=clightning;server=unix:///${cfg.clightning.dataDir}/${bitcoind.makeNetworkName "bitcoin" "regtest"}/lightning-rpc
+          '' + optionalString (cfg.btcpayserver.lightningBackend == "lnd")
+            (
+              "btclightning=type=lnd-rest;" +
+              "server=https://${cfg.lnd.restAddress}:${toString cfg.lnd.restPort}/;" +
+              "macaroonfilepath=/run/lnd/btcpayserver.macaroon;" +
+              "certfilepath=${config.services.lnd.certPath}" +
+              "\n"
+            )
+          + optionalString cfg.btcpayserver.lbtc ''
+            chains=btc,lbtc
+            lbtcexplorerurl=${nbExplorerUrl}
+            lbtcexplorercookiefile=${nbExplorerCookie}
+          '');
+          serviceRequires = [ "nbxplorer.service" "postgresql.service" ]
+                            ++ optional (cfg.btcpayserver.lightningBackend != null) "${cfg.btcpayserver.lightningBackend}.service";
+        in {
+          wantedBy = [ "multi-user.target" ];
+          requires = serviceRequires;
+          after = serviceRequires;
+          serviceConfig = nbLib.defaultHardening // {
+            ExecStart = ''
+              ${cfg.btcpayserver.package}/bin/btcpayserver --conf=${configFile} \
+                --datadir='${cfg.btcpayserver.dataDir}'
+            '';
+            User = cfg.btcpayserver.user;
+            # Also restart after the program has exited successfully.
+            # This is required to support restarting from the web interface after
+            # interactive plugin installation.
+            # Restart rate limiting is implemented via the `startLimit*` options below.
+            Restart = "always";
+            ReadWritePaths = [ cfg.btcpayserver.dataDir ];
+            MemoryDenyWriteExecute = false;
+          } // nbLib.allowedIPAddresses cfg.btcpayserver.tor.enforce;
+          startLimitIntervalSec = 30;
+          startLimitBurst = 10;
+        };
       };
-      bitcoin-HMAC-btcpayserver.user = cfg.bitcoind.user;
     };
-    nix-bitcoin.generateSecretsCmds.btcpayserver = ''
-      makeBitcoinRPCPassword btcpayserver
-    '';
+
+    users = {
+      users = {
+        ${cfg.nbxplorer.user} = {
+          isSystemUser = true;
+          inherit (cfg.nbxplorer) group;
+          extraGroups = [ "bitcoinrpc-public" ]
+                        ++ optional cfg.btcpayserver.lbtc liquidd.group;
+          home = cfg.nbxplorer.dataDir;
+        };
+
+        ${cfg.btcpayserver.user} = {
+          isSystemUser = true;
+          inherit (cfg.btcpayserver) group;
+          extraGroups = [ cfg.nbxplorer.group ]
+                        ++ optional (cfg.btcpayserver.lightningBackend == "clightning") cfg.clightning.user;
+          home = cfg.btcpayserver.dataDir;
+        };
+      };
+
+      groups = {
+        ${cfg.nbxplorer.group} = {};
+        ${cfg.btcpayserver.group} = {};
+      };
+    };
+
+    nix-bitcoin = {
+      secrets = {
+        bitcoin-rpcpassword-btcpayserver = {
+          inherit (cfg.bitcoind) user;
+          inherit (cfg.nbxplorer) group;
+        };
+        bitcoin-HMAC-btcpayserver.user = cfg.bitcoind.user;
+      };
+      generateSecretsCmds.btcpayserver = ''
+        makeBitcoinRPCPassword btcpayserver
+      '';
+    };
   };
 }

--- a/modules/charge-lnd.nix
+++ b/modules/charge-lnd.nix
@@ -90,7 +90,7 @@ in
     services.lnd = {
       enable = true;
       macaroons.charge-lnd = {
-        user = user;
+        inherit user;
         permissions = ''{"entity":"info","action":"read"},{"entity":"onchain","action":"read"},{"entity":"offchain","action":"read"},{"entity":"offchain","action":"write"}'';
       };
     };
@@ -134,7 +134,7 @@ in
 
     users.users.${user} = {
       isSystemUser = true;
-      group = group;
+      inherit group;
     };
     users.groups.${group} = {};
   };

--- a/modules/clightning-plugins/trustedcoin.nix
+++ b/modules/clightning-plugins/trustedcoin.nix
@@ -29,7 +29,7 @@ let cfg = config.services.clightning.plugins.trustedcoin; in
       tor.enforce = mkIf (!cfg.tor.proxy) false;
     };
 
-    systemd.services.clightning.environment = mkIf (cfg.tor.proxy) {
+    systemd.services.clightning.environment = mkIf cfg.tor.proxy {
       HTTPS_PROXY = let
         clnProxy = config.services.clightning.proxy;
         proxy = if clnProxy != null then clnProxy else config.nix-bitcoin.torClientAddressWithPort;

--- a/modules/clightning-replication.nix
+++ b/modules/clightning-replication.nix
@@ -209,7 +209,7 @@ in {
     nix-bitcoin = mkMerge [
       (mkIf useSshfs {
         secrets.clightning-replication-ssh-key = {
-          user = user;
+          inherit user;
           permissions = "400";
         };
         generateSecretsCmds.clightning-replication-ssh-key = ''

--- a/modules/hardware-wallets.nix
+++ b/modules/hardware-wallets.nix
@@ -33,7 +33,7 @@ in {
   config = mkMerge [
     (mkIf (cfg.ledger || cfg.trezor) {
       assertions = [
-        { assertion = (config.services.bitcoind.disablewallet == null || !config.services.bitcoind.disablewallet);
+        { assertion = config.services.bitcoind.disablewallet == null || !config.services.bitcoind.disablewallet;
           message = ''
             Hardware-Wallets are not compatible with bitcoind.disablewallet.
           '';

--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -369,23 +369,26 @@ in {
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 
-    users.users.${cfg.user} = {
-      isSystemUser = true;
-      group = cfg.group;
-      home = cfg.dataDir;
-      # Allow access to the tor control socket, needed for payjoin onion service creation
-      extraGroups = [ "tor" "bitcoin" ];
+    users = {
+      users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = cfg.dataDir;
+        # Allow access to the tor control socket, needed for payjoin onion service creation
+        extraGroups = [ "tor" "bitcoin" ];
+      };
+      groups.${cfg.group} = {};
     };
-    users.groups.${cfg.group} = {};
-    nix-bitcoin.operator = {
-      groups = [ cfg.group ];
-      allowRunAsUsers = [ cfg.user ];
+    nix-bitcoin = {
+      operator = {
+        groups = [ cfg.group ];
+        allowRunAsUsers = [ cfg.user ];
+      };
+      secrets.jm-wallet-password.user = cfg.user;
+      generateSecretsCmds.joinmarket = ''
+        makePasswordSecret jm-wallet-password
+      '';
     };
-
-    nix-bitcoin.secrets.jm-wallet-password.user = cfg.user;
-    nix-bitcoin.generateSecretsCmds.joinmarket = ''
-      makePasswordSecret jm-wallet-password
-    '';
   }
 
   (mkIf cfg.yieldgenerator.enable {

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -237,7 +237,7 @@ in {
 
   config = mkIf cfg.enable {
     assertions = [
-      { assertion = bitcoind.regtest -> cfg.validatepegin != true;
+      { assertion = bitcoind.regtest -> !cfg.validatepegin;
         message = "liquidd: `validatepegin` is incompatible with regtest.";
       }
     ];

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -170,7 +170,7 @@ let
     bitcoin.active=1
     bitcoin.node=bitcoind
 
-    ${optionalString (cfg.tor.proxy) "tor.active=true"}
+    ${optionalString cfg.tor.proxy "tor.active=true"}
     ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
 
     bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}

--- a/modules/lndconnect.nix
+++ b/modules/lndconnect.nix
@@ -178,7 +178,7 @@ in {
               isClightning = true;
               enableOnion = clightning-rest.lndconnect.onion;
               onionService = "${operatorName}/clightning-rest";
-              port = clightning-rest.port;
+              inherit (clightning-rest) port;
               certPath = "${clightning-rest.dataDir}/certs/certificate.pem";
               macaroonPath = "${clightning-rest.dataDir}/certs/access.macaroon";
             }
@@ -193,7 +193,7 @@ in {
             relay.onionServices.clightning-rest = nbLib.mkOnionService {
               target.addr = nbLib.address clightning-rest.address;
               target.port = clightning-rest.port;
-              port = clightning-rest.port;
+              inherit (clightning-rest) port;
             };
           };
           # This also allows nodeinfo to show the clightning-rest onion address

--- a/modules/mempool.nix
+++ b/modules/mempool.nix
@@ -269,7 +269,7 @@ in {
         DATABASE = cfg.database.name;
         SOCKET = "/run/mysqld/mysqld.sock";
       };
-    } // optionalAttrs (cfg.tor.proxy) {
+    } // optionalAttrs cfg.tor.proxy {
       # Use Tor for rate fetching
       SOCKS5PROXY = {
         ENABLED = true;

--- a/modules/presets/secure-node.nix
+++ b/modules/presets/secure-node.nix
@@ -35,23 +35,25 @@ in {
     services.tor.relay.onionServices.sshd = nbLib.mkOnionService { port = 22; };
     nix-bitcoin.onionAddresses.access.${operatorName} = [ "sshd" ];
 
-    services.bitcoind = {
-      enable = true;
-      listen = true;
-      dbCache = 1000;
-    };
-
-    services.liquidd = {
-      # Enable `validatepegin` to verify that a transaction sending BTC into
-      # Liquid exists on Bitcoin. Without it, a malicious liquid federation can
-      # make the node accept a sidechain that is not fully backed.
-      validatepegin = true;
-      listen = true;
-    };
-
     nix-bitcoin.nodeinfo.enable = true;
 
-    services.backups.frequency = "daily";
+    services = {
+      bitcoind = {
+        enable = true;
+        listen = true;
+        dbCache = 1000;
+      };
+
+      liquidd = {
+        # Enable `validatepegin` to verify that a transaction sending BTC into
+        # Liquid exists on Bitcoin. Without it, a malicious liquid federation can
+        # make the node accept a sidechain that is not fully backed.
+        validatepegin = true;
+        listen = true;
+      };
+
+      backups.frequency = "daily";
+    };
 
     # operator
     nix-bitcoin.operator.enable = true;

--- a/modules/rtl.nix
+++ b/modules/rtl.nix
@@ -106,8 +106,8 @@ let
   cfg = config.services.rtl;
   nbLib = config.nix-bitcoin.lib;
   nbPkgs = config.nix-bitcoin.pkgs;
-  secretsDir = config.nix-bitcoin.secretsDir;
 
+  inherit (config.nix-bitcoin) secretsDir;
   inherit (nbLib) optionalAttr;
 
   node = { isLnd, index }: {
@@ -149,7 +149,7 @@ let
   rtlConfig = {
     multiPass = "@multiPass@";
     host = cfg.address;
-    port = cfg.port;
+    inherit (cfg) port;
     SSO.rtlSSO = 0;
     inherit nodes;
   };
@@ -216,7 +216,7 @@ in {
 
     users.users.${cfg.user} = {
       isSystemUser = true;
-      group = cfg.group;
+      inherit (cfg) group;
       extraGroups =
         # Reads cert and macaroon from the clightning-rest datadir
         optional cfg.nodes.clightning.enable clightning-rest.group ++

--- a/pkgs/build-support/fetch-node-modules.nix
+++ b/pkgs/build-support/fetch-node-modules.nix
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation ({
   name = "${src.name}-node_modules";
   nativeBuildInputs = [
     makeWrapper
-    (if args ? nodejs then args.nodejs else nodejs)
+    (args.nodejs or nodejs)
   ];
 
   outputHashMode =  "recursive";

--- a/pkgs/nixops/default.nix
+++ b/pkgs/nixops/default.nix
@@ -42,7 +42,7 @@ let
   nixopsRelease = import "${src}/release.nix" {
     nixpkgs = pkgs.path;
     inherit pluginData;
-    p = (p: with p; [ aws hetzner vbox ]);
+    p = p: with p; [ aws hetzner vbox ];
   };
 in
 nixopsRelease.build.${builtins.currentSystem}

--- a/pkgs/python-packages/pyln-client/default.nix
+++ b/pkgs/python-packages/pyln-client/default.nix
@@ -2,10 +2,8 @@
 
 buildPythonPackageWithDepsCheck rec {
   pname = "pyln-client";
-  version = clightning.version;
+  inherit (clightning) src version;
   format = "pyproject";
-
-  inherit (clightning) src;
 
   nativeBuildInputs = [ poetry-core ];
 

--- a/pkgs/python-packages/pyln-proto/default.nix
+++ b/pkgs/python-packages/pyln-proto/default.nix
@@ -11,10 +11,8 @@
 
 buildPythonPackageWithDepsCheck rec {
   pname = "pyln-proto";
-  version = clightning.version;
+  inherit (clightning) src version;
   format = "pyproject";
-
-  inherit (clightning) src;
 
   nativeBuildInputs = [ poetry-core ];
 

--- a/pkgs/python-packages/txzmq/default.nix
+++ b/pkgs/python-packages/txzmq/default.nix
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Twisted bindings for ZeroMQ";
-    homepage = https://github.com/smira/txZMQ;
+    homepage = "https://github.com/smira/txZMQ";
     license = licenses.gpl2;
   };
 }

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,4 @@
+disabled = [
+  "repeated_keys",
+  "manual_inherit_from",
+]

--- a/test/lib/shellcheck-services.nix
+++ b/test/lib/shellcheck-services.nix
@@ -52,9 +52,9 @@ let
         isMatching = lib.hasPrefix sourcePrefix file;
       in
         # Nix has no boolean XOR, so use `if`
-        lib.optionals (if shouldMatch then isMatching else !isMatching) (
+        lib.optionals (if shouldMatch then isMatching else !isMatching)
           (map (service: { name = service; value = true; }) (builtins.attrNames services))
-        )
+
     ) systemdServices.definitionsWithLocations));
   in
     # Calculate set difference: matchingServices - nonMatchingServices

--- a/test/statix.sh
+++ b/test/statix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+. "${BASH_SOURCE[0]%/*}/../helper/run-in-nix-env" "statix" "$@"
+
+cd "${BASH_SOURCE[0]%/*}/.."
+
+# Run statix over all nix files in this repo
+statix check --format=errfmt .

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -12,9 +12,11 @@ let
       nixBitcoinModule
       {
         # Features required by the Python test suite
-        nix-bitcoin.secretsDir = "/secrets";
-        nix-bitcoin.generateSecrets = true;
-        nix-bitcoin.operator.enable = true;
+        nix-bitcoin = {
+          secretsDir = "/secrets";
+          generateSecrets = true;
+          operator.enable = true;
+        };
         environment.systemPackages = with pkgs; [ jq ];
       }
     ];


### PR DESCRIPTION
Hello,
I have prepared basic support for [statix](https://github.com/nerdypepper/statix) linter and fixed various issues.

For now, I have disabled the `repeated_keys` and `manual_inherit_from` warnings in the `statix.toml` configuration file. I'm not completely sure if it makes sense to fix all of these issues, as it might impact code readability. I have addressed just some of them.

What is your opinion? Thanks.

CC: @erikarvstedt @jonasnick 

```
./modules/electrs.nix>47:3:W:4:This assignment is better written with `inherit`
./modules/electrs.nix>48:3:W:4:This assignment is better written with `inherit`
./modules/electrs.nix>101:7:W:4:This assignment is better written with `inherit`
./modules/presets/secure-node.nix>23:5:W:20:The key `nix-bitcoin` is first assigned here ...
./modules/presets/secure-node.nix>36:5:W:20:... repeated here ...
./modules/presets/secure-node.nix>38:5:W:20:... and here (`1` occurrence omitted). Try `nix-bitcoin = { security.dbusHideProcessInformation=...; onionAddresses.access.${operatorName}=...; nodeinfo.enable=...; }` instead.
./test/lib/make-test.nix>28:9:W:4:This assignment is better written with `inherit`
./test/lib/make-test.nix>29:9:W:4:This assignment is better written with `inherit`
./helper/update-flake.nix>14:5:W:4:This assignment is better written with `inherit`
./modules/lightning-pool.nix>61:5:W:4:This assignment is better written with `inherit`
./modules/lightning-pool.nix>67:3:W:4:This assignment is better written with `inherit`
./modules/lightning-pool.nix>69:3:W:4:This assignment is better written with `inherit`
./modules/lndconnect.nix>148:15:W:4:This assignment is better written with `inherit`
./modules/rtl.nix>178:5:W:20:The key `services` is first assigned here ...
./modules/rtl.nix>179:5:W:20:... repeated here ...
./modules/rtl.nix>180:5:W:20:... and here (`1` occurrence omitted). Try `services = { lnd.enable=...; lightning-loop.enable=...; clightning-rest.enable=...; }` instead.
./modules/backups.nix>96:7:W:20:The key `services` is first assigned here ...
./modules/backups.nix>112:7:W:20:... repeated here ...
./modules/backups.nix>125:7:W:20:... and here. Try `services = { duplicity=...; postgresqlBackup=...; backups.postgresqlDatabases=...; }` instead.
./modules/backups.nix>103:9:W:4:This assignment is better written with `inherit`
./modules/presets/wireguard.nix>44:3:W:4:This assignment is better written with `inherit`
./modules/fulcrum.nix>66:3:W:4:This assignment is better written with `inherit`
./modules/fulcrum.nix>67:3:W:4:This assignment is better written with `inherit`
./modules/fulcrum.nix>135:7:W:4:This assignment is better written with `inherit`
./modules/bitcoind.nix>276:7:W:4:This assignment is better written with `inherit`
./modules/bitcoind.nix>282:3:W:4:This assignment is better written with `inherit`
./modules/bitcoind.nix>441:9:W:4:This assignment is better written with `inherit`
./modules/bitcoind.nix>454:11:W:4:This assignment is better written with `inherit`
./examples/flakes/flake.nix>11:3:W:20:The key `inputs` is first assigned here ...
./examples/flakes/flake.nix>15:3:W:20:... repeated here ...
./examples/flakes/flake.nix>16:3:W:20:... and here. Try `inputs = { nix-bitcoin.url=...; nixpkgs.follows=...; nixpkgs-unstable.follows=...; }` instead.
./modules/presets/bitcoind-remote.nix>5:3:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>146:5:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>151:3:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>155:3:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>158:3:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>291:7:W:4:This assignment is better written with `inherit`
./modules/lnd.nix>296:5:W:20:The key `nix-bitcoin` is first assigned here ...
./modules/lnd.nix>301:5:W:20:... repeated here ...
./modules/lnd.nix>310:5:W:20:... and here. Try `nix-bitcoin = { operator=...; secrets=...; generateSecretsCmds.lnd=...; }` instead.
./examples/krops/deploy.nix>9:3:W:4:This assignment is better written with `inherit`
./examples/qemu-vm/minimal-vm.nix>16:3:W:4:This assignment is better written with `inherit`
./examples/qemu-vm/minimal-vm.nix>28:7:W:20:The key `services` is first assigned here ...
./examples/qemu-vm/minimal-vm.nix>30:7:W:20:... repeated here ...
./examples/qemu-vm/minimal-vm.nix>36:7:W:20:... and here (`1` occurrence omitted). Try `services = { clightning.enable=...; clightning.extraConfig=...; getty.autologinUser=...; }` instead.
./modules/clightning.nix>107:5:W:4:This assignment is better written with `inherit`
./modules/clightning.nix>206:7:W:4:This assignment is better written with `inherit`
./modules/charge-lnd.nix>72:3:W:4:This assignment is better written with `inherit`
./modules/netns-isolation.nix>285:11:W:4:This assignment is better written with `inherit`
./modules/netns-isolation.nix>308:5:W:20:The key `services` is first assigned here ...
./modules/netns-isolation.nix>317:5:W:20:... repeated here ...
./modules/netns-isolation.nix>319:5:W:20:... and here (`13` occurrences omitted). Try `services = { bitcoind=...; clightning.address=...; lnd=...; }` instead.
./modules/netns-isolation.nix>309:7:W:4:This assignment is better written with `inherit`
./modules/netns-isolation.nix>320:7:W:4:This assignment is better written with `inherit`
./modules/netns-isolation.nix>326:7:W:4:This assignment is better written with `inherit`
./modules/lightning-loop.nix>85:5:W:4:This assignment is better written with `inherit`
./modules/lightning-loop.nix>90:3:W:4:This assignment is better written with `inherit`
./modules/lightning-loop.nix>92:3:W:4:This assignment is better written with `inherit`
./modules/lightning-loop.nix>94:3:W:4:This assignment is better written with `inherit`
./dev/dev-scenarios.nix>60:5:W:20:The key `services` is first assigned here ...
./dev/dev-scenarios.nix>62:5:W:20:... repeated here ...
./dev/dev-scenarios.nix>69:5:W:20:... and here. Try `services = { clightning.extraConfig=...; lnd=...; clightning-rest=...; }` instead.
./test/lib/shellcheck-services.nix>77:5:W:4:This assignment is better written with `inherit`
./modules/joinmarket.nix>139:3:W:4:This assignment is better written with `inherit`
./modules/joinmarket.nix>375:9:W:4:This assignment is better written with `inherit`
./modules/clightning-replication.nix>92:3:W:4:This assignment is better written with `inherit`
./modules/clightning-replication.nix>94:3:W:4:This assignment is better written with `inherit`
./modules/clightning-replication.nix>95:3:W:4:This assignment is better written with `inherit`
./modules/clightning-replication.nix>132:5:W:20:The key `systemd` is first assigned here ...
./modules/clightning-replication.nix>140:5:W:20:... repeated here ...
./modules/clightning-replication.nix>155:5:W:20:... and here. Try `systemd = { tmpfiles.rules=...; services.clightning=...; services.clightning-replication-mounts=...; }` instead.
./modules/presets/hardened-extended.nix>17:3:W:20:The key `boot` is first assigned here ...
./modules/presets/hardened-extended.nix>63:3:W:20:... repeated here ...
./modules/presets/hardened-extended.nix>99:3:W:20:... and here. Try `boot = { kernel.sysctl=...; kernelParams=...; blacklistedKernelModules=...; }` instead.
./test/tests.nix>36:7:W:20:The key `tests` is first assigned here ...
./test/tests.nix>42:7:W:20:... repeated here ...
./test/tests.nix>44:7:W:20:... and here (`18` occurrences omitted). Try `tests = { bitcoind=...; clightning=...; trustedcoin=...; }` instead.
./test/tests.nix>37:7:W:20:The key `services` is first assigned here ...
./test/tests.nix>48:7:W:20:... repeated here ...
./test/tests.nix>70:7:W:20:... and here (`7` occurrences omitted). Try `services = { bitcoind=...; clightning.extraConfig=...; rtl=...; }` instead.
./test/tests.nix>43:7:W:20:The key `test` is first assigned here ...
./test/tests.nix>49:7:W:20:... repeated here ...
./test/tests.nix>123:7:W:20:... and here. Try `test = { data.clightning-replication=...; data.clightning-plugins=...; data.btcpayserver-lbtc=...; }` instead.
./test/tests.nix>50:9:W:4:This assignment is better written with `inherit`
./test/tests.nix>129:9:W:4:This assignment is better written with `inherit`
./test/tests.nix>188:7:W:20:The key `services` is first assigned here ...
./test/tests.nix>189:7:W:20:... repeated here ...
./test/tests.nix>195:7:W:20:... and here (`16` occurrences omitted). Try `services = { clightning.enable=...; clightning.replication=...; rtl.enable=...; }` instead.
./test/tests.nix>225:7:W:20:The key `tests` is first assigned here ...
./test/tests.nix>226:7:W:20:... repeated here ...
./test/tests.nix>231:7:W:20:... and here. Try `tests = { secure-node=...; restart-bitcoind=...; stop-electrs=...; }` instead.
./test/tests.nix>243:7:W:20:The key `services` is first assigned here ...
./test/tests.nix>245:7:W:20:... repeated here ...
./test/tests.nix>246:7:W:20:... and here (`10` occurrences omitted). Try `services = { clightning.enable=...; clightning-rest.enable=...; liquidd.enable=...; }` instead.
./test/tests.nix>293:7:W:20:The key `services` is first assigned here ...
./test/tests.nix>305:7:W:20:... repeated here ...
./test/tests.nix>311:7:W:20:... and here (`2` occurrences omitted). Try `services = { bitcoind.regtest=...; lightning-loop.extraConfig=...; lightning-pool.extraConfig=...; }` instead.
./test/wireguard-lndconnect.nix>21:7:W:20:The key `services` is first assigned here ...
./test/wireguard-lndconnect.nix>27:7:W:20:... repeated here ...
./test/wireguard-lndconnect.nix>29:7:W:20:... and here. Try `services = { clightning-rest=...; clightning.extraConfig=...; lnd=...; }` instead.
./modules/versioning.nix>85:9:W:4:This assignment is better written with `inherit`
./modules/versioning.nix>86:9:W:4:This assignment is better written with `inherit`
./modules/mempool.nix>136:7:W:4:This assignment is better written with `inherit`
./modules/mempool.nix>156:3:W:4:This assignment is better written with `inherit`
./modules/mempool.nix>228:5:W:20:The key `services` is first assigned here ...
./modules/mempool.nix>229:5:W:20:... repeated here ...
./modules/mempool.nix>230:5:W:20:... and here (`3` occurrences omitted). Try `services = { bitcoind.txindex=...; electrs.enable=...; fulcrum.enable=...; }` instead.
./modules/mempool.nix>317:51:W:4:This assignment is better written with `inherit`
./modules/mempool.nix>327:7:W:4:This assignment is better written with `inherit`
./test/lib/make-test-vm.nix>4:5:W:4:This assignment is better written with `inherit`
./modules/joinmarket-ob-watcher.nix>40:3:W:4:This assignment is better written with `inherit`
./modules/joinmarket-ob-watcher.nix>106:7:W:4:This assignment is better written with `inherit`
./shell.nix>2:3:W:4:This assignment is better written with `inherit`
./modules/liquid.nix>161:7:W:4:This assignment is better written with `inherit`
./modules/liquid.nix>168:3:W:4:This assignment is better written with `inherit`
./modules/liquid.nix>170:3:W:4:This assignment is better written with `inherit`
./modules/liquid.nix>283:7:W:4:This assignment is better written with `inherit`
./modules/liquid.nix>287:5:W:20:The key `nix-bitcoin` is first assigned here ...
./modules/liquid.nix>289:5:W:20:... repeated here ...
./modules/liquid.nix>290:5:W:20:... and here. Try `nix-bitcoin = { operator.groups=...; secrets.liquid-rpcpassword.user=...; generateSecretsCmds.liquid=...; }` instead.
```