### PR TITLE
trustedcoin: 2024-11-15 -> 0.8.4

### DIFF
--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -1,14 +1,14 @@
-{ lib, buildGo123Module, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub }:
 
-buildGo123Module rec {
+buildGoModule rec {
   pname = "trustedcoin";
-  version = "2024-11-15";
+  version = "0.8.4";
 
   src = fetchFromGitHub {
     owner = "nbd-wtf";
     repo = pname;
-    rev = "92e6f2129f85548693b4a44b39eab9e5ade8c23d";
-    hash = "sha256-Blw2s0JECe01s3Wn6gY3Ladd81+wWBBeXarICa0l/bU=";
+    rev = "v${version}";
+    hash = "sha256-mROWJEMRuIAcDXtEyin2+MLFplPInOsv5Q7vACNzi80=";
   };
 
   vendorHash = "sha256-fW+EoNPC0mH8C06Q6GXNwFdzE7oQT+qd+B7hGGml+hc=";


### PR DESCRIPTION
https://github.com/nbd-wtf/trustedcoin/releases/tag/v0.8.4

Test with:
```bash
run-tests.sh -s trustedcoin
```