### PR TITLE
update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767480499,
-        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
+        "lastModified": 1770136044,
+        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
+        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
     },
     "nixpkgs-25_05": {
       "locked": {
-        "lastModified": 1767051569,
-        "narHash": "sha256-0MnuWoN+n1UYaGBIpqpPs9I9ZHW4kynits4mrnh1Pk4=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40ee5e1944bebdd128f9fbada44faefddfde29bd",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1770169770,
+        "narHash": "sha256-awR8qIwJxJJiOmcEGgP2KUqYmHG4v/z8XpL9z8FnT1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "aa290c9891fa4ebe88f8889e59633d20cc06a5f2",
         "type": "github"
       },
       "original": {

--- a/modules/lightning-loop.nix
+++ b/modules/lightning-loop.nix
@@ -128,6 +128,8 @@ in {
       requires = [ "lnd.service" ];
       after = [ "lnd.service" "nix-bitcoin-secrets.target" ];
       serviceConfig = nbLib.defaultHardening // {
+        # TODO: temporary sleep to prevent race condition
+        ExecStartPre = "${pkgs.coreutils}/bin/sleep 5";
         ExecStart = "${cfg.package}/bin/loopd --configfile=${configFile}";
         User = lnd.user;
         Restart = "on-failure";

--- a/modules/lightning-pool.nix
+++ b/modules/lightning-pool.nix
@@ -99,6 +99,8 @@ in {
         ln -sfn ${configFile} '${cfg.dataDir}/${network}/poold.conf'
       '';
       serviceConfig = nbLib.defaultHardening // {
+        # TODO: temporary sleep to prevent race condition
+        ExecStartPre = "${pkgs.coreutils}/bin/sleep 5";
         ExecStart = "${cfg.package}/bin/poold --basedir='${cfg.dataDir}' --network=${network}";
         User = "lnd";
         Restart = "on-failure";

--- a/pkgs/clnrest/default.nix
+++ b/pkgs/clnrest/default.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage rec {
 
   inherit (clightning) src;
 
-  cargoHash = "sha256-2xOLwj42Ua85+kn73y+5q3YmzKYMCjxLlq/UrYjiZv0=";
+  cargoHash = "sha256-SjGvKeDBZzbn4TR2nbGHb3XAon0Dv4KtSlkzX+eji8c=";
 
   depsExtraArgs = {
     nativeBuildInputs = [ unzip ];

--- a/pkgs/pinned.nix
+++ b/pkgs/pinned.nix
@@ -5,21 +5,20 @@ pkgs: pkgsUnstable: pkgs-25_05:
     bitcoin
     bitcoind
     bitcoind-knots
-    btcpayserver
     charge-lnd
     clboss
-    clightning
     electrs
-    elementsd
     extra-container
     fulcrum
     lightning-loop
     lightning-pool
-    lnd
     lndconnect;
 
   inherit (pkgsUnstable)
-    ;
+    btcpayserver
+    clightning
+    elementsd
+    lnd;
 
   inherit pkgs pkgsUnstable pkgs-25_05;
 }

--- a/test/nixos-search/flake.lock
+++ b/test/nixos-search/flake.lock
@@ -21,11 +21,11 @@
     "nixos-infra": {
       "flake": false,
       "locked": {
-        "lastModified": 1767225854,
-        "narHash": "sha256-RESYvk2PXt6SkYG6UnPSlMcSEAQpabiKha1lkv/NtT4=",
+        "lastModified": 1769258963,
+        "narHash": "sha256-n+O20kwpemP2NDF4v7mNxQg202uwpVTcdY+CLWBO1Jg=",
         "owner": "NixOS",
         "repo": "infra",
-        "rev": "cfa5982b9961fccd252ff550213a0eb00c77f6f8",
+        "rev": "ed96d8432e6579d43bdd1c2f9b3d6eb61f5e1ea2",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1767372151,
-        "narHash": "sha256-JOQu3GRk3hWsJilqJ8XgKKD2BHvve3FTfzDYxJV9Btc=",
+        "lastModified": 1769334606,
+        "narHash": "sha256-LRqtY3zYXXP9l5YgIGRyql9ye88UmR1UiqLiusVB9NI=",
         "owner": "nixos",
         "repo": "nixos-search",
-        "rev": "9bce76e857f6874ede35d1065c39da42b1a70e2a",
+        "rev": "3a28d23cd7c842c4e83b33062c0f61b188960bcb",
         "type": "github"
       },
       "original": {
@@ -59,11 +59,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1762938485,
-        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
+        "lastModified": 1768158989,
+        "narHash": "sha256-67vyT1+xClLldnumAzCTBvU0jLZ1YBcf4vANRWP3+Ak=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+        "rev": "e96d59dff5c0d7fddb9d113ba108f03c3ef99eca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
bitcoin: 30.0 -> 30.2
bitcoind: 30.0 -> 30.2
bitcoind-knots: 29.2.knots20251110 -> 29.3.knots20260210
btcpayserver: 2.2.1 -> 2.3.4
clightning: 25.09.2 -> 25.12.1
elementsd: 23.2.4 -> 23.3.2
lnd: 0.19.3-beta -> 0.20.1-beta

## Draft

This is a draft because it contains a workaround to deal with the following problem:

After updating LND from 0.19.3-beta to 0.20.0-beta, one of the test fails because both lightning-loop and lightning-pool crash on startup.

Sequence of events:
1. LND appears to be available (lncli getinfo works)
2. Both lightning-loop and lightning-pool fail with: `rpc error: code = Unknown desc = chain notifier RPC is still in the process of starting`
   and they don't seem to recover.

In the failing test scenario, 100 blocks are mined at startup and LND needs to sync to these blocks.

With the new lnd version are we supposed to explicitly check that `lncli getinfo 2>&1 | grep -q '"synced_to_chain": true'` before starting up lightning-loop/pool?

CC original contributor of the pool pkg/module @sputn1ck
