### PR TITLE
Fix test `persistentContainerExample`

### DIFF
--- a/examples/container/flake.nix
+++ b/examples/container/flake.nix
@@ -61,7 +61,7 @@
               # Enable some services.
               # See ../configuration.nix for all available features.
               services.bitcoind.enable = true;
-              services.clightning.enable = true;
+              services.electrs.enable = true;
             };
           };
         };

--- a/examples/container/usage.sh
+++ b/examples/container/usage.sh
@@ -39,7 +39,7 @@ extra-container start mynode
 # You can also use the `create --start` command above
 
 # Destroy container
-nix run . -- destroy
+extra-container destroy mynode
 
 #―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
 # Inspect container config

--- a/examples/container/usage.sh
+++ b/examples/container/usage.sh
@@ -21,8 +21,8 @@ nix run . -- create --start
 # Run command in container
 extra-container run mynode -- hostname
 extra-container run mynode -- systemctl status bitcoind
-extra-container run mynode -- lightning-cli getinfo
-extra-container run mynode -- bash -c 'bitcoin-cli -getinfo && lightning-cli getinfo'
+extra-container run mynode -- bitcoin-cli -getinfo
+extra-container run mynode -- bash -c 'bitcoin-cli -getinfo && systemctl status electrs'
 
 # Start shell in container
 extra-container root-login mynode


### PR DESCRIPTION
#### Copy of main commit msg
This test requires `electrs` to be enabled.

Also, by using `electrs` instead of `clightning` we avoid the bug where clightning hangs at startup when internet access is unavailable. Due to technical limititations, internet access is available in NixOS containers only after the container has started.