### PR TITLE
LND: add neutrino backend support

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -80,6 +80,15 @@
   # Set this to enable lnd, a lightning implementation written in Go.
   # services.lnd.enable = true;
   #
+  # By default, lnd uses bitcoind as its backend. You can use neutrino instead
+  # to run lnd without a full Bitcoin node. This is useful for resource-constrained
+  # systems, but provides less privacy and security than a local bitcoind.
+  # services.lnd = {
+  #   enable = true;
+  #   backend = "neutrino";
+  #   neutrino.peers = [ "btcd.example.com:8333" ];
+  # };
+  #
   # NOTE: In order to avoid collisions with clightning you must disable clightning or
   # change the services.clightning.port or services.lnd.port to a port other than
   # 9735.

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -150,12 +150,12 @@ let
       description = "The backend to use for fetching blockchain data.";
     };
     neutrino = {
-      addpeers = mkOption {
+      peers = mkOption {
         type = types.listOf types.str;
         default = [];
         example = [ "192.168.1.1:8333" "btcd.example.com:8333" ];
         description = ''
-          List of Bitcoin full node peers to connect to via neutrino.addpeer.
+          List of Bitcoin full node peers to connect to for neutrino.
           Multiple peers provide redundancy for maximum uptime.
         '';
       };
@@ -206,7 +206,7 @@ let
       bitcoind.zmqpubrawtx=${zmqHandleSpecialAddress bitcoind.zmqpubrawtx}
     '' else ''
       bitcoin.node=neutrino
-      ${lib.concatMapStringsSep "\n" (peer: "neutrino.addpeer=${peer}") cfg.neutrino.addpeers}
+      ${lib.concatMapStringsSep "\n" (peer: "neutrino.addpeer=${peer}") cfg.neutrino.peers}
       fee.url=${cfg.neutrino.feeUrl}
     ''}
 
@@ -232,10 +232,10 @@ in {
           services.lnd.port to a port other than 9735.
         '';
       }
-      { assertion = cfg.backend != "neutrino" || cfg.neutrino.addpeers != [];
+      { assertion = cfg.backend != "neutrino" || cfg.neutrino.peers != [];
         message = ''
           When using neutrino backend, you must configure at least one peer
-          in services.lnd.neutrino.addpeers.
+          in services.lnd.neutrino.peers.
         '';
       }
     ];

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -167,6 +167,13 @@ let
           Required because neutrino doesn't have access to mempool data.
         '';
       };
+      maxPeers = mkOption {
+        type = types.int;
+        default = 8;
+        description = ''
+          Maximum number of inbound and outbound peers for neutrino.
+        '';
+      };
     };
   };
 
@@ -207,6 +214,7 @@ let
     '' else ''
       bitcoin.node=neutrino
       ${lib.concatMapStringsSep "\n" (peer: "neutrino.addpeer=${peer}") cfg.neutrino.peers}
+      neutrino.maxpeers=${toString cfg.neutrino.maxPeers}
       fee.url=${cfg.neutrino.feeUrl}
     ''}
 

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -261,8 +261,8 @@ in {
 
     systemd.services.lnd = {
       wantedBy = [ "multi-user.target" ];
-      requires = optional (cfg.backend == "bitcoind") "bitcoind.service";
-      after = optional (cfg.backend == "bitcoind") "bitcoind.service" ++ [ "nix-bitcoin-secrets.target" ];
+      requires = optionals (cfg.backend == "bitcoind") [ "bitcoind.service" ];
+      after = optionals (cfg.backend == "bitcoind") [ "bitcoind.service" ] ++ [ "nix-bitcoin-secrets.target" ];
       preStart = ''
         install -m600 ${configFile} '${cfg.dataDir}/lnd.conf'
         ${optionalString (cfg.backend == "bitcoind") ''
@@ -324,7 +324,7 @@ in {
     users.users.${cfg.user} = {
       isSystemUser = true;
       group = cfg.group;
-      extraGroups = optional (cfg.backend == "bitcoind") "bitcoinrpc-public";
+      extraGroups = optionals (cfg.backend == "bitcoind") [ "bitcoinrpc-public" ];
       home = cfg.dataDir; # lnd creates .lnd dir in HOME
     };
     users.groups.${cfg.group} = {};

--- a/modules/lnd.nix
+++ b/modules/lnd.nix
@@ -144,6 +144,30 @@ let
       description = "LND TLS certificate path.";
     };
     tor = nbLib.tor;
+    backend = mkOption {
+      type = types.enum [ "bitcoind" "neutrino" ];
+      default = "bitcoind";
+      description = "The backend to use for fetching blockchain data.";
+    };
+    neutrino = {
+      addpeers = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [ "192.168.1.1:8333" "btcd.example.com:8333" ];
+        description = ''
+          List of Bitcoin full node peers to connect to via neutrino.addpeer.
+          Multiple peers provide redundancy for maximum uptime.
+        '';
+      };
+      feeUrl = mkOption {
+        type = types.str;
+        default = "https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json";
+        description = ''
+          URL for fee estimation when using neutrino on mainnet.
+          Required because neutrino doesn't have access to mempool data.
+        '';
+      };
+    };
   };
 
   cfg = config.services.lnd;
@@ -170,15 +194,21 @@ let
     restlisten=${cfg.restAddress}:${toString cfg.restPort}
 
     bitcoin.${bitcoind.network}=1
-    bitcoin.node=bitcoind
 
     ${optionalString (cfg.tor.proxy) "tor.active=true"}
     ${optionalString (cfg.tor-socks != null) "tor.socks=${cfg.tor-socks}"}
 
-    bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}
-    bitcoind.rpcuser=${bitcoind.rpc.users.public.name}
-    bitcoind.zmqpubrawblock=${zmqHandleSpecialAddress bitcoind.zmqpubrawblock}
-    bitcoind.zmqpubrawtx=${zmqHandleSpecialAddress bitcoind.zmqpubrawtx}
+    ${if cfg.backend == "bitcoind" then ''
+      bitcoin.node=bitcoind
+      bitcoind.rpchost=${bitcoindRpcAddress}:${toString bitcoind.rpc.port}
+      bitcoind.rpcuser=${bitcoind.rpc.users.public.name}
+      bitcoind.zmqpubrawblock=${zmqHandleSpecialAddress bitcoind.zmqpubrawblock}
+      bitcoind.zmqpubrawtx=${zmqHandleSpecialAddress bitcoind.zmqpubrawtx}
+    '' else ''
+      bitcoin.node=neutrino
+      ${lib.concatMapStringsSep "\n" (peer: "neutrino.addpeer=${peer}") cfg.neutrino.addpeers}
+      fee.url=${cfg.neutrino.feeUrl}
+    ''}
 
     wallet-unlock-password-file=${secretsDir}/lnd-wallet-password
 
@@ -202,9 +232,15 @@ in {
           services.lnd.port to a port other than 9735.
         '';
       }
+      { assertion = cfg.backend != "neutrino" || cfg.neutrino.addpeers != [];
+        message = ''
+          When using neutrino backend, you must configure at least one peer
+          in services.lnd.neutrino.addpeers.
+        '';
+      }
     ];
 
-    services.bitcoind = {
+    services.bitcoind = mkIf (cfg.backend == "bitcoind") {
       enable = true;
 
       # Increase rpc thread count due to reports that lightning implementations fail
@@ -225,16 +261,16 @@ in {
 
     systemd.services.lnd = {
       wantedBy = [ "multi-user.target" ];
-      requires = [ "bitcoind.service" ];
-      after = [ "bitcoind.service" "nix-bitcoin-secrets.target" ];
+      requires = optional (cfg.backend == "bitcoind") "bitcoind.service";
+      after = optional (cfg.backend == "bitcoind") "bitcoind.service" ++ [ "nix-bitcoin-secrets.target" ];
       preStart = ''
         install -m600 ${configFile} '${cfg.dataDir}/lnd.conf'
-        {
-          echo "bitcoind.rpcpass=$(cat ${secretsDir}/bitcoin-rpcpassword-public)"
-          ${optionalString (cfg.getPublicAddressCmd != "") ''
-            echo "externalip=$(${cfg.getPublicAddressCmd})"
-          ''}
-        } >> '${cfg.dataDir}/lnd.conf'
+        ${optionalString (cfg.backend == "bitcoind") ''
+          echo "bitcoind.rpcpass=$(cat ${secretsDir}/bitcoin-rpcpassword-public)" >> '${cfg.dataDir}/lnd.conf'
+        ''}
+        ${optionalString (cfg.getPublicAddressCmd != "") ''
+          echo "externalip=$(${cfg.getPublicAddressCmd})" >> '${cfg.dataDir}/lnd.conf'
+        ''}
 
         if [[ ! -f ${networkDir}/wallet.db ]]; then
           seed='${cfg.dataDir}/lnd-seed-mnemonic'
@@ -288,7 +324,7 @@ in {
     users.users.${cfg.user} = {
       isSystemUser = true;
       group = cfg.group;
-      extraGroups = [ "bitcoinrpc-public" ];
+      extraGroups = optional (cfg.backend == "bitcoind") "bitcoinrpc-public";
       home = cfg.dataDir; # lnd creates .lnd dir in HOME
     };
     users.groups.${cfg.group} = {};


### PR DESCRIPTION
Add option to use neutrino instead of bitcoind for fetching blockchain data. This allows running LND as a lightweight client that connects to remote Bitcoin full nodes.

New options:
- services.lnd.backend: choose between "bitcoind" (default) or "neutrino"
- services.lnd.neutrino.addpeers: list of Bitcoin node peers to connect to
- services.lnd.neutrino.feeUrl: fee estimation URL

Example configuration:

```nix
  services.lnd = {
    enable = true;

    backend = "neutrino";
    neutrino.addpeers = [
      "btcd1.lnolymp.us"
      "btcd2.lnolymp.us"
      "btcd-mainnet.lightning.computer"
      "uswest.blixtwallet.com"
      "node.eldamar.icu"
      "noad.sathoarder.com"
      "bb1.breez.technology"
      "bb2.breez.technology"
      "neutrino.shock.network"
    ];

    neutrino.feeUrl = "https://nodes.lightning.computer/fees/v1/btc-fee-estimates.json" # default value

  };
```