### PR TITLE
bitcoind: remove upper limit of option `dbcache`

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -205,7 +205,7 @@ let
         '';
       };
       dbCache = mkOption {
-        type = types.nullOr (types.ints.between 4 16384);
+        type = types.nullOr (intAtLeast 4);
         default = null;
         example = 4000;
         description = "Override the default database cache size in MiB.";
@@ -350,6 +350,11 @@ let
   '';
 
   zmqServerEnabled = (cfg.zmqpubrawblock != null) || (cfg.zmqpubrawtx != null);
+
+  intAtLeast = n: types.addCheck types.int (x: x >= n) // {
+    name = "intAtLeast";
+    description = "integer >= ${toString n}";
+  };
 in {
   inherit options;
 


### PR DESCRIPTION
#### Copy of commit msg
The upper limit has been removed.
See item `The maximum allowed value...` at https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-29.0.md#updated-settings

#### Testing
Test with
```bash
run-tests.sh -s '{ services.bitcoind.dbCache = 0; }' eval
run-tests.sh -s '{ services.bitcoind.dbCache = 4; }' eval
```