### PR TITLE
bitcoind-rpc-public-whitelist: add `getblockfrompeer`

### DIFF
--- a/modules/bitcoind-rpc-public-whitelist.nix
+++ b/modules/bitcoind-rpc-public-whitelist.nix
@@ -12,6 +12,7 @@
   "getblockchaininfo"
   "getblockcount"
   "getblockfilter"
+  "getblockfrompeer"
   "getblockhash"
   "getblockheader"
   "getblockstats"


### PR DESCRIPTION
#### Copy of commit msg
This is used by nbxplorer since v2.5.24 on pruned nodes:
https://github.com/dgarage/NBXplorer/pull/511