### PR TITLE
services: use `wants` dependency where possible

### DIFF
--- a/modules/clightning-rest.nix
+++ b/modules/clightning-rest.nix
@@ -75,7 +75,7 @@ in {
 
     systemd.services.clightning-rest = mkIf cfg.enable {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "clightning.service" ];
+      wants = [ "clightning.service" ];
       after = [ "clightning.service" ];
       path = [ pkgs.openssl ];
       environment.CL_REST_STATE_DIR = cfg.dataDir;

--- a/modules/fulcrum.nix
+++ b/modules/fulcrum.nix
@@ -111,7 +111,7 @@ in {
 
     systemd.services.fulcrum = {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "bitcoind.service" ];
+      wants = [ "bitcoind.service" ];
       after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       preStart = ''
         {

--- a/modules/liquid.nix
+++ b/modules/liquid.nix
@@ -255,7 +255,7 @@ in {
     ];
 
     systemd.services.liquidd = {
-      requires = [ "bitcoind.service" ];
+      wants = [ "bitcoind.service" ];
       after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
       wantedBy = [ "multi-user.target" ];
       preStart = ''

--- a/modules/mempool.nix
+++ b/modules/mempool.nix
@@ -275,10 +275,11 @@ in {
       };
     };
 
-    systemd.services.mempool = {
+    systemd.services.mempool = rec {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "${cfg.electrumServer}.service" ];
-      after = [ "${cfg.electrumServer}.service" "mysql.service" ];
+      requires = [ "mysql.service" ];
+      wants = [ "${cfg.electrumServer}.service" ];
+      after = requires ++ wants;
       preStart = ''
         mkdir -p '${cacheDir}/cache'
         <${configFile} sed \

--- a/modules/rtl.nix
+++ b/modules/rtl.nix
@@ -190,9 +190,9 @@ in {
 
     systemd.services.rtl = rec {
       wantedBy = [ "multi-user.target" ];
-      requires = optional cfg.nodes.clightning.enable "clightning.service" ++
-                 optional cfg.nodes.lnd.enable "lnd.service";
-      after = requires ++ [ "nix-bitcoin-secrets.target" ];
+      wants = optional cfg.nodes.clightning.enable "clightning.service" ++
+              optional cfg.nodes.lnd.enable "lnd.service";
+      after = wants ++ [ "nix-bitcoin-secrets.target" ];
       environment.RTL_CONFIG_PATH = cfg.dataDir;
       environment.DB_DIRECTORY_PATH = cfg.dataDir;
       serviceConfig = nbLib.defaultHardening // {

--- a/test/tests.py
+++ b/test/tests.py
@@ -386,7 +386,6 @@ def _():
 @test("restart-bitcoind")
 def _():
     # Sanity-check system by restarting bitcoind.
-    # This also restarts all services depending on bitcoind.
     succeed("systemctl restart bitcoind")
 
 @test("regtest")


### PR DESCRIPTION
#### Copy of commit msg
Let A be a service that depends on another service B.
When A can gracefully handle failures and restarts of B, use
```
wants = [ "B.service" ];
after = [ "B.service" ];
```
instead of
```
requires = [ "B.service" ];
after = [ "B.service" ];
```
in the definition of A.

This way, A keeps running when B is stopped or restarted after a failure.
With `requires`, A is instead stopped when B is stopped or restarted due to a failure.

This brings two benefits:

1. Improved uptime
   Examples:
   - RTL keeps running when one lightning node has failed
   - btcpayserver keeps running and accepting on-chain payments when the lightning node has crashed

2. Avoids a systemd bug where depending units (`A.service` in the above example) are not restarted when their dependency fails
   (issue github/systemd#18856, no full link to avoid spamming the issue).
   In real world nix-bitcoin deployments, this issue was only likely to appear when clightning failed during activation, causing depending units (like `RTL`) to stop and not be restarted.
   All services depending on `clightning` have now been changed to use `wants`, thereby avoiding the bug.

Services `electrs` and `lightning-loop` fail when their respective dependencies stop, so these services have not been changed.
I also haven't changed services `joinmarket` and `joinmarket-yieldgenerator`. Further manual testing is needed to determine if they can be switched to `wants`.

#### Manual testing
<details>
<summary>Commands used for manual testing</summary>

```bash
run-tests.sh --scenario '{
imports = [ scenarios.regtestBase ];
services.btcpayserver.enable = true;
services.clightning.enable = true;
services.clightning-rest.enable = true;
services.fulcrum.enable = true;
services.liquidd.enable = true;
services.lnd = {
  enable = true;
  port = 9736;
};
services.mempool.enable = true;
services.rtl = {
  enable = true;
  address = "0.0.0.0";
  nodes.clightning.enable = true;
  nodes.lnd.enable = true;
};
}' container --run c

# Check that all services are running
systemctl status

time=$(date +%s.%6N)
systemctl stop bitcoind
sleep 10
systemctl status bitcoind
lightning-cli getinfo
lncli getinfo # this hangs when bitcoind is stopped
systemctl start bitcoind

# Check that no service failed
journalctl --grep 'Failed with result'

## Check that services gracefully handle connection loss to bitcoind
journalctl -u nbxplorer --since=@$time
journalctl -u btcpayserver --since=@$time
# clightning shows bitcoind rpc failures as '... exited with status 1'
journalctl -u clightning --since=@$time
lightning-cli getinfo
journalctl -u fulcrum --since=@$time
journalctl -u liquidd --since=@$time
journalctl -u lnd --since=@$time
lncli getinfo
journalctl -u mempool --since=@$time

# Check stopping and starting clightning and lnd
time=$(date +%s.%6N)
systemctl stop clightning lnd
systemctl status clightning lnd
journalctl --grep 'Failed with result'
# open RTL to check that it gracefully handles node connection errors
http://10.225.255.2:3000
systemctl start clightning lnd
journalctl --grep 'Failed with result'
journalctl -u clightning-rest --since=@$time


### Test units that fail when their requirement fails
run-tests.sh --scenario '{
imports = [ scenarios.regtestBase ];
services.electrs.enable = true;
services.lightning-loop.enable = true;
}' container --run c

time=$(date +%s.%6N)
systemctl stop bitcoind lnd
sleep 10
journalctl -u electrs --since=@$time
journalctl -u lightning-loop --since=@$time
```
</details>