### PR TITLE
update nixpkgs

### DIFF
--- a/examples/deploy-container-minimal.sh
+++ b/examples/deploy-container-minimal.sh
@@ -21,7 +21,13 @@ cat > "$tmpDir/configuration.nix" <<EOF
       password = "a";
     };
     # When WAN is disabled, DNS bootstrapping slows down service startup by ~15 s
-    services.clightning.extraConfig = "disable-dns";
+    # TODO-EXTERNAL:
+    # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+    # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+    services.clightning.extraConfig = ''
+      disable-dns
+      disable-plugin=offers
+    '';
   }
 EOF
 

--- a/examples/deploy-container.sh
+++ b/examples/deploy-container.sh
@@ -83,6 +83,13 @@ read -rd '' src <<EOF || true
         $(realpath "$configuration")
       ];
       nix-bitcoin.generateSecrets = true;
+
+      # TODO-EXTERNAL:
+      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+      services.clightning.extraConfig = ''
+        disable-plugin=offers
+      '';
     };
   };
 }

--- a/examples/deploy-qemu-vm.sh
+++ b/examples/deploy-qemu-vm.sh
@@ -30,6 +30,13 @@ nix-build --out-link "$tmpDir/vm" - <<'EOF'
       <qemu-vm/vm-config.nix>
     ];
     nix-bitcoin.generateSecrets = true;
+
+    # TODO-EXTERNAL:
+    # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+    # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+    services.clightning.extraConfig = ''
+      disable-plugin=offers
+    '';
   };
 }).config.system.build.vm
 EOF

--- a/examples/krops-vm-configuration.nix
+++ b/examples/krops-vm-configuration.nix
@@ -4,4 +4,11 @@
     <nix-bitcoin/modules/deployment/krops.nix>
     <qemu-vm/vm-config.nix>
   ];
+
+  # TODO-EXTERNAL:
+  # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+  # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+  services.clightning.extraConfig = ''
+    disable-plugin=offers
+  '';
 }

--- a/examples/qemu-vm/minimal-vm.nix
+++ b/examples/qemu-vm/minimal-vm.nix
@@ -26,8 +26,14 @@ rec {
 
       nix-bitcoin.generateSecrets = true;
       services.clightning.enable = true;
-      # For faster startup in offline VMs
-      services.clightning.extraConfig = "disable-dns";
+      # disable-dns leads to faster startup in offline VMs
+      # TODO-EXTERNAL:
+      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+      services.clightning.extraConfig = ''
+        disable-dns
+        disable-plugin=offers
+      '';
 
       # Avoid lengthy build of the nixos manual
       documentation.nixos.enable = false;

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716361217,
-        "narHash": "sha256-mzZDr00WUiUXVm1ujBVv6A0qRd8okaITyUp4ezYRgc4=",
+        "lastModified": 1719663039,
+        "narHash": "sha256-tXlrgAQygNIy49LDVFuPXlWD2zTQV9/F8pfoqwwPJyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46397778ef1f73414b03ed553a3368f0e7e33c2f",
+        "rev": "4a1e673523344f6ccc84b37f4413ad74ea19a119",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1716451822,
-        "narHash": "sha256-0lT5RVelqN+dgXWWneXvV5ufSksW0r0TDQi8O6U2+o8=",
+        "lastModified": 1719468428,
+        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3305b2b25e4ae4baee872346eae133cf6f611783",
+        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
         "type": "github"
       },
       "original": {

--- a/test/clightning-replication.nix
+++ b/test/clightning-replication.nix
@@ -24,7 +24,13 @@ let
 
       # TODO-EXTERNAL:
       # When WAN is disabled, DNS bootstrapping slows down service startup by ~15 s.
-      extraConfig = "disable-dns";
+      # TODO-EXTERNAL:
+      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+      extraConfig = ''
+        disable-dns
+        disable-plugin=offers
+      '';
     };
   };
 in

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1714782417,
-        "narHash": "sha256-AhnsgqwOvK7Ftv1Sw9uzJGxov0cx9ygSjcKQSAWbiPg=",
+        "lastModified": 1719512984,
+        "narHash": "sha256-Mp16JvE5A9RxMh1vFuwUroInbzM0ZZZ+x/GFVQYt6PQ=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "0b39213973d7a4bab9f710dadb8ea1b14d206627",
+        "rev": "8ff24cb2648f7f08749d5891aa9b0bacb638fe84",
         "type": "github"
       },
       "original": {
@@ -39,14 +39,15 @@
         "flake-utils": "flake-utils",
         "nixos-infra": "nixos-infra",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-npmlock2nix": "nixpkgs-npmlock2nix",
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1715356306,
-        "narHash": "sha256-PRGw/1gCYDsLVXFwSGfOWe9vJhiQ7lE0XHpKXLDcsRw=",
+        "lastModified": 1719737420,
+        "narHash": "sha256-X+DK41RO/vxUBMyCJfWMVBxVDuPHkZskZK03knNoeTk=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "1242aebd1438548fa1e3699824599337cce4cd32",
+        "rev": "69a9eab2525e49be3f331e8570efef126cff4a1f",
         "type": "github"
       },
       "original": {
@@ -57,16 +58,31 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714635257,
-        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
+        "lastModified": 1719506693,
+        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-npmlock2nix": {
+      "locked": {
+        "lastModified": 1636623366,
+        "narHash": "sha256-jOQMlv9qFSj0U66HB+ujZoapty0UbewmSNbX8+3ujUQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5ed8beb478a8ca035f033f659b60c89500a3034",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "c5ed8beb478a8ca035f033f659b60c89500a3034",
         "type": "indirect"
       }
     },

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -43,7 +43,13 @@ let
 
       # TODO-EXTERNAL:
       # When WAN is disabled, DNS bootstrapping slows down service startup by ~15 s.
-      services.clightning.extraConfig = mkIf config.test.noConnections "disable-dns";
+      # TODO-EXTERNAL:
+      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+      services.clightning.extraConfig = ''
+        ${optionalString config.test.noConnections "disable-dns"}
+        disable-plugin=offers
+      '';
       test.data.clightning-plugins = let
         plugins = config.services.clightning.plugins;
         removed = [

--- a/test/wireguard-lndconnect.nix
+++ b/test/wireguard-lndconnect.nix
@@ -24,7 +24,13 @@ makeTestVM {
       };
       # TODO-EXTERNAL:
       # When WAN is disabled, DNS bootstrapping slows down service startup by ~15 s.
-      services.clightning.extraConfig = "disable-dns";
+      # TODO-EXTERNAL:
+      # When bitcoind is not fully synced, the offers plugin in clightning 24.05
+      # crashes (see https://github.com/ElementsProject/lightning/issues/7378).
+      services.clightning.extraConfig = ''
+        disable-dns
+        disable-plugin=offers
+      '';
 
       services.lnd = {
         enable = true;


### PR DESCRIPTION
bitcoin: 27.0 -> 27.1
bitcoind: 27.0 -> 27.1
clightning: 24.02.2 -> 24.05
fulcrum: 1.10.0 -> 1.11.0
lnd: 0.17.5-beta -> 0.18.0-beta

The trustedcoin test scenario currently fails with error:
```
vm-test-run-nix-bitcoin-trustedcoin> machine # [    8.757348] lightningd[1084]: Wrong network! Our Bitcoin backend is running on '', but we expect 'regtest'.
```
This appears to be an issue in trustedcoin.
CC @seberm
