### PR TITLE
README: don't mention IRC channel which is now unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,5 @@ See [dev/README](./dev/README.md).
 Troubleshooting
 ---
 If you are having problems with nix-bitcoin check the [FAQ](docs/faq.md) or submit an issue.\
-There's also a Matrix room at [#general:nixbitcoin.org](https://matrix.to/#/#general:nixbitcoin.org)
-and a `#nix-bitcoin` IRC channel on [libera](https://libera.chat).\
+There's also a Matrix room at [#general:nixbitcoin.org](https://matrix.to/#/#general:nixbitcoin.org).\
 We are always happy to help.


### PR DESCRIPTION
There's 3-4 people and one of them is me. There hasn't been actual discussion in months.

Would be also nice to put link to the matrix channel in the topic but that would probably require assistance from libera.chat or nix people who own the `#nix-` prefix?