### PR TITLE
`bitcoind`: add IPC support

### DIFF
--- a/examples/configuration.nix
+++ b/examples/configuration.nix
@@ -46,6 +46,11 @@
   # services.bitcoind.extraConfig = ''
   #   maxorphantx=110
   # '';
+  #
+  # To enable Bitcoin Core IPC, use a package version >= 30 and configure one
+  # or more IPC socket addresses. Full paths are optional:
+  # services.bitcoind.ipcbind = [ "unix" ];
+  # services.bitcoind.ipcbind = [ "unix:/run/bitcoin-ipc/node.sock" ];
 
   ### CLIGHTNING
   # Enable clightning, a Lightning Network implementation in C.

--- a/modules/bitcoind.nix
+++ b/modules/bitcoind.nix
@@ -155,6 +155,21 @@ let
           }));
         };
       };
+      ipcbind = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        example = [
+          "unix"
+          "unix:/run/bitcoin-ipc/node.sock"
+        ];
+        description = ''
+          Unix socket addresses for incoming Bitcoin Core IPC connections.
+
+          This requires a Bitcoin Core package version >= 30 with IPC support.
+          Use `"unix"` for the default path (`node.sock` in the network data
+          directory), or `"unix:/custom/path"` for an absolute path.
+        '';
+      };
       regtest = mkOption {
         type = types.bool;
         default = false;
@@ -291,6 +306,30 @@ let
 
   i2pSAM = config.services.i2pd.proto.sam;
 
+  dataDir = toString cfg.dataDir;
+  ipcEnabled = cfg.ipcbind != [];
+  ipcAbsolutePaths = map
+    (address: builtins.substring 5 ((builtins.stringLength address) - 5) address)
+    (builtins.filter (address: hasPrefix "unix:/" address) cfg.ipcbind);
+  ipcWritableDirs = unique (
+    builtins.filter
+      (dir: dir != dataDir && !(hasPrefix "${dataDir}/" dir))
+      (map builtins.dirOf ipcAbsolutePaths)
+  );
+  execStart =
+    if ipcEnabled then
+      concatStringsSep " " (
+        [
+          "${cfg.package}/bin/bitcoin"
+          "-m"
+          "node"
+          "-datadir=${escapeShellArg dataDir}"
+        ]
+        ++ map (address: "-ipcbind=${escapeShellArg address}") cfg.ipcbind
+      )
+    else
+      "${cfg.package}/bin/bitcoind -datadir=${escapeShellArg dataDir}";
+
   configFile = builtins.toFile "bitcoin.conf" ''
     # We're already logging via journald
     nodebuglogfile=1
@@ -359,6 +398,13 @@ in {
   inherit options;
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !ipcEnabled || versionAtLeast cfg.package.version "30";
+        message = "services.bitcoind.ipcbind requires a Bitcoin Core package version >= 30.";
+      }
+    ];
+
     environment.systemPackages = [ cfg.package (hiPrio cfg.cli) ];
 
     services.bitcoind = mkMerge [
@@ -384,7 +430,7 @@ in {
 
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
-    ];
+    ] ++ map (dir: "d '${dir}' 0770 ${cfg.user} ${cfg.group} - -") ipcWritableDirs;
 
     systemd.services.bitcoind = rec {
       wants = [
@@ -444,10 +490,10 @@ in {
         Group = cfg.group;
         TimeoutStartSec = "30min";
         TimeoutStopSec = "30min";
-        ExecStart = "${cfg.package}/bin/bitcoind -datadir='${cfg.dataDir}'";
+        ExecStart = execStart;
         Restart = "on-failure";
         UMask = mkIf cfg.dataDirReadableByGroup "0027";
-        ReadWritePaths = [ cfg.dataDir ];
+        ReadWritePaths = [ cfg.dataDir ] ++ ipcWritableDirs;
       } // nbLib.allowedIPAddresses cfg.tor.enforce
         // optionalAttrs zmqServerEnabled nbLib.allowNetlink;
     };

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -32,6 +32,7 @@ let
       ]);
 
       tests.bitcoind = cfg.bitcoind.enable;
+      tests.bitcoin-ipc = cfg.bitcoind.ipcbind != [];
       services.bitcoind = {
         enable = true;
         extraConfig = mkIf config.test.noConnections "connect=0";
@@ -347,6 +348,10 @@ let
       imports = [ scenarios.regtest ];
       services.joinmarket.enable = true;
       services.bitcoind.package = config.nix-bitcoin.pkgs.bitcoind_29;
+    };
+
+    bitcoin-ipc = {
+      services.bitcoind.ipcbind = [ "unix:/run/bitcoin-ipc/node.sock" ];
     };
   } // (import ../dev/dev-scenarios.nix {
     inherit lib scenarios;

--- a/test/tests.py
+++ b/test/tests.py
@@ -103,6 +103,12 @@ def _():
         log_has_string("bitcoind", "RPC User public not allowed to call method stop")
     )
 
+@test("bitcoin-ipc")
+def _():
+    assert_running("bitcoind")
+    machine.wait_until_succeeds("[[ -S /run/bitcoin-ipc/node.sock ]]")
+    assert_full_match("stat -c '%U:%G %a' /run/bitcoin-ipc", "bitcoin:bitcoin 770\n")
+
 @test("electrs")
 def _():
     assert_running("electrs")


### PR DESCRIPTION
close #836

## Summary

This PR adds first-class IPC support to the Bitcoin Core module.

It introduces a new `services.bitcoind.ipcbind` option.

When this option is set, `nix-bitcoin` starts Bitcoin Core via `bitcoin -m node` and passes the configured `-ipcbind` arguments, instead of starting `bitcoind` directly.

This makes it possible to deploy Bitcoin Core 30+ with IPC enabled, including setups that rely on the [multiprocess interface](https://github.com/bitcoin/bitcoin/blob/master/doc/design/multiprocess.md) (e.g.: [Sv2](https://github.com/stratum-mining/sv2-apps/tree/main/bitcoin-core-sv2))

## What changed

- Added `services.bitcoind.ipcbind` as a new module option.
- Switched `ExecStart` to `bitcoin -m node` when IPC is enabled.
- Kept the existing `bitcoind` startup path unchanged when IPC is not configured.
- Added support for absolute IPC socket paths by creating the parent directories via `systemd.tmpfiles` and allowing them in `ReadWritePaths`.
- Added an assertion requiring Bitcoin Core >= 30 when `ipcbind` is used.
- Added a NixOS VM test scenario covering IPC startup and socket creation.

## Example Usage

```
services.bitcoind.ipcbind = [ "unix" ];
```

or with a custom path for `node.sock`:
```
services.bitcoind.ipcbind = [ "unix:/run/bitcoin-ipc/node.sock" ];
```

## Testing

- `python -m py_compile test/tests.py`
- `nix-instantiate --parse modules/bitcoind.nix`
- `nix-instantiate --parse test/tests.nix`
- `./test/run-tests.sh -s bitcoin-ipc build`

The new VM test verifies that:
- Bitcoin Core starts successfully in IPC mode
- the IPC socket is created at `/run/bitcoin-ipc/node.sock`
- the socket directory has the expected ownership and permissions

---

note: this PR was created by feeding #836 to a `gpt-5.4` model via `codex-cli`

I made sure to run all tests manually, and also successfully deployed it on my personal setup (currently running v30.2)