### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1699821751,
-        "narHash": "sha256-UlId5jvJFmkVcKpn0oZ2VTvWAc/mZy6butRZGk73xXM=",
+        "lastModified": 1719830626,
+        "narHash": "sha256-7Wb2KiImYxrrIehtodNG9IvumFtZ2f5DkhrjnUBe7zk=",
         "owner": "erikarvstedt",
         "repo": "extra-container",
-        "rev": "842912907bf189ef17a80ca09ba37b6bdfc76c49",
+        "rev": "37b479006a80a936ac17e82fb2e8c07b822e17f2",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719663039,
-        "narHash": "sha256-tXlrgAQygNIy49LDVFuPXlWD2zTQV9/F8pfoqwwPJyo=",
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a1e673523344f6ccc84b37f4413ad74ea19a119",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1719468428,
-        "narHash": "sha256-vN5xJAZ4UGREEglh3lfbbkIj+MPEYMuqewMn4atZFaQ=",
+        "lastModified": 1720027103,
+        "narHash": "sha256-Q92DHQjIvaMLpawMdXnbKQjCkzAWqjhjWJYS5RcKujY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1e3deb3d8a86a870d925760db1a5adecc64d329d",
+        "rev": "61684d356e41c97f80087e89659283d00fe032ab",
         "type": "github"
       },
       "original": {

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1719512984,
-        "narHash": "sha256-Mp16JvE5A9RxMh1vFuwUroInbzM0ZZZ+x/GFVQYt6PQ=",
+        "lastModified": 1719778568,
+        "narHash": "sha256-W9SPjBPAOGGzCU7SxhQ4VaQvm30GjEJfx+augFPwlEA=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "8ff24cb2648f7f08749d5891aa9b0bacb638fe84",
+        "rev": "dd2613701333234c5d1b84c7bc9cab907b712e77",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1719737420,
-        "narHash": "sha256-X+DK41RO/vxUBMyCJfWMVBxVDuPHkZskZK03knNoeTk=",
+        "lastModified": 1719923111,
+        "narHash": "sha256-4MhPR5FP6Jj+OoMek/RWpFUzvgTuUtYi8QRPK3GtVnw=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "69a9eab2525e49be3f331e8570efef126cff4a1f",
+        "rev": "6c6f9f5effdd20d1aa7bc6b9a01e20800d02a7bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes SSH unauthenticated RCE (CVE-2024-6387) via
https://github.com/NixOS/nixpkgs/pull/323765.