### PR TITLE
dev: add more automation to NixOS version updates

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -98,7 +98,4 @@ It's easiest to use an existing service as a template:
 
 ## Switching to a new NixOS release
 - Run command `update-flake.sh 24.11`
-- [cirrus.yml](../.cirrus.yml): update toplevel container -> image attribute
-- [examples/configuration.nix](../examples/configuration.nix): update `system.stateVersion`
-- [examples/flakes/flake.nix](../examples/flakes/flake.nix): update `inputs.nix-bitcoin.url`
 - Treewide: check if any `TODO-EXTERNAL` comments can be resolved

--- a/examples/container/flake.nix
+++ b/examples/container/flake.nix
@@ -12,7 +12,7 @@
   inputs = {
     nix-bitcoin.url = "github:fort-nix/nix-bitcoin/release";
     # You can also use a version branch to track a specific NixOS release
-    # nix-bitcoin.url = "github:fort-nix/nix-bitcoin/nixos-23.05";
+    # nix-bitcoin.url = "github:fort-nix/nix-bitcoin/nixos-24.11";
 
     nixpkgs.follows = "nix-bitcoin/nixpkgs";
     nixpkgs-unstable.follows = "nix-bitcoin/nixpkgs-unstable";

--- a/helper/update-flake.sh
+++ b/helper/update-flake.sh
@@ -52,9 +52,18 @@ versions=$(nix eval --json -f update-flake.nix versions)
 ## Uncomment the following to generate a version change message for testing
 # versions=$(echo "$versions" | sed 's|1|0|g')
 
+setVersion() {
+    sed -Ei "s|($1)[0-9.]+|\1$nixosVersion|" "$2"
+}
+
 echo "Updating main flake"
 if [[ $nixosVersion ]]; then
-    sed -Ei "s|(nixpkgs.url = .*nixos-)[^\"]+|\1$nixosVersion|" ../flake.nix
+    setVersion 'nixpkgs.url = .*?nixos-' ../flake.nix
+    setVersion 'system.stateVersion = "' ../examples/configuration.nix
+    setVersion 'nix-bitcoin.url = .*?/nixos-' ../examples/flakes/flake.nix
+    setVersion 'nix-bitcoin.url = .*?/nixos-' ../examples/container/flake.nix
+    setVersion 'image: nixpkgs.*?nixos-' ../.cirrus.yml
+    setVersion 'update-flake.sh ' ../dev/README.md
     nix flake update nixpkgs --flake ..
 else
     nix flake update --flake ..


### PR DESCRIPTION
#### Copy of commit msg
Use the `update-flake.sh` script to auto-update the NixOS version at various places.

Also update `examples/container/flake.nix` which has been missing in the update instructions.