### PR TITLE
container example: add clightning to flake, remove electrs

### DIFF
--- a/examples/container/flake.nix
+++ b/examples/container/flake.nix
@@ -61,7 +61,7 @@
               # Enable some services.
               # See ../configuration.nix for all available features.
               services.bitcoind.enable = true;
-              services.electrs.enable = true;
+              services.clightning.enable = true;
             };
           };
         };


### PR DESCRIPTION
Some of the commands listed in `usage.sh` require clightning to be enabled. This commit enables clightning so they will work.