### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733808091,
-        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1732997066,
-        "narHash": "sha256-9Vvu3a1ep1LB6F/kVE2hHH2HQzhSFtUyJYiJRkUkC4Q=",
+        "lastModified": 1734126203,
+        "narHash": "sha256-0XovF7BYP50rTD2v4r55tR5MuBLet7q4xIz6Rgh3BBU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "33b9d57c656e65a9c88c5f34e4eb00b83e2b0ca9",
+        "rev": "71a6392e367b08525ee710a93af2e80083b5b3e2",
         "type": "github"
       },
       "original": {

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -6,10 +6,6 @@ pkgs: pkgsUnstable:
     bitcoind
     btcpayserver
     charge-lnd
-    clboss
-    clightning
-    electrs
-    elementsd
     extra-container
     fulcrum
     hwi
@@ -20,7 +16,10 @@ pkgs: pkgsUnstable:
     nbxplorer;
 
   inherit (pkgsUnstable)
-    ;
+    clboss
+    clightning
+    electrs
+    elementsd;
 
   inherit pkgs pkgsUnstable;
 }

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1732983965,
-        "narHash": "sha256-F3aFC/sdVvch7rRTBMfYo2fSdt6az+nzc1d1NUlN6dE=",
+        "lastModified": 1733506865,
+        "narHash": "sha256-vI4fLD2lEj09J3s/rSERNUBM0t+YjpGmmEUzhGXpngM=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "b312050edc40c388c8218aaa28bb390ba8c3373f",
+        "rev": "fadaefc936f321e6f18f9144a2b9a18b3c703644",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "npmlock2nix": "npmlock2nix"
       },
       "locked": {
-        "lastModified": 1733014289,
-        "narHash": "sha256-hgMG4ndkArZYCWu4OPkDKfvYz48pHpWs3jw6y7arlIg=",
+        "lastModified": 1733672217,
+        "narHash": "sha256-8VqXAkRpel6e50q6cetpXlSzmxgig3zf+THgMbf3Dd4=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "89daae878ab3d860802322aa9366ba5b0cf7fa45",
+        "rev": "381ffa11f1d22cc4421ff88fbb6e0d75a4e5de26",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733392399,
+        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pkg updates in nixpkgs stable:
btcpayserver: 1.13.5 -> 1.13.7
nbxplorer: 2.5.7 -> 2.5.16

Pkg updates in nixpkgs unstable:
clboss: 0.14.0 -> 0.14.1
clightning: 24.08.2 -> 24.11
electrs: 0.10.6 -> 0.10.7
elementsd: 23.2.1 -> 23.2.4