### PR TITLE
bitcoind-rpc-public-whitelist: add `getpeerinfo`

### DIFF
--- a/modules/bitcoind-rpc-public-whitelist.nix
+++ b/modules/bitcoind-rpc-public-whitelist.nix
@@ -35,6 +35,7 @@
   "getnetworkhashps"
   # Network
   "getnetworkinfo"
+  "getpeerinfo"
   # Rawtransactions
   "analyzepsbt"
   "combinepsbt"


### PR DESCRIPTION
Required by lnd 0.18.0.

The bug fixed here can only be reproduced on a fully-synced mainnet/testnet node.
lnd error:
```
[ERR] LNWL: Encountered err while fetching fee filters: status code: 403, response: ""
```