### PR TITLE
lnd: make `ExecStartPost` extensible

### DIFF
--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -262,9 +262,8 @@ in {
         ExecStartPost = let
           curl = "${pkgs.curl}/bin/curl -fsS --cacert ${cfg.certPath}";
           restUrl = "https://${nbLib.addressWithPort cfg.restAddress cfg.restPort}/v1";
-        in
           # Setting macaroon permissions for other users needs root permissions
-          nbLib.rootScript "lnd-create-macaroons" ''
+          script = nbLib.rootScript "lnd-create-macaroons" ''
             umask ug=r,o=
             ${lib.concatMapStrings (macaroon: ''
               echo "Create custom macaroon ${macaroon}"
@@ -278,6 +277,9 @@ in {
               chown ${cfg.macaroons.${macaroon}.user}: "$macaroonPath"
             '') (attrNames cfg.macaroons)}
           '';
+        in [
+          script
+        ];
       } // nbLib.allowedIPAddresses cfg.tor.enforce;
     };
 


### PR DESCRIPTION
#### Copy of commit msg
By wrapping the value in a list, users can add other `ExecStartPost` scripts.
The previous scalar value could only be replaced, but not merged with other definitions.

#### Example
```bash
run-tests.sh -s '{
  services.lnd.enable = true;
  systemd.services.lnd.serviceConfig.ExecStartPost = lib.mkAfter [ "${pkgs.hello}/bin/hello" ];
}' container --run c journalctl -u lnd
```
Result:
```
...
Nov 06 16:51:05 nb-test lnd[533]: 2024-11-06 16:51:05.096 [INF] LTND: Waiting for chain backend to finish sync, start_height=0
Nov 06 16:51:05 nb-test hello[545]: Hello, world!
Nov 06 16:51:05 nb-test systemd[1]: Started lnd.service.
```