### PR TITLE
Add UTXOracle service

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -26,6 +26,92 @@ systemctl cat bitcoind
 systemctl show bitcoind
 ```
 
+# UTXOracle Local
+
+UTXOracle Local calculates a Bitcoin price estimate from local Bitcoin Core
+confirmed-block data. nix-bitcoin packages UTXOracle with its custom license
+metadata and requires explicit license acceptance before enabling the service.
+The UTXOracle license is not OSI-approved and includes restrictions on
+commercial, live, real-time, naming, and branding uses. See
+https://utxo.live/oracle/license.php.
+
+To run the default daily confirmed-block calculation:
+
+```nix
+{ lib, ... }: {
+  nixpkgs.config.allowUnfreePredicate = pkg:
+    builtins.elem (lib.getName pkg) [ "utxoracle" ];
+
+  services.utxoracle = {
+    enable = true;
+    acceptLicense = true;
+  };
+}
+```
+
+The service runs as the bitcoind user by default, reads the local Bitcoin Core
+data directory, and writes cached output under `/var/lib/utxoracle`. It creates
+`latest.log`, `latest.html` when UTXOracle generates HTML output, and
+`latest.json` when a price can be parsed.
+
+The module does not open firewall ports.
+
+For a moving confirmed-block estimate, enable recent 144-block mode:
+
+```nix
+services.utxoracle = {
+  enable = true;
+  acceptLicense = true;
+  recentBlocks = true;
+};
+```
+
+With `recentBlocks = true`, nix-bitcoin runs UTXOracle's recent block mode and
+labels the cached JSON output as `mode = "recent_blocks_144"`. This is a moving
+price estimate from the most recent 144 confirmed blocks. It is not exchange
+price data, mempool data, or live real-time price data.
+
+To update that recent-block estimate whenever Bitcoin Core connects a block:
+
+```nix
+services.utxoracle = {
+  enable = true;
+  acceptLicense = true;
+  recentBlocks = true;
+  updateOnBlock = true;
+};
+```
+
+`updateOnBlock` adds a Bitcoin Core `blocknotify` command and starts the
+oneshot `utxoracle.service` from a systemd path unit. The daily timer remains
+enabled as a fallback.
+
+## Cached local price feed
+
+To serve the cached 144-block rolling output over loopback HTTP:
+
+```nix
+services.utxoracle = {
+  enable = true;
+  acceptLicense = true;
+  recentBlocks = true;
+  updateOnBlock = true;
+  priceFeed.enable = true;
+};
+```
+
+The price feed binds to `127.0.0.1:8174` by default and serves only cached
+confirmed-block output from `/var/lib/utxoracle/latest.json`. It does not
+calculate prices itself, read mempool data, stream pushed updates, open firewall
+ports, or expose a public service.
+
+Available local endpoints:
+
+```shell
+curl -fsS http://127.0.0.1:8174/latest.json
+curl -fsS http://127.0.0.1:8174/health
+```
+
 # clightning database replication
 
 The clightning database can be replicated to a local path

--- a/modules/modules.nix
+++ b/modules/modules.nix
@@ -21,6 +21,7 @@
     ./lndconnect.nix # Requires onion-addresses.nix
     ./rtl.nix
     ./mempool.nix
+    ./utxoracle.nix
     ./electrs.nix
     ./fulcrum.nix
     ./liquid.nix

--- a/modules/utxoracle.nix
+++ b/modules/utxoracle.nix
@@ -1,0 +1,353 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  options.services.utxoracle = {
+    enable = mkEnableOption "UTXOracle Local";
+
+    acceptLicense = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Accept the custom UTXOracle License 1.0.
+
+        UTXOracle is not released under a normal open-source license.
+        The license permits consensus-compatible use of UTXOracle Local for
+        confirmed-block daily and recent 144-block window prices, and includes
+        restrictions on commercial, live, real-time, naming, and branding uses.
+        See https://utxo.live/oracle/license.php.
+      '';
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = config.nix-bitcoin.pkgs.utxoracle;
+      defaultText = "config.nix-bitcoin.pkgs.utxoracle";
+      description = "Package providing the {command}`utxoracle` command.";
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/utxoracle";
+      description = ''
+        Directory where UTXOracle writes generated HTML output and nix-bitcoin
+        writes cached `latest.log`, `latest.html`, and `latest.json` files.
+      '';
+    };
+
+    user = mkOption {
+      type = types.str;
+      default = bitcoind.user;
+      defaultText = "config.services.bitcoind.user";
+      description = ''
+        User as which to run UTXOracle.
+
+        UTXOracle reads local Bitcoin Core block files and RPC cookie data, so
+        the default is the bitcoind user. This avoids changing bitcoind data
+        directory permissions.
+      '';
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = bitcoind.group;
+      defaultText = "config.services.bitcoind.group";
+      description = "Group as which to run UTXOracle.";
+    };
+
+    bitcoinDataDir = mkOption {
+      type = types.path;
+      default = bitcoind.dataDir;
+      defaultText = "config.services.bitcoind.dataDir";
+      description = "Bitcoin Core data directory used by UTXOracle.";
+    };
+
+    calendar = mkOption {
+      type = types.str;
+      default = "*-*-* 00:45:00 UTC";
+      description = ''
+        systemd calendar expression for recalculating the confirmed-block
+        UTXOracle output.
+      '';
+    };
+
+    recentBlocks = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Calculate the UTXOracle Block Window Price from the most recent 144
+        confirmed blocks instead of the previous UTC day's UTXOracle Consensus
+        Price.
+
+        This is a moving confirmed-block estimate, not exchange price data,
+        mempool data, or live real-time price data.
+      '';
+    };
+
+    updateOnBlock = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Recalculate UTXOracle output after Bitcoin Core connects a new block.
+
+        This adds a `blocknotify` command to `services.bitcoind.extraConfig`
+        and a systemd path unit that starts `utxoracle.service`. This is most
+        useful with `recentBlocks = true`.
+      '';
+    };
+
+    priceFeed = {
+      enable = mkEnableOption "a local cached UTXOracle JSON price feed";
+
+      address = mkOption {
+        type = types.enum [ "127.0.0.1" "::1" ];
+        default = "127.0.0.1";
+        description = ''
+          Loopback address for the cached UTXOracle price feed.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 8174;
+        description = "Port for the cached UTXOracle price feed.";
+      };
+    };
+  };
+
+  cfg = config.services.utxoracle;
+  bitcoind = config.services.bitcoind;
+  nbLib = config.nix-bitcoin.lib;
+
+  blockNotifyDir = "${toString cfg.bitcoinDataDir}/utxoracle-blocknotify";
+
+  blockNotifyScript = pkgs.writeShellScriptBin "utxoracle-blocknotify" ''
+    set -eu
+
+    notify_dir='${blockNotifyDir}'
+    mkdir -p "$notify_dir"
+
+    block_hash="$1"
+    printf '%s\n' "$block_hash" > "$notify_dir/latest-block.tmp"
+    mv "$notify_dir/latest-block.tmp" "$notify_dir/latest-block"
+    touch "$notify_dir/trigger"
+  '';
+
+  priceFeed = pkgs.writeTextFile {
+    name = "utxoracle-price-feed";
+    executable = true;
+    destination = "/bin/utxoracle-price-feed";
+    text = ''
+      #!${pkgs.python3}/bin/python3
+      import json
+      import os
+      from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+      data_dir = os.environ["UTXORACLE_DATA_DIR"]
+      listen_address = os.environ["UTXORACLE_PRICE_FEED_ADDRESS"]
+      listen_port = int(os.environ["UTXORACLE_PRICE_FEED_PORT"])
+
+      def latest_json():
+          path = os.path.join(data_dir, "latest.json")
+          with open(path, "r", encoding="utf-8") as f:
+              return json.load(f)
+
+      class Handler(BaseHTTPRequestHandler):
+          server_version = "utxoracle-price-feed"
+
+          def log_message(self, fmt, *args):
+              return
+
+          def send_bytes(self, status, content_type, body):
+              self.send_response(status)
+              self.send_header("Content-Type", content_type)
+              self.send_header("Cache-Control", "no-store")
+              self.send_header("Content-Length", str(len(body)))
+              self.end_headers()
+              self.wfile.write(body)
+
+          def send_json(self, status, payload):
+              body = json.dumps(payload, sort_keys=True).encode("utf-8") + b"\n"
+              self.send_bytes(status, "application/json; charset=utf-8", body)
+
+          def do_GET(self):
+              if self.path in ("/health", "/healthz"):
+                  try:
+                      latest = latest_json()
+                      self.send_json(200, {"ok": True, "has_price": "price_usd" in latest})
+                  except Exception as exc:
+                      self.send_json(503, {"ok": False, "error": str(exc)})
+                  return
+
+              if self.path in ("/", "/latest", "/latest.json", "/price"):
+                  try:
+                      self.send_json(200, latest_json())
+                  except FileNotFoundError:
+                      self.send_json(503, {
+                          "ok": False,
+                          "error": "UTXOracle has not generated latest.json yet",
+                      })
+                  except Exception as exc:
+                      self.send_json(500, {"ok": False, "error": str(exc)})
+                  return
+
+              if self.path == "/latest.html":
+                  path = os.path.join(data_dir, "latest.html")
+                  try:
+                      with open(path, "rb") as f:
+                          body = f.read()
+                  except FileNotFoundError:
+                      self.send_json(404, {"ok": False, "error": "latest.html not found"})
+                      return
+                  self.send_bytes(200, "text/html; charset=utf-8", body)
+                  return
+
+              self.send_json(404, {"ok": False, "error": "not found"})
+
+      ThreadingHTTPServer((listen_address, listen_port), Handler).serve_forever()
+    '';
+  };
+in {
+  inherit options;
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.acceptLicense;
+        message = ''
+          services.utxoracle requires accepting the custom UTXOracle License 1.0
+          via `services.utxoracle.acceptLicense = true`.
+          See https://utxo.live/oracle/license.php.
+        '';
+      }
+      {
+        assertion = bitcoind.prune == 0;
+        message = "UTXOracle needs local block files, so bitcoind pruning must be disabled.";
+      }
+      {
+        assertion = cfg.recentBlocks || !cfg.updateOnBlock;
+        message = "services.utxoracle.updateOnBlock is only supported with recentBlocks = true.";
+      }
+    ];
+
+    services.bitcoind = {
+      enable = true;
+      extraConfig = mkIf cfg.updateOnBlock ''
+        blocknotify=/run/current-system/sw/bin/utxoracle-blocknotify %s
+      '';
+    };
+
+    environment.systemPackages = [ cfg.package ] ++ optional cfg.updateOnBlock blockNotifyScript;
+
+    systemd.tmpfiles.rules = [
+      "d '${cfg.dataDir}' 0750 ${cfg.user} ${cfg.group} - -"
+    ] ++ optional cfg.updateOnBlock
+      "d '${blockNotifyDir}' 0750 ${cfg.user} ${cfg.group} - -";
+
+    systemd.services.utxoracle = {
+      description = "Calculate UTXOracle output from local Bitcoin Core data";
+      requires = [ "bitcoind.service" ];
+      after = [ "bitcoind.service" ];
+      path = with pkgs; [ coreutils gnugrep gnused ];
+      script = ''
+        set -euo pipefail
+
+        export BROWSER=true
+        cd '${cfg.dataDir}'
+
+        rm -f latest.log.tmp
+        ${cfg.package}/bin/utxoracle -p '${cfg.bitcoinDataDir}' ${optionalString cfg.recentBlocks "-rb"} 2>&1 | tee latest.log.tmp
+        mv latest.log.tmp latest.log
+
+        # shellcheck disable=SC2012
+        html="$(ls -t UTXOracle_*.html 2>/dev/null | head -n1 || true)"
+        if [[ -n "$html" ]]; then
+          ln -sfn "$html" latest.html
+        fi
+
+        label=""
+        price=""
+        price_line="$(grep -E 'price: \$[0-9,]+' latest.log | tail -n1 || true)"
+
+        if [[ -n "$price_line" ]]; then
+          label="$(printf '%s\n' "$price_line" | sed -E 's/^[[:space:]]*([^$]+) price:.*/\1/')"
+          # shellcheck disable=SC2016
+          price="$(printf '%s\n' "$price_line" | sed -E 's/.*price: \$([0-9,]+).*/\1/' | tr -d ',')"
+        elif [[ -n "$html" ]]; then
+          # shellcheck disable=SC2016
+          price="$(grep -oE 'UTXOracle Block Window Price \$[0-9,]+' "$html" | tail -n1 | sed -E 's/.*\$([0-9,]+).*/\1/' | tr -d ',' || true)"
+          if [[ "$html" =~ UTXOracle_([0-9]+)-([0-9]+)\.html ]]; then
+            label="blocks ''${BASH_REMATCH[1]}-''${BASH_REMATCH[2]}"
+          else
+            label="latest 144 blocks"
+          fi
+        fi
+
+        if [[ -n "$price" ]]; then
+          updated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          trigger_block_hash="$(cat '${blockNotifyDir}/latest-block' 2>/dev/null || true)"
+          cat > latest.json.tmp <<EOF
+{
+  "name": "${if cfg.recentBlocks then "UTXOracle Block Window Price" else "UTXOracle Consensus Price"}",
+  "date": "$label",
+  "price_usd": $price,
+  "mode": "${if cfg.recentBlocks then "recent_blocks_144" else "24h_confirmed"}",
+  "source": "local bitcoin node confirmed blocks",
+  "license_scope": "consensus-compatible confirmed-block output",
+  "trigger_block_hash": "$trigger_block_hash",
+  "updated_at": "$updated_at"
+}
+EOF
+          mv latest.json.tmp latest.json
+        fi
+      '';
+      serviceConfig = nbLib.defaultHardening // {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = cfg.dataDir;
+        ReadOnlyPaths = [ cfg.bitcoinDataDir ];
+        ReadWritePaths = [ cfg.dataDir ];
+      } // nbLib.allowLocalIPAddresses;
+    };
+
+    systemd.timers.utxoracle = {
+      description = "Run UTXOracle";
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.calendar;
+        Persistent = true;
+        Unit = "utxoracle.service";
+      };
+    };
+
+    systemd.paths.utxoracle-blocknotify = mkIf cfg.updateOnBlock {
+      description = "Run UTXOracle after Bitcoin Core connects a block";
+      wantedBy = [ "multi-user.target" ];
+      pathConfig = {
+        PathChanged = blockNotifyDir;
+        Unit = "utxoracle.service";
+      };
+    };
+
+    systemd.services.utxoracle-price-feed = mkIf cfg.priceFeed.enable {
+      description = "Serve cached UTXOracle output over local HTTP";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "utxoracle.service" ];
+      environment = {
+        UTXORACLE_DATA_DIR = toString cfg.dataDir;
+        UTXORACLE_PRICE_FEED_ADDRESS = cfg.priceFeed.address;
+        UTXORACLE_PRICE_FEED_PORT = toString cfg.priceFeed.port;
+      };
+      serviceConfig = nbLib.defaultHardening // {
+        ExecStart = "${priceFeed}/bin/utxoracle-price-feed";
+        User = cfg.user;
+        Group = cfg.group;
+        Restart = "on-failure";
+        RestartSec = "10s";
+        WorkingDirectory = cfg.dataDir;
+        ReadOnlyPaths = [ cfg.dataDir ];
+      } // nbLib.allowLocalIPAddresses;
+    };
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -23,6 +23,7 @@ let self = {
   liquid-swap = pkgs.python3Packages.callPackage ./liquid-swap { };
   nbxplorer = pkgs.callPackage ./nbxplorer { };
   rtl = pkgs.callPackage ./rtl { inherit (self) fetchNodeModules; };
+  utxoracle = pkgs.callPackage ./utxoracle { };
   inherit (pkgs.callPackage ./mempool { inherit (self) fetchNodeModules; })
     mempool-backend
     mempool-frontend

--- a/pkgs/utxoracle/default.nix
+++ b/pkgs/utxoracle/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, stdenvNoCC
+, fetchurl
+, makeWrapper
+, python3
+}:
+
+stdenvNoCC.mkDerivation rec {
+  pname = "utxoracle";
+  version = "9.1";
+
+  src = fetchurl {
+    url = "https://utxo.live/oracle/UTXOracle.py";
+    hash = "sha256-m20z+clE3L4oV4R9NAqYSg7p85qR9cwu8XODkmpqAsU=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm444 "$src" "$out/share/utxoracle/UTXOracle.py"
+    makeWrapper ${python3}/bin/python3 "$out/bin/utxoracle" \
+      --add-flags "$out/share/utxoracle/UTXOracle.py"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Local confirmed-block Bitcoin price estimator";
+    homepage = "https://utxo.live/oracle/";
+    mainProgram = "utxoracle";
+    license = {
+      fullName = "UTXOracle License 1.0";
+      url = "https://utxo.live/oracle/license.php";
+      free = false;
+      redistributable = true;
+    };
+    maintainers = with lib.maintainers; [ nixbitcoin ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/test/tests.nix
+++ b/test/tests.nix
@@ -90,6 +90,8 @@ let
         settings.MEMPOOL.POOLS_JSON_URL = mkIf config.test.noConnections "disable-pool-fetching";
       };
 
+      tests.utxoracle = cfg.utxoracle.enable;
+
       tests.lnd = cfg.lnd.enable;
       services.lnd = {
         port = 9736;
@@ -338,6 +340,36 @@ let
       services.clightning = {
         enable = true;
         plugins.trustedcoin.enable = true;
+      };
+    };
+
+    utxoracle = { pkgs, ... }: {
+      services.utxoracle = {
+        enable = true;
+        acceptLicense = true;
+        recentBlocks = true;
+        priceFeed.enable = true;
+        package = pkgs.writeShellScriptBin "utxoracle" ''
+          set -eu
+
+          recent=0
+          for arg in "$@"; do
+            if [[ "$arg" == "-rb" ]]; then
+              recent=1
+            fi
+          done
+
+          if [[ "$recent" == 1 ]]; then
+            cat > UTXOracle_1-144.html <<EOF
+UTXOracle Block Window Price \$64,935
+EOF
+          else
+            cat > UTXOracle_2026-06-17.html <<EOF
+Jun 17, 2026 price: \$65,042
+EOF
+            echo 'Jun 17, 2026 price: $65,042'
+          fi
+        '';
       };
     };
 

--- a/test/tests.py
+++ b/test/tests.py
@@ -265,6 +265,19 @@ def _():
     )
     assert_matches(f"curl -L {ip('nginx')}:60845", "mempool - Bitcoin Explorer")
 
+@test("utxoracle")
+def _():
+    succeed("systemctl start utxoracle")
+    assert_no_failure("utxoracle")
+    assert_running("utxoracle-price-feed")
+    assert_matches("jq -r .mode /var/lib/utxoracle/latest.json", "recent_blocks_144")
+    assert_matches("jq -r .name /var/lib/utxoracle/latest.json", "UTXOracle Block Window Price")
+    assert_matches("jq -r .price_usd /var/lib/utxoracle/latest.json", "64935")
+    assert_matches("curl -fsS 127.0.0.1:8174/latest.json | jq -r .mode", "recent_blocks_144")
+    assert_matches("curl -fsS 127.0.0.1:8174/health | jq -r .ok", "true")
+    succeed("test -L /var/lib/utxoracle/latest.html")
+    machine.fail("systemctl cat utxoracle | grep -F -- '--listen'")
+
 @test("joinmarket")
 def _():
     assert_running("joinmarket")


### PR DESCRIPTION
## Summary

  Add optional UTXOracle Local support to nix-bitcoin.

  This adds:
  - `config.nix-bitcoin.pkgs.utxoracle`
  - `services.utxoracle`
  - confirmed-block daily mode
  - optional recent 144-block rolling mode
  - optional `blocknotify` updates for recent-block mode
  - optional loopback-only cached JSON price feed
  - docs and a focused VM test

  The service runs as the bitcoind user by default so it can read local Bitcoin Core block files and RPC cookie data without changing bitcoind data directory permissions.

  ## Scope

  This intentionally does not add:
  - public API exposure
  - firewall openings
  - Tailscale/Funnel integration
  - mempool or live/real-time price behavior
  - exchange price data

  The optional price feed serves only cached confirmed-block output from `/var/lib/utxoracle/latest.json`.

  ## License Handling

  UTXOracle uses a custom license, not a normal open-source license. The package is marked as custom, redistributable, and non-free in Nix terms, and the module requires:

  ```nix
  services.utxoracle.acceptLicense = true;
  ```

  Docs also show a scoped `allowUnfreePredicate` for `utxoracle`.

  ## Testing

  I ran:

  ```console
  nix build .#legacyPackages.x86_64-linux.tests.utxoracle
  NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#legacyPackages.x86_64-linux.utxoracle
  git diff --check
  nix-instantiate --parse modules/utxoracle.nix
  ```

  ## Authorship

  I implemented and tested this branch with assistance from OpenAI Codex.

