### PR TITLE
albyhub: add module

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -192,6 +192,14 @@
   # public access to the web interface.
   # nix-bitcoin.onionServices.btcpayserver.enable = true;
 
+  ### Alby Hub
+  # Set this to enable Alby Hub.
+  # services.albyhub.enable = true;
+  #
+  # Set this to create an onion service to make the Alby Hub web interface
+  # accessible via Tor.
+  # nix-bitcoin.onionServices.albyhub.public = true;
+
   ### LIQUIDD
   # Enable this module to use Liquid, a sidechain for an inter-exchange
   # settlement network linking together cryptocurrency exchanges and

--- a/examples/qemu-vm/run-vm.sh
+++ b/examples/qemu-vm/run-vm.sh
@@ -41,7 +41,7 @@ vmWaitForSSH() {
 
 # Run command in VM
 c() {
-    ssh -p "$sshPort" -i "$identityFile" -o IdentitiesOnly=yes -o ConnectTimeout=1 \
+    ssh -p "$sshPort" -i "$identityFile" -o ConnectTimeout=1 \
         -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR \
         -o ControlMaster=auto -o ControlPath=$tmpDir/ssh-connection -o ControlPersist=60 \
         root@127.0.0.1 "$@"

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -164,7 +164,7 @@ in
       type = with types; nullOr str;
       default =
         if config.services.mempool.enable then
-          "http://${nbLib.addressWithPort config.services.mempool.address config.services.mempool.port}"
+          "http://${nbLib.addressWithPort config.services.mempool.address config.services.mempool.port}/api"
         else
           null;
       description = "Mempool API endpoint.";

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -13,10 +13,6 @@ let
   lnd = config.services.lnd;
   # Use loopback for client connections if lnd is bound to wildcard addresses
   lndRpcClientAddress = builtins.replaceStrings [ "0.0.0.0" "[::]" ] [ "127.0.0.1" "[::1]" ] lnd.rpcAddress;
-  torRelays = [
-    "ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion"
-    "ws://bitcoinr6de5lkvx4tpwdmzrdfdpla5sya2afwpcabjup2xpi5dulbad.onion"
-  ];
 
   envFileContent =
     let
@@ -127,15 +123,11 @@ in
     };
 
     relay = mkOption {
-      type = with types; nullOr (either str (listOf str));
+      type = with types; nullOr (listOf str);
       example = [ "wss://relay.damus.io" "wss://offchain.pub" "wss://relay.primal.net" ];
-      default = if cfg.tor.proxy then torRelays else null;
+      default = null;
       apply = value: if builtins.isList value then concatStringsSep "," value else value;
-      description = ''
-        The default nostr relays to use. Find more relays:
-        - https://nostrwat.ch/
-        - https://github.com/0xtrr/onion-service-nostr-relays
-      '';
+      description = "The nostr relays to use. Note that onion relays are not supported due to proxy limitations in hub. Find more relays: https://nostrwat.ch/";
     };
 
     logLevel = mkOption {

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -61,11 +61,11 @@ let
       ${optionalString (cfg.baseUrl != null) "BASE_URL=${cfg.baseUrl}"}
       ${optionalString (cfg.frontendUrl != null) "FRONTEND_URL=${cfg.frontendUrl}"}
       ${optionalString (cfg.logEvents != null) "LOG_EVENTS=${boolToString cfg.logEvents}"}
+      ${optionalString (cfg.relay != null) "RELAY=${cfg.relay}"}
+      ${optionalString (cfg.boltzApi != null) "BOLTZ_API=${cfg.boltzApi}"}
       ${optionalString (
         cfg.enableAdvancedSetup != null
       ) "ENABLE_ADVANCED_SETUP=${boolToString cfg.enableAdvancedSetup}"}
-      RELAY=${cfg.relay}
-      BOLTZ_API=${cfg.boltzApi}
       ${backendOpts}
       ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
     '';
@@ -124,7 +124,8 @@ in
 
     relay = mkOption {
       type = with types; nullOr str;
-      default = "wss://relay.getalby.com/v1";
+      default = null;
+      example = "wss://relay.getalby.com,wss://relay2.getalby.com";
       description = "The default nostr relay.";
     };
 
@@ -167,15 +168,21 @@ in
     baseUrl = mkOption {
       type = with types; nullOr str;
       default = null;
-      description = "Base URL for the Alby Hub. Required if you want to connect to your Alby account.";
+      description = ''
+        Public base URL of your Alby Hub backend (used as `BASE_URL`).
+        This must be reachable by the browser and is required when using a custom Alby OAuth client,
+        because the OAuth callback is `${baseUrl}/api/alby/callback`.
+      '';
       example = "http://localhost:8082";
     };
 
     frontendUrl = mkOption {
       type = with types; nullOr str;
       default = null;
-      description = "Frontend URL for the Alby Hub";
-      example = "http://127.0.0.1:8082";
+      description = ''
+        Public URL of the Hub frontend UI used for browser redirects (for example after OAuth or logout).
+        If unset, redirects fall back to `baseUrl`.
+      '';
     };
 
     logEvents = mkOption {
@@ -198,11 +205,10 @@ in
 
     boltzApi = mkOption {
       type = with types; nullOr str;
-      default = "wss://api.boltz.exchange/v2/ws";
+      default = null;
+      example = "wss://api.boltz.exchange/";
       description = "Boltz API endpoint.";
     };
-
-    # Removed: relayBridge and boltzBridge options. Bridges are auto-managed when tor.proxy is enabled.
 
     extraConfig = mkOption {
       type = with types; nullOr str;
@@ -370,18 +376,16 @@ in
         ++ optional cfg.tor.proxy "tor.service";
 
         environment = mkIf cfg.tor.proxy {
-          # Use Tor SOCKS for generic proxy-aware clients.
-          # Use Tor's HTTP CONNECT tunnel for clients that only support HTTP(S)_PROXY.
           ALL_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
-          SOCKS_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
           HTTP_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
-          HTTPS_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
-          NO_PROXY = "127.0.0.1,localhost,::1";
         };
 
         serviceConfig =
           nbLib.defaultHardening
           // {
+            # Build `${envFile}` at service start so dynamic values and secrets are resolved at runtime,
+            # rather than being baked into the Nix-evaluated config. This hook also handles privileged
+            # setup (for example copying LND macaroon and fixing ownership/permissions) before dropping to `${cfg.user}`.
             ExecStartPre =
               let
                 catSecret = secret: optionalString (secret != null) "cat ${secret}";
@@ -402,6 +406,9 @@ in
                   cat > ${envFile} <<EOF
                   ${envFileContent}
                   EOF
+                  ${optionalString (cfg.frontendUrl == null && cfg.getPublicAddressCmd != "") ''
+                    echo "FRONTEND_URL=http://$(${cfg.getPublicAddressCmd})" >> ${envFile}
+                  ''}
                   # Append secrets
                   ${appendToFile "AUTO_UNLOCK_PASSWORD" cfg.autoUnlockPasswordFile}
                   ${optionalString (cfg.jwtSecretFile != null) (appendToFile "JWT_SECRET" cfg.jwtSecretFile)}

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -13,6 +13,11 @@ let
   lnd = config.services.lnd;
   # Use loopback for client connections if lnd is bound to wildcard addresses
   lndRpcClientAddress = builtins.replaceStrings [ "0.0.0.0" "[::]" ] [ "127.0.0.1" "[::1]" ] lnd.rpcAddress;
+  torRelays = [
+    "wss://relay.damus.io"
+    "ws://nostrland2gdw7g3y77ctftovvil76vquipymo7tsctlxpiwknevzfid.onion"
+    "ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion"
+  ];
 
   envFileContent =
     let
@@ -123,10 +128,11 @@ in
     };
 
     relay = mkOption {
-      type = with types; nullOr str;
-      default = null;
-      example = "wss://relay.getalby.com,wss://relay2.getalby.com";
-      description = "The default nostr relay.";
+      type = with types; nullOr (either str (listOf str));
+      example = [ "wss://relay.getalby.com" "wss://relay2.getalby.com" ];
+      default = if cfg.tor.proxy then torRelays else null;
+      apply = value: if builtins.isList value then concatStringsSep "," value else value;
+      description = "The default nostr relays to use.";
     };
 
     logLevel = mkOption {
@@ -376,8 +382,11 @@ in
         ++ optional cfg.tor.proxy "tor.service";
 
         environment = mkIf cfg.tor.proxy {
-          ALL_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
           HTTP_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
+          HTTPS_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
+          # Use Tor SOCKS for generic proxy-aware clients.
+          ALL_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
+          NO_PROXY = "127.0.0.1,localhost,::1";
         };
 
         serviceConfig =

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -14,9 +14,8 @@ let
   # Use loopback for client connections if lnd is bound to wildcard addresses
   lndRpcClientAddress = builtins.replaceStrings [ "0.0.0.0" "[::]" ] [ "127.0.0.1" "[::1]" ] lnd.rpcAddress;
   torRelays = [
-    "wss://relay.damus.io"
-    "ws://nostrland2gdw7g3y77ctftovvil76vquipymo7tsctlxpiwknevzfid.onion"
     "ws://oxtrdevav64z64yb7x6rjg4ntzqjhedm5b5zjqulugknhzr46ny2qbad.onion"
+    "ws://bitcoinr6de5lkvx4tpwdmzrdfdpla5sya2afwpcabjup2xpi5dulbad.onion"
   ];
 
   envFileContent =
@@ -129,10 +128,14 @@ in
 
     relay = mkOption {
       type = with types; nullOr (either str (listOf str));
-      example = [ "wss://relay.getalby.com" "wss://relay2.getalby.com" ];
+      example = [ "wss://relay.damus.io" "wss://offchain.pub" "wss://relay.primal.net" ];
       default = if cfg.tor.proxy then torRelays else null;
       apply = value: if builtins.isList value then concatStringsSep "," value else value;
-      description = "The default nostr relays to use.";
+      description = ''
+        The default nostr relays to use. Find more relays:
+        - https://nostrwat.ch/
+        - https://github.com/0xtrr/onion-service-nostr-relays
+      '';
     };
 
     logLevel = mkOption {

--- a/modules/albyhub.nix
+++ b/modules/albyhub.nix
@@ -1,0 +1,435 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+let
+  cfg = config.services.albyhub;
+  nbLib = config.nix-bitcoin.lib;
+  bitcoind = config.services.bitcoind;
+  lnd = config.services.lnd;
+  # Use loopback for client connections if lnd is bound to wildcard addresses
+  lndRpcClientAddress = builtins.replaceStrings [ "0.0.0.0" "[::]" ] [ "127.0.0.1" "[::1]" ] lnd.rpcAddress;
+
+  envFileContent =
+    let
+      backendOpts =
+        if cfg.lnBackend == "lnd" then
+          ''
+            LN_BACKEND_TYPE=LND
+            LND_ADDRESS=${lndRpcClientAddress}:${toString lnd.rpcPort}
+            LND_CERT_FILE=${lnd.certPath}
+            LND_MACAROON_FILE=${cfg.dataDir}/admin.macaroon
+          ''
+        else if cfg.lnBackend == "ldk" then
+          ''
+            LN_BACKEND_TYPE=LDK
+            ${optionalString (cfg.ldk.network != null) "LDK_NETWORK=${cfg.ldk.network}"}
+            ${optionalString (cfg.ldk.esploraServer != null) "LDK_ESPLORA_SERVER=${cfg.ldk.esploraServer}"}
+            ${optionalString (cfg.ldk.gossipSource != null) "LDK_GOSSIP_SOURCE=${cfg.ldk.gossipSource}"}
+            ${optionalString (cfg.ldk.logLevel != null) "LDK_LOG_LEVEL=${toString cfg.ldk.logLevel}"}
+            ${optionalString (cfg.ldk.vssUrl != null) "LDK_VSS_URL=${cfg.ldk.vssUrl}"}
+            ${optionalString (
+              cfg.ldk.listeningAddresses != null
+            ) "LDK_LISTENING_ADDRESSES=${cfg.ldk.listeningAddresses}"}
+            ${optionalString (
+              cfg.ldk.transientNetworkGraph != null
+            ) "LDK_TRANSIENT_NETWORK_GRAPH=${boolToString cfg.ldk.transientNetworkGraph}"}
+          ''
+        else if cfg.lnBackend == "phoenix" then
+          ''
+            LN_BACKEND_TYPE=PHOENIX
+            ${optionalString (cfg.phoenix.address != null) "PHOENIXD_ADDRESS=${cfg.phoenix.address}"}
+          ''
+        else
+          "";
+    in
+    ''
+      WORK_DIR=${cfg.dataDir}
+      DATABASE_URI=${cfg.dataDir}/nwc.db
+      PORT=${toString cfg.port}
+      LOG_LEVEL=${toString cfg.logLevel}
+      AUTO_LINK_ALBY_ACCOUNT=${boolToString cfg.autoLinkAlbyAccount}
+      ${optionalString (cfg.logToFile != null) "LOG_TO_FILE=${boolToString cfg.logToFile}"}
+      ${optionalString (cfg.logDBQueries != null) "LOG_DB_QUERIES=${boolToString cfg.logDBQueries}"}
+      ${optionalString (cfg.network != null) "NETWORK=${cfg.network}"}
+      ${optionalString (cfg.mempoolApi != null) "MEMPOOL_API=${cfg.mempoolApi}"}
+      ${optionalString (cfg.albyOAuth.clientId != null) "ALBY_OAUTH_CLIENT_ID=${cfg.albyOAuth.clientId}"}
+      ${optionalString (cfg.baseUrl != null) "BASE_URL=${cfg.baseUrl}"}
+      ${optionalString (cfg.frontendUrl != null) "FRONTEND_URL=${cfg.frontendUrl}"}
+      ${optionalString (cfg.logEvents != null) "LOG_EVENTS=${boolToString cfg.logEvents}"}
+      ${optionalString (
+        cfg.enableAdvancedSetup != null
+      ) "ENABLE_ADVANCED_SETUP=${boolToString cfg.enableAdvancedSetup}"}
+      RELAY=${cfg.relay}
+      BOLTZ_API=${cfg.boltzApi}
+      ${backendOpts}
+      ${optionalString (cfg.extraConfig != null) cfg.extraConfig}
+    '';
+
+  # Persisted env file that contains secrets
+  envFile = "${cfg.dataDir}/.env";
+
+in
+{
+  options.services.albyhub = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Alby Hub, a service to control lightning wallets over nostr.
+        See the user guide at https://guides.getalby.com/user-guide/alby-hub.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.albyhub;
+      defaultText = "config.nix-bitcoin.pkgs.albyhub";
+      description = "The albyhub package to use.";
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = "albyhub";
+      description = "The user as which to run Alby Hub.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = cfg.user;
+      description = "The group as which to run Alby Hub.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/albyhub";
+      description = "The data directory for Alby Hub.";
+    };
+
+    address = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = "This option does nothing. It is only present only to satisfy the onion service module requirements.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8082;
+      description = "The port for Alby Hub to listen on.";
+    };
+
+    relay = mkOption {
+      type = with types; nullOr str;
+      default = "wss://relay.getalby.com/v1";
+      description = "The default nostr relay.";
+    };
+
+    logLevel = mkOption {
+      type = types.int;
+      default = 4;
+      description = "Log level for the application. Higher is more verbose.";
+    };
+
+    logToFile = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log to file.";
+    };
+
+    logDBQueries = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log database queries.";
+    };
+
+    network = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "The network to use (e.g. mainnet, testnet, regtest).";
+      example = "signet";
+    };
+
+    mempoolApi = mkOption {
+      type = with types; nullOr str;
+      default =
+        if config.services.mempool.enable then
+          "http://${nbLib.addressWithPort config.services.mempool.address config.services.mempool.port}"
+        else
+          null;
+      description = "Mempool API endpoint.";
+      example = "https://mempool.space/api";
+    };
+
+    baseUrl = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "Base URL for the Alby Hub. Required if you want to connect to your Alby account.";
+      example = "http://localhost:8082";
+    };
+
+    frontendUrl = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "Frontend URL for the Alby Hub";
+      example = "http://127.0.0.1:8082";
+    };
+
+    logEvents = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Log events.";
+    };
+
+    autoLinkAlbyAccount = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Auto link Alby account.";
+    };
+
+    enableAdvancedSetup = mkOption {
+      type = with types; nullOr bool;
+      default = null;
+      description = "Enable advanced setup.";
+    };
+
+    boltzApi = mkOption {
+      type = with types; nullOr str;
+      default = "wss://api.boltz.exchange/v2/ws";
+      description = "Boltz API endpoint.";
+    };
+
+    # Removed: relayBridge and boltzBridge options. Bridges are auto-managed when tor.proxy is enabled.
+
+    extraConfig = mkOption {
+      type = with types; nullOr str;
+      default = null;
+      description = "Extra configuration options appended to the environment file.";
+    };
+
+    autoUnlockPasswordFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the password to auto-unlock Alby Hub on startup.
+        Password will still be required to access the interface.
+        Setting this option is insecure. The password file will be world-readable
+        in the Nix store.
+      '';
+    };
+
+    jwtSecretFile = mkOption {
+      type = with types; nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the JWT secret.
+        Setting this option is insecure. The secret file will be world-readable
+        in the Nix store.
+      '';
+    };
+
+    lnBackend = mkOption {
+      type =
+        with types;
+        nullOr (enum [
+          "lnd"
+          "ldk"
+          "phoenix"
+        ]);
+      default = null;
+      description = ''
+        The lightning backend to use.
+        - `lnd`: Use the LND backend.
+        - `ldk`: Use the built-in LDK backend.
+        - `phoenix`: Use a phoenixd backend.
+      '';
+    };
+
+    ldk = {
+      network = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "The LDK network to use.";
+      };
+      esploraServer = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "LDK Esplora Server URL.";
+      };
+      gossipSource = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "LDK Gossip Source.";
+      };
+      vssUrl = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "LDK VSS URL.";
+      };
+      listeningAddresses = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "LDK Listening Addresses.";
+      };
+      transientNetworkGraph = mkOption {
+        type = with types; nullOr bool;
+        default = null;
+        description = "LDK Transient Network Graph.";
+      };
+      logLevel = mkOption {
+        type = with types; nullOr int;
+        default = null;
+        description = "LDK debug log level to get more info.";
+      };
+    };
+
+    albyOAuth = {
+      clientId = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "Alby OAuth Client ID.";
+      };
+      clientSecretFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = ''
+          Path to a file containing the Alby OAuth client secret.
+        '';
+      };
+    };
+
+    phoenix = {
+      address = mkOption {
+        type = with types; nullOr str;
+        default = null;
+        description = "Phoenixd address.";
+      };
+      authorizationFile = mkOption {
+        type = with types; nullOr path;
+        default = null;
+        description = "Path to a file containing the Phoenixd authorization.";
+      };
+    };
+
+    tor = nbLib.tor;
+
+    httpProxyPort = mkOption {
+      type = types.port;
+      default = 8118;
+      description = ''
+        Local Tor HTTP CONNECT proxy port used for `HTTP_PROXY`/`HTTPS_PROXY`
+        when `services.albyhub.tor.proxy` is enabled.
+      '';
+    };
+
+    getPublicAddressCmd = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Bash expression which outputs the public service address.
+        If left empty, no address is announced.
+      '';
+    };
+  };
+
+  config = mkMerge [
+    # If lnd is enabled, use it as the albyhub backend
+    (mkIf config.services.lnd.enable {
+      services.albyhub.lnBackend = mkDefault "lnd";
+    })
+    (mkIf cfg.enable {
+
+      users.users.${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+      };
+      users.groups.${cfg.group} = { };
+
+      # Ensure Tor SOCKS client is available when proxying
+      services.tor = mkIf cfg.tor.proxy {
+        enable = true;
+        client.enable = true;
+        # Provide an HTTP CONNECT proxy via Tor so HTTP(S)/WS clients can use it
+        settings.HTTPTunnelPort = [ { addr = "127.0.0.1"; port = cfg.httpProxyPort; } ];
+      };
+
+      systemd.tmpfiles.rules = [
+        "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
+      ];
+
+      systemd.services.albyhub = {
+        description = mkDefault "Alby Hub";
+        wantedBy = [ "multi-user.target" ];
+        after = [
+          "network.target"
+        ]
+        ++ optional (cfg.lnBackend == "lnd") "lnd.service"
+        ++ optional cfg.tor.proxy "tor.service";
+
+        environment = mkIf cfg.tor.proxy {
+          # Use Tor SOCKS for generic proxy-aware clients.
+          # Use Tor's HTTP CONNECT tunnel for clients that only support HTTP(S)_PROXY.
+          ALL_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
+          SOCKS_PROXY = "socks5h://${config.nix-bitcoin.torClientAddressWithPort}";
+          HTTP_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
+          HTTPS_PROXY = "http://127.0.0.1:${toString cfg.httpProxyPort}";
+          NO_PROXY = "127.0.0.1,localhost,::1";
+        };
+
+        serviceConfig =
+          nbLib.defaultHardening
+          // {
+            ExecStartPre =
+              let
+                catSecret = secret: optionalString (secret != null) "cat ${secret}";
+                appendToFile =
+                  key: secret:
+                  optionalString (secret != null) ''
+                    echo -n '${key}=' >> ${envFile}
+                    ${catSecret secret} >> ${envFile}
+                    echo >> ${envFile}
+                  '';
+              in
+              [
+                (nbLib.rootScript "albyhub-setup" ''
+                  ${optionalString (cfg.lnBackend == "lnd") ''
+                    install -m640 -o ${cfg.user} -g ${cfg.group} -D ${lnd.networkDir}/admin.macaroon ${cfg.dataDir}/admin.macaroon
+                  ''}
+                  # Create env file without secrets
+                  cat > ${envFile} <<EOF
+                  ${envFileContent}
+                  EOF
+                  # Append secrets
+                  ${appendToFile "AUTO_UNLOCK_PASSWORD" cfg.autoUnlockPasswordFile}
+                  ${optionalString (cfg.jwtSecretFile != null) (appendToFile "JWT_SECRET" cfg.jwtSecretFile)}
+                  ${optionalString (cfg.albyOAuth.clientSecretFile != null) (
+                    appendToFile "ALBY_OAUTH_CLIENT_SECRET" cfg.albyOAuth.clientSecretFile
+                  )}
+                  ${optionalString (cfg.phoenix.authorizationFile != null) (
+                    appendToFile "PHOENIXD_AUTHORIZATION" cfg.phoenix.authorizationFile
+                  )}
+
+                  chown -R ${cfg.user}:${cfg.group} ${cfg.dataDir}
+                  chmod 600 ${envFile}
+                '')
+              ];
+
+            User = cfg.user;
+            Group = cfg.group;
+            ExecStart = "${cfg.package}/bin/albyhub";
+            EnvironmentFile = "-${envFile}";
+            WorkingDirectory = cfg.dataDir;
+            Restart = "on-failure";
+            RestartSec = "10s";
+            ReadWritePaths = [ cfg.dataDir ];
+          }
+          // nbLib.allowedIPAddresses cfg.tor.enforce;
+
+      };
+
+    })
+  ];
+}

--- a/modules/nodeinfo.nix
+++ b/modules/nodeinfo.nix
@@ -158,6 +158,7 @@ in {
         inherit name cfg;
         systemdServiceName = "nginx";
       };
+      albyhub = mkInfo "";
       # Only add sshd when it has an onion service
       sshd = name: cfg: mkIfOnionPort "sshd" (onionPort: ''
         add_service("sshd", """info["onion_address"] = get_onion_address("sshd", ${onionPort})""")

--- a/modules/onion-services.nix
+++ b/modules/onion-services.nix
@@ -116,6 +116,9 @@ in {
         mempool-frontend = {
           externalPort = 80;
         };
+        albyhub = {
+          externalPort = 80;
+        };
       };
     }
   ];

--- a/modules/presets/enable-tor.nix
+++ b/modules/presets/enable-tor.nix
@@ -28,6 +28,7 @@ in {
     # btcpayserver = defaultEnableTorProxy;
     lightning-pool = defaultEnableTorProxy;
     mempool = defaultEnableTorProxy;
+    albyhub = defaultEnableTorProxy;
 
     # These services don't make outgoing connections
     # (or use Tor by default in case of joinmarket)
@@ -50,5 +51,6 @@ in {
     fulcrum.enable = defaultTrue;
     joinmarket-ob-watcher.enable = defaultTrue;
     rtl.enable = defaultTrue;
+    albyhub.enable = defaultTrue;
   };
 }

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -19,7 +19,7 @@ pkgs: pkgsUnstable: pkgs-25_05:
     lndconnect;
 
   inherit (pkgsUnstable)
-    ;
+    albyhub;
 
   inherit pkgs pkgsUnstable pkgs-25_05;
 }

--- a/pkgs/rtl/default.nix
+++ b/pkgs/rtl/default.nix
@@ -9,11 +9,11 @@
 }:
 let self = stdenvNoCC.mkDerivation {
   pname = "rtl";
-  version = "0.15.8";
+  version = "0.15.6";
 
   src = fetchurl {
     url = "https://github.com/Ride-The-Lightning/RTL/archive/refs/tags/v${self.version}.tar.gz";
-    hash = "sha256-8XdGyORxB2dkZRB/Yl7zh+Quqo4L/Y0VmC6Brbr/hqU=";
+    hash = "sha256-99Nn07gOKaasdV0OW+92EOHnpyoGhLUEVhrMrMlXFiU=";
   };
 
   passthru = {
@@ -25,7 +25,7 @@ let self = stdenvNoCC.mkDerivation {
       # TODO-EXTERNAL: Remove `npmFlags` when no longer required
       # See: https://github.com/Ride-The-Lightning/RTL/issues/1182
       npmFlags = "--legacy-peer-deps";
-      hash = "sha256-oMqd6nLzS6iQ9w4z2yzpR2unA5qhOq5YdvfoS8IgYLY=";
+      hash = "sha256-hWG5T1m0UoE/54fCPVGBJZiP3IIcqBRv/oeud1neG38=";
     };
   };
 

--- a/pkgs/rtl/generate.sh
+++ b/pkgs/rtl/generate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 . "${BASH_SOURCE[0]%/*}/../../helper/run-in-nix-env" "gnupg wget gnused" "$@"
 
-version="0.15.8"
+version="0.15.6"
 repo=https://github.com/Ride-The-Lightning/RTL
 
 scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)


### PR DESCRIPTION
## Project description

<!-- Describe the project a little: -->
This app was previously [nostr-wallet-connect](https://github.com/getAlby/nostr-wallet-connect) which implemented protocols ([nip-47](https://github.com/nostr-protocol/nips/blob/master/47.md) and [lud16](https://github.com/lnurl/luds/blob/luds/16.md), among others) for controlling an lnd lightning wallet over the distributed network protocol called [nostr](https://nostr.com/). The Alby "hub" expands the scope of the project to include support for more lightning wallet backends in addition to lnd: pheonixd and an internal ldk node.

While Alby started out providing custodial lightning software, they have since developed more self-custodial software such as this.

In full transparency, I've observed some rough edges in the build process, some of which have been smoothed out by deploying this as a nix package. Many other rough edges were smoothed out by updates over the last six months, so I have a lot more confidence in this project as of late.

* The upstream build [process](https://github.com/getAlby/hub/blob/master/Dockerfile) involves [pulling in pre-compiled](https://github.com/getAlby/hub/blob/master/build/docker/copy_dylibs.sh) library modules for ldk-node from separate repositories. By contrast, the new nix package handles this gracefully by creating builds inputs for albyhub and building all library modules from source.
* Minor auditability concern: I'm not a C or GO developer, but I wish [go-secp256k1-zkp](https://github.com/vulpemventures/go-secp256k1-zkp) imported the C library as a gitmodule, rather than maintaining the entire tree in repo. Then it would've been easier for me to reason about any changes they may have made to secp256k1-zkp. I did mention this concern in an [issue](https://github.com/vulpemventures/go-secp256k1-zkp/issues/20
) and was dismissed summarily (possibly for not explaining it well).

## Metadata

* homepage URL: https://albyhub.com/
* source URL: https://github.com/getAlby/hub
* user guide: https://guides.getalby.com/user-guide/alby-hub
* license: asl20
* platforms: amd64, aarch64