### PR TITLE
trustedcoin: 0.8.4 -> 0.8.6

### DIFF
--- a/pkgs/trustedcoin/default.nix
+++ b/pkgs/trustedcoin/default.nix
@@ -2,13 +2,13 @@
 
 buildGoModule rec {
   pname = "trustedcoin";
-  version = "0.8.4";
+  version = "0.8.6";
 
   src = fetchFromGitHub {
     owner = "nbd-wtf";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-mROWJEMRuIAcDXtEyin2+MLFplPInOsv5Q7vACNzi80=";
+    hash = "sha256-b+Icq/9qMF+Zvh7RuG9RxU8/U07Tl8ymZvNKWsZzatw=";
   };
 
   vendorHash = "sha256-fW+EoNPC0mH8C06Q6GXNwFdzE7oQT+qd+B7hGGml+hc=";


### PR DESCRIPTION
https://github.com/nbd-wtf/trustedcoin/releases/tag/v0.8.5
https://github.com/nbd-wtf/trustedcoin/releases/tag/v0.8.6