### PR TITLE
Add bitcoin-tui module: terminal UI dashboard

### DIFF
--- a/modules/bitcoin-tui.nix
+++ b/modules/bitcoin-tui.nix
@@ -1,0 +1,26 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  options.services.bitcoin-tui = {
+    enable = mkEnableOption "bitcoin-tui, a terminal UI dashboard for Bitcoin Core";
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.bitcoin-tui or (pkgs.callPackage ../pkgs/bitcoin-tui {});
+      description = "The bitcoin-tui package to use.";
+    };
+  };
+
+  cfg = config.services.bitcoin-tui;
+  bitcoind = config.services.bitcoind;
+in {
+  inherit options;
+
+  config = mkIf cfg.enable {
+    services.bitcoind.enable = true;
+
+    environment.systemPackages = [ cfg.package ];
+
+    nix-bitcoin.operator.groups = [ "bitcoinrpc-public" ];
+  };
+}

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -28,6 +28,7 @@
     ./joinmarket.nix
     ./joinmarket-ob-watcher.nix
     ./hardware-wallets.nix
+    ./bitcoin-tui.nix
 
     # Support features
     ./versioning.nix

--- a/pkgs/bitcoin-tui/default.nix
+++ b/pkgs/bitcoin-tui/default.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchFromGitHub, cmake }:
+
+let
+  ftxui = fetchFromGitHub {
+    owner = "ArthurSonzogni";
+    repo = "FTXUI";
+    rev = "v5.0.0";
+    hash = "sha256-IF6G4wwQDksjK8nJxxAnxuCw2z2qvggCmRJ2rbg00+E=";
+  };
+
+  catch2 = fetchFromGitHub {
+    owner = "catchorg";
+    repo = "Catch2";
+    rev = "v3.7.1";
+    hash = "sha256-Zt53Qtry99RAheeh7V24Csg/aMW25DT/3CN/h+BaeoM=";
+  };
+in stdenv.mkDerivation {
+  pname = "bitcoin-tui";
+  version = "0.8.1-unstable-2026-03-27";
+
+  src = fetchFromGitHub {
+    owner = "janb84";
+    repo = "bitcoin-tui";
+    rev = "49d97039d4d1cb18699973edfc73d4790ed817ea";
+    hash = "sha256-kbBesK0aPrpERktmyf4R7tqWyDmHZtwoAzdHt3vSVbM=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [
+    "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "-DFETCHCONTENT_SOURCE_DIR_FTXUI=${ftxui}"
+    "-DFETCHCONTENT_SOURCE_DIR_CATCH2=${catch2}"
+  ];
+
+  installPhase = ''
+    install -Dm755 bin/bitcoin-tui $out/bin/bitcoin-tui
+  '';
+
+  meta = with lib; {
+    description = "Terminal UI dashboard for Bitcoin Core nodes";
+    homepage = "https://github.com/janb84/bitcoin-tui";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [];
+  };
+}

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -138,6 +138,8 @@ let
         cjfee_r = 0.00003;
       };
 
+      tests.bitcoin-tui = cfg.bitcoin-tui.enable;
+
       tests.nodeinfo = config.nix-bitcoin.nodeinfo.enable;
 
       tests.backups = cfg.backups.enable;
@@ -214,6 +216,7 @@ let
       services.liquidd.enable = true;
       services.btcpayserver.enable = true;
       services.joinmarket-ob-watcher.enable = true;
+      services.bitcoin-tui.enable = true;
       services.backups.enable = true;
 
       nix-bitcoin.nodeinfo.enable = true;

--- a/test/tests.py
+++ b/test/tests.py
@@ -286,6 +286,13 @@ def _():
     assert_running("joinmarket-ob-watcher")
     machine.wait_until_succeeds(log_has_string("joinmarket-ob-watcher", "Starting ob-watcher"))
 
+@test("bitcoin-tui")
+def _():
+    assert_running("bitcoind")
+    # bitcoin-tui is an interactive TUI, just verify the binary is installed
+    # and can show its version
+    assert_matches("runuser -u operator -- bitcoin-tui --version", "bitcoin-tui")
+
 @test("nodeinfo")
 def _():
     status, _ = machine.execute("systemctl is-enabled --quiet onion-addresses 2> /dev/null")


### PR DESCRIPTION
## Summary

Adds a NixOS module for [bitcoin-tui](https://github.com/janb84/bitcoin-tui), a terminal UI for monitoring and interacting with a Bitcoin Core node via JSON-RPC, built with [FTXUI](https://github.com/ArthurSonzogni/FTXUI).

- **Module** (`modules/bitcoin-tui.nix`): installs the binary and grants operator RPC access
- **Package** (`pkgs/bitcoin-tui/`): C++20, pinned to commit `49d9703` (v0.8.1). Dependencies (FTXUI v5.0.0, Catch2 v3.7.1) are pre-fetched as Nix sources via `FETCHCONTENT_FULLY_DISCONNECTED` — no network access needed during build
- **Tests**: verify binary is installed and accessible to operator

### Features
- **Dashboard** — blockchain height, difficulty, sync progress, network status, mempool summary
- **Mempool** — tx count, vsize, total fees, memory usage gauge, animated recent block fill visualization
- **Search** — search mempool or confirmed transactions by txid, drill into blocks/inputs/outputs (`txindex=1` required for confirmed lookups)
- **Network** — connection counts, client/protocol version, relay fee, soft-fork tracking table with deployment status and activation height
- **Peers** — live peer table with address, network type, direction, ping, bytes sent/received; detail overlay to disconnect or ban peers; added nodes and ban list management
- **Tools** — broadcast raw transactions, private broadcast queue (Bitcoin Core PR #29415), shutdown node

Uses cookie auth by default (auto-detects `.cookie` from the data directory). Supports `--testnet`, `--regtest`, `--signet`, custom host/port, and explicit credentials.

### Usage
```nix
services.bitcoin-tui.enable = true;
```

Then as operator: `bitcoin-tui`

### Notes
- MIT licensed — no licensing concerns
- No tagged releases upstream yet; package is pinned to commit hash
- This is an interactive tool (not a daemon), so the module just installs the binary and grants operator access — similar to how `bitcoin-cli` works
- No external dependencies beyond FTXUI; JSON parsing and HTTP are handled in-tree

## Test plan
- [ ] `./test/run-tests.sh -s bitcoin-tui` — verify binary is installed
- [ ] `./test/run-tests.sh -s full` — verify no regressions
- [ ] Manual test on a live node: SSH in as operator, run `bitcoin-tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)