### PR TITLE
run-tests: Fix `tmpDir` being deleted before it's used

### DIFF
--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -190,6 +190,7 @@ buildTestAttr() {
 buildTests() {
     local -n tests=$1
     shift
+    makeTmpDir
     # TODO-EXTERNAL:
     # Simplify and switch to pure build when `nix build` can instantiate flake function outputs
     # shellcheck disable=SC2207


### PR DESCRIPTION
#### Copy of commit msg
In `buildTests`, `nixInstantiate` is called in a subshell. When `tmpDir` is unset before the call, the tmpdir is created in the
subshell and gets deleted before subshell exit (via `trap`).
But subsequent code accesses the tmpdir, which has now been deleted, leading to an error.

This bug has been undetected for a long time because bash 5.2 has a [bug](https://mail.gnu.org/archive/html/help-bash/2024-07/msg00007.html) where `trap` is not always executed, causing the tmpdir to never be deleted.
Bash 5.3 (introduced in NixOS 25.05) now works correctly and exposes the bug.

Fix it by creating the tmpdir before the subshell call.