### PR TITLE
examples/configuration.nix: Improve `secure-node` preset documentation

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -4,6 +4,12 @@
 
 { config, pkgs, lib, ... }: {
   imports = [
+    <nix-bitcoin/modules/modules.nix>
+
+    # FIXME: The secure-node preset is an opinionated config to enhance security
+    # and privacy.
+    # Among other settings, it routes traffic of all nix-bitcoin services through Tor.
+    # Turn it off when not needed.
     <nix-bitcoin/modules/presets/secure-node.nix>
 
     # FIXME: The hardened kernel profile improves security but


### PR DESCRIPTION
#### Copy of commit msg
Explicitly import modules.nix, so that users can remove the secure-node.nix import.

Fixes #804