### PR TITLE
CI: Group job output, print eval results

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
       - id: main
-        run: nix shell --inputs-from . nixpkgs#{bash,coreutils,cachix} -c ./test/ci/build_test_drivers.sh
+        name: Build test drivers
+        run: |
+          echo "::group::Setup Nix env"
+          nix shell --inputs-from . nixpkgs#{bash,coreutils,cachix} -c ./test/ci/build_test_drivers.sh
 
   test_scenario:
     runs-on: ubuntu-latest

--- a/test/ci/build_test_drivers.sh
+++ b/test/ci/build_test_drivers.sh
@@ -10,10 +10,17 @@ driverDrvs=()
 drivers=()
 scenarioTests=()
 
+echo '::group::Eval test drivers'
 # Call ./test-info.nix
 testInfo=$(time nix eval --raw --show-trace ../..#ciTestInfo)
 # This sets variables `driverDrvs`, `drivers`, `scenarioTests`
 eval "$testInfo"
+
+for i in "${!drivers[@]}"; do
+    echo "${drivers[$i]}"
+    echo "${driverDrvs[$i]%^*}"
+done
+echo '::endgroup::'
 
 if nix path-info --store "https://${cachixCache}.cachix.org" "${scenarioTests[@]}" &>/dev/null; then
     echo
@@ -31,6 +38,8 @@ if nix path-info --store "https://${cachixCache}.cachix.org" "${drivers[@]}" &>/
     echo "All test drivers have already been built successfully:"
     exit 0
 fi
+
+echo '::group::Build test drivers'
 
 if [[ -v GITHUB_ACTIONS ]]; then
     # Avoid cachix warning message


### PR DESCRIPTION
Useful for debugging.

See it in action:
[Old output](https://github.com/fort-nix/nix-bitcoin/actions/runs/16885984579/job/47833742323) (Expand step "Run nix shell...")
[New output](https://github.com/fort-nix/nix-bitcoin/actions/runs/16891054541/job/47850663849) (Expand step "Build test drivers")