### PR TITLE
add asmap-data package and bitcoind module option

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -254,6 +254,11 @@ let
         example = "bech32";
         description = "The type of addresses to use";
       };
+      fetchASmap = mkOption {
+        type = types.nullOr types.bool;
+        default = null;
+        description = "Fetch the latest ASmap from the github:asmap/asmap-data repository.";
+      };
       user = mkOption {
         type = types.str;
         default = "bitcoin";
@@ -336,6 +341,9 @@ let
     # ZMQ options
     ${optionalString (cfg.zmqpubrawblock != null) "zmqpubrawblock=${cfg.zmqpubrawblock}"}
     ${optionalString (cfg.zmqpubrawtx != null) "zmqpubrawtx=${cfg.zmqpubrawtx}"}
+
+    # ASmap option
+    ${optionalString (cfg.fetchASmap != null) "asmap=${pkgs.asmap-data}"}
 
     # Extra options
     ${cfg.extraConfig}

--- a/pkgs/asmap-data.nix
+++ b/pkgs/asmap-data.nix
@@ -1,0 +1,23 @@
+{ stdenv, pkgs, lib, fetchFromGitHub, ... }:
+
+stdenv.mkDerivation rec {
+  name = "asmap-data";
+  version = "dcce69e48211facdbd52a461cfce333d5800b7de";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "asmap";
+    repo = "asmap-data";
+    rev = version;
+    sha256 = "sha256-bp93VZX6EF6vwpbA4jqAje/1txfKeqN9BhVRLkdM+94=";
+  };
+
+  installPhase = ''
+    cp -r $src/latest_asmap.dat $out
+  '';
+
+  meta = {
+    description = "Contains an asmap file from the ASMap Data Demo Repository";
+    homepage = "https://github.com/asmap/asmap-data";
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Taken from @0xB10C 's [config](https://github.com/0xB10C/nix/blob/master/pkgs/asmap-data/default.nix) . 

The output of the package is just the ASmap file itself, which lives in the [asmap-data](https://github.com/asmap/asmap-data/) repository. 

Ran tests locally but didn't try a configuration with the setting enabled. 
