### PR TITLE
Enable zmqpubhashblock in bitcoind when Fulcrum is enabled

### DIFF
--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -224,6 +224,12 @@ let
         default = false;
         description = "Enable the transaction index.";
       };
+      zmqpubhashblock = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        example = "tcp://127.0.0.1:28331";
+        description = "ZMQ address for zmqpubhashblock notifications";
+      };
       zmqpubrawblock = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -342,6 +348,7 @@ let
     ${optionalString (cfg.addresstype != null) "addresstype=${cfg.addresstype}"}
 
     # ZMQ options
+    ${optionalString (cfg.zmqpubhashblock != null) "zmqpubhashblock=${cfg.zmqpubhashblock}"}
     ${optionalString (cfg.zmqpubrawblock != null) "zmqpubrawblock=${cfg.zmqpubrawblock}"}
     ${optionalString (cfg.zmqpubrawtx != null) "zmqpubrawtx=${cfg.zmqpubrawtx}"}
 
@@ -349,7 +356,7 @@ let
     ${cfg.extraConfig}
   '';
 
-  zmqServerEnabled = (cfg.zmqpubrawblock != null) || (cfg.zmqpubrawtx != null);
+  zmqServerEnabled = (cfg.zmqpubhashblock != null) || (cfg.zmqpubrawblock != null) || (cfg.zmqpubrawtx != null);
 
   intAtLeast = n: types.addCheck types.int (x: x >= n) // {
     name = "intAtLeast";

--- a/modules/fulcrum.nix
+++ b/modules/fulcrum.nix
@@ -65,6 +65,7 @@ let
   nbLib = config.nix-bitcoin.lib;
   secretsDir = config.nix-bitcoin.secretsDir;
   bitcoind = config.services.bitcoind;
+  bitcoindRpcAddress = nbLib.address bitcoind.rpc.address;
 
   configFile = builtins.toFile "fulcrum.conf" ''
     datadir = ${cfg.dataDir}
@@ -103,6 +104,7 @@ in {
     services.bitcoind = {
       enable = true;
       txindex = true;
+      zmqpubhashblock = mkDefault "tcp://${bitcoindRpcAddress}:28331";
     };
 
     systemd.tmpfiles.rules = [


### PR DESCRIPTION
Fulcrum recommends enabling this option and will automatically listen for the broadcasts when enabled.