### PR TITLE
add RestartMode=direct

### DIFF
--- a/modules/clightning-rest.nix
+++ b/modules/clightning-rest.nix
@@ -96,6 +96,7 @@ in {
         User = clightning.user;
         Restart = "on-failure";
         RestartSec = "10s";
+        RestartMode = "direct";
         ReadWritePaths = [ cfg.dataDir ];
         inherit (nbLib.allowNetlink) RestrictAddressFamilies;
       } // nbLib.allowedIPAddresses cfg.tor.enforce

--- a/modules/rtl.nix
+++ b/modules/rtl.nix
@@ -209,6 +209,7 @@ in {
         User = cfg.user;
         Restart = "on-failure";
         RestartSec = "10s";
+        RestartMode = "direct";
         ReadWritePaths = [ cfg.dataDir ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce
         // nbLib.nodejs;


### PR DESCRIPTION
i've noticed when my clightning crashes, services that have it as a dependency (clightning-rest, rtl) will be deactived without restarting:
![2024-10-05-210614_1280x1024_scrot](https://github.com/user-attachments/assets/5db8e96e-f8b4-463f-9b08-131103078771)
if we set RestartMode="direct", it should restart the services along with the parent:
https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#RestartMode=
i just started testing this on my server, will report back once clightning crashes again (in a day or two) to see if I have the expected result
would we want this on all dependency services?
these are the only two i am using and can test.