### PR TITLE
joinmarket: update directory nodes

### DIFF
--- a/modules/joinmarket.nix
+++ b/modules/joinmarket.nix
@@ -224,7 +224,7 @@ in {
         onion_serving_host = cfg.messagingAddress;
         onion_serving_port = cfg.messagingPort;
         hidden_service_dir = "";
-        directory_nodes = "g3hv4uynnmynqqq2mchf3fcm3yd46kfzmcdogejuckgwknwyq5ya6iad.onion:5222,3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222";
+        directory_nodes = "3kxw6lf5vf6y26emzwgibzhrzhmhqiw6ekrek3nqfjjmhwznb2moonad.onion:5222,bqlpq6ak24mwvuixixitift4yu42nxchlilrcqwk2ugn45tdclg42qid.onion:5222,odpwaf67rs5226uabcamvypg3y4bngzmfk7255flcdodesqhsvkptaid.onion:5222,ylegp63psfqh3zk2huckf2xth6dxvh2z364ykjfmvsoze6tkfjceq7qd.onion:5222,coinjointovy3eq5fjygdwpkbcdx63d7vd4g32mw7y553uj3kjjzkiqd.onion:5222,satoshi2vcg5e2ept7tjkzlkpomkobqmgtsjzegg6wipnoajadissead.onion:5222,shssats5ucnwdpbticbb4dymjzf2o27tdecpes35ededagjpdmpxm6yd.onion:5222,jmarketxf5wc4aldf3slm5u6726zsky52bqnfv6qyxe5hnafgly6yuyd.onion:5222";
       };
       # irc.darkscience.net
       "MESSAGING:server1" = socks5Settings // {


### PR DESCRIPTION
#### Copy of commit msg
Upstream update: https://github.com/JoinMarket-Org/joinmarket-clientserver/pull/1789

The old set of `directory_nodes` doesn't contain any online nodes, so this PR is essential for joinmarket to work again.

#### Discussion
This PR is deployed to nixbitcoin.org, the orderbook is [working again](https://nixbitcoin.org/orderbook).

Many thanks @mariaa144 for reporting this and suggesting a solution!